### PR TITLE
refactor: use slug as primary identifier for cards

### DIFF
--- a/entrypoints/popup/debug/DebugCard.tsx
+++ b/entrypoints/popup/debug/DebugCard.tsx
@@ -13,9 +13,6 @@ export function DebugCard({ card, onRemove }: DebugCardProps) {
   return (
     <div className="debug-panel-card">
       <div className="debug-panel-card-label">
-        <strong>ID:</strong> <span className="debug-panel-card-value">{card.id}</span>
-      </div>
-      <div className="debug-panel-card-label">
         <strong>Slug:</strong> <span className="debug-panel-card-value">{card.slug}</span>
       </div>
       <div className="debug-panel-card-label">

--- a/entrypoints/popup/debug/DebugPanel.tsx
+++ b/entrypoints/popup/debug/DebugPanel.tsx
@@ -84,7 +84,7 @@ export function DebugPanel() {
         ) : (
           <div className="debug-panel-cards-container">
             {cards.map((card) => (
-              <DebugCard key={card.id} card={card} onRemove={handleRemoveCard} />
+              <DebugCard key={card.slug} card={card} onRemove={handleRemoveCard} />
             ))}
           </div>
         )}

--- a/services/cards.test.ts
+++ b/services/cards.test.ts
@@ -10,7 +10,6 @@ describe('Card serialization', () => {
     it('should convert Date to timestamp', () => {
       const testDate = new Date('2024-01-15T10:30:00Z');
       const card: Card = {
-        id: 'test-id-123',
         slug: 'two-sum',
         name: 'Two Sum',
         createdAt: testDate,
@@ -19,7 +18,6 @@ describe('Card serialization', () => {
 
       const serialized = serializeCard(card);
 
-      expect(serialized.id).toBe('test-id-123');
       expect(serialized.slug).toBe('two-sum');
       expect(serialized.name).toBe('Two Sum');
       expect(serialized.createdAt).toBe(testDate.getTime());
@@ -32,7 +30,6 @@ describe('Card serialization', () => {
       fsrsCard.last_review = new Date('2024-01-14T09:00:00Z');
 
       const card: Card = {
-        id: 'test-id-123',
         slug: 'two-sum',
         name: 'Two Sum',
         createdAt: testDate,
@@ -55,7 +52,6 @@ describe('Card serialization', () => {
       const timestamp = new Date('2024-01-15T10:30:00Z').getTime();
       const emptyFsrs = createEmptyCard();
       const storedCard: StoredCard = {
-        id: 'test-id-456',
         slug: 'merge-intervals',
         name: 'Merge Intervals',
         createdAt: timestamp,
@@ -68,7 +64,6 @@ describe('Card serialization', () => {
 
       const deserialized = deserializeCard(storedCard);
 
-      expect(deserialized.id).toBe('test-id-456');
       expect(deserialized.slug).toBe('merge-intervals');
       expect(deserialized.name).toBe('Merge Intervals');
       expect(deserialized.createdAt).toBeInstanceOf(Date);
@@ -79,7 +74,6 @@ describe('Card serialization', () => {
   describe('serializeCard and deserializeCard roundtrip', () => {
     it('should maintain data integrity through serialization and deserialization', () => {
       const originalCard: Card = {
-        id: crypto.randomUUID(),
         slug: 'two-pointers',
         name: 'Two Pointers',
         createdAt: new Date(),
@@ -89,7 +83,6 @@ describe('Card serialization', () => {
       const serialized = serializeCard(originalCard);
       const deserialized = deserializeCard(serialized);
 
-      expect(deserialized.id).toBe(originalCard.id);
       expect(deserialized.slug).toBe(originalCard.slug);
       expect(deserialized.name).toBe(originalCard.name);
       expect(deserialized.createdAt.getTime()).toBe(originalCard.createdAt.getTime());
@@ -108,7 +101,6 @@ describe('addCard', () => {
 
     expect(card.slug).toBe('two-sum');
     expect(card.name).toBe('Two Sum');
-    expect(card.id).toBeDefined();
     expect(card.createdAt).toBeInstanceOf(Date);
 
     // Verify FSRS card is created
@@ -121,59 +113,51 @@ describe('addCard', () => {
 
     // Verify the card was actually stored using WXT storage
     const cards = await storage.getItem<Record<string, StoredCard>>(STORAGE_KEYS.cards);
-    const slugToCardId = await storage.getItem<Record<string, string>>(STORAGE_KEYS.slugToCardId);
 
     expect(cards).toBeDefined();
-    expect(cards![card.id]).toBeDefined();
-    expect(slugToCardId!['two-sum']).toBe(card.id);
-    expect(cards![card.id].slug).toBe('two-sum');
-    expect(cards![card.id].name).toBe('Two Sum');
+    expect(cards!['two-sum']).toBeDefined();
+    expect(cards!['two-sum'].slug).toBe('two-sum');
+    expect(cards!['two-sum'].name).toBe('Two Sum');
 
     // Verify FSRS data is stored properly
-    expect(cards![card.id].fsrs).toBeDefined();
-    expect(typeof cards![card.id].fsrs.due).toBe('number');
+    expect(cards!['two-sum'].fsrs).toBeDefined();
+    expect(typeof cards!['two-sum'].fsrs.due).toBe('number');
   });
 
   it('should return existing card when adding same slug (idempotent)', async () => {
     // Add card first time
     const firstCard = await addCard('valid-parentheses', 'Valid Parentheses');
-    const firstId = firstCard.id;
     const firstCreatedAt = firstCard.createdAt;
 
     // Add same card again
     const secondCard = await addCard('valid-parentheses', 'A different name');
 
     // Should return the same card
-    expect(secondCard.id).toBe(firstId);
-    expect(secondCard.createdAt.getTime()).toBe(firstCreatedAt.getTime());
     expect(secondCard.slug).toBe('valid-parentheses');
+    expect(secondCard.createdAt.getTime()).toBe(firstCreatedAt.getTime());
     expect(secondCard.name).toBe('Valid Parentheses');
 
     // Verify only one card exists in storage
     const cards = await storage.getItem<Record<string, StoredCard>>(STORAGE_KEYS.cards);
-    const slugToCardId = await storage.getItem<Record<string, string>>(STORAGE_KEYS.slugToCardId);
 
     expect(Object.keys(cards || {}).length).toBe(1);
-    expect(Object.keys(slugToCardId || {}).length).toBe(1);
   });
 
   it('should store multiple different cards correctly', async () => {
     // Add multiple cards
-    const card1 = await addCard('two-sum', 'Two Sum');
-    const card2 = await addCard('valid-parentheses', 'Valid Parentheses');
-    const card3 = await addCard('merge-two-sorted-lists', 'Merge Two Sorted Lists');
+    await addCard('two-sum', 'Two Sum');
+    await addCard('valid-parentheses', 'Valid Parentheses');
+    await addCard('merge-two-sorted-lists', 'Merge Two Sorted Lists');
 
     // Verify all cards are stored
     const cards = await storage.getItem<Record<string, StoredCard>>(STORAGE_KEYS.cards);
-    const slugToCardId = await storage.getItem<Record<string, string>>(STORAGE_KEYS.slugToCardId);
 
     expect(Object.keys(cards || {}).length).toBe(3);
-    expect(Object.keys(slugToCardId || {}).length).toBe(3);
 
-    // Verify slug mappings
-    expect(slugToCardId!['two-sum']).toBe(card1.id);
-    expect(slugToCardId!['valid-parentheses']).toBe(card2.id);
-    expect(slugToCardId!['merge-two-sorted-lists']).toBe(card3.id);
+    // Verify cards exist
+    expect(cards!['two-sum']).toBeDefined();
+    expect(cards!['valid-parentheses']).toBeDefined();
+    expect(cards!['merge-two-sorted-lists']).toBeDefined();
   });
 
   it('should set createdAt to current date', async () => {
@@ -190,10 +174,9 @@ describe('addCard', () => {
     const card = await addCard('serialize-test', 'Serialize Test');
 
     const cards = await storage.getItem<Record<string, StoredCard>>(STORAGE_KEYS.cards);
-    const storedCard = cards![card.id];
+    const storedCard = cards![card.slug];
 
     expect(typeof storedCard.createdAt).toBe('number');
-    expect(storedCard.id).toBe(card.id);
     expect(storedCard.slug).toBe(card.slug);
     expect(storedCard.name).toBe(card.name);
   });
@@ -212,9 +195,9 @@ describe('getAllCards', () => {
 
   it('should return all cards from storage', async () => {
     // Add multiple cards
-    const card1 = await addCard('two-sum', 'Two Sum');
-    const card2 = await addCard('valid-parentheses', 'Valid Parentheses');
-    const card3 = await addCard('merge-intervals', 'Merge Intervals');
+    await addCard('two-sum', 'Two Sum');
+    await addCard('valid-parentheses', 'Valid Parentheses');
+    await addCard('merge-intervals', 'Merge Intervals');
 
     // Get all cards
     const allCards = await getAllCards();
@@ -222,22 +205,19 @@ describe('getAllCards', () => {
     expect(allCards).toHaveLength(3);
 
     // Check that all cards are present
-    const cardIds = allCards.map((c) => c.id);
-    expect(cardIds).toContain(card1.id);
-    expect(cardIds).toContain(card2.id);
-    expect(cardIds).toContain(card3.id);
+    const cardSlugs = allCards.map((c) => c.slug);
+    expect(cardSlugs).toContain('two-sum');
+    expect(cardSlugs).toContain('valid-parentheses');
+    expect(cardSlugs).toContain('merge-intervals');
 
     // Check that cards have correct data
-    const foundCard1 = allCards.find((c) => c.id === card1.id);
-    expect(foundCard1?.slug).toBe('two-sum');
+    const foundCard1 = allCards.find((c) => c.slug === 'two-sum');
     expect(foundCard1?.name).toBe('Two Sum');
 
-    const foundCard2 = allCards.find((c) => c.id === card2.id);
-    expect(foundCard2?.slug).toBe('valid-parentheses');
+    const foundCard2 = allCards.find((c) => c.slug === 'valid-parentheses');
     expect(foundCard2?.name).toBe('Valid Parentheses');
 
-    const foundCard3 = allCards.find((c) => c.id === card3.id);
-    expect(foundCard3?.slug).toBe('merge-intervals');
+    const foundCard3 = allCards.find((c) => c.slug === 'merge-intervals');
     expect(foundCard3?.name).toBe('Merge Intervals');
   });
 
@@ -247,7 +227,6 @@ describe('getAllCards', () => {
     // Manually add a serialized card to storage
     const emptyFsrs = createEmptyCard();
     const storedCard: StoredCard = {
-      id: 'test-id-123',
       slug: 'test-problem',
       name: 'Test Problem',
       createdAt: testDate.getTime(),
@@ -258,13 +237,12 @@ describe('getAllCards', () => {
       },
     };
 
-    await storage.setItem(STORAGE_KEYS.cards, { 'test-id-123': storedCard });
+    await storage.setItem(STORAGE_KEYS.cards, { 'test-problem': storedCard });
 
     // Get all cards
     const allCards = await getAllCards();
 
     expect(allCards).toHaveLength(1);
-    expect(allCards[0].id).toBe('test-id-123');
     expect(allCards[0].slug).toBe('test-problem');
     expect(allCards[0].name).toBe('Test Problem');
     expect(allCards[0].createdAt).toBeInstanceOf(Date);
@@ -280,22 +258,18 @@ describe('removeCard', () => {
 
   it('should remove an existing card and its slug mapping', async () => {
     // Add a card first
-    const card = await addCard('two-sum', 'Two Sum');
+    await addCard('two-sum', 'Two Sum');
 
     // Verify it exists
     let cards = await storage.getItem<Record<string, StoredCard>>(STORAGE_KEYS.cards);
-    let slugToCardId = await storage.getItem<Record<string, string>>(STORAGE_KEYS.slugToCardId);
-    expect(cards![card.id]).toBeDefined();
-    expect(slugToCardId!['two-sum']).toBe(card.id);
+    expect(cards!['two-sum']).toBeDefined();
 
     // Remove the card
     await removeCard('two-sum');
 
     // Verify it's removed
     cards = await storage.getItem<Record<string, StoredCard>>(STORAGE_KEYS.cards);
-    slugToCardId = await storage.getItem<Record<string, string>>(STORAGE_KEYS.slugToCardId);
-    expect(cards![card.id]).toBeUndefined();
-    expect(slugToCardId!['two-sum']).toBeUndefined();
+    expect(cards!['two-sum']).toBeUndefined();
   });
 
   it('should handle removing non-existent card gracefully', async () => {
@@ -304,50 +278,31 @@ describe('removeCard', () => {
 
     // Verify storage is still empty/unchanged
     const cards = await storage.getItem<Record<string, StoredCard>>(STORAGE_KEYS.cards);
-    const slugToCardId = await storage.getItem<Record<string, string>>(STORAGE_KEYS.slugToCardId);
     expect(cards || {}).toEqual({});
-    expect(slugToCardId || {}).toEqual({});
   });
 
   it('should only remove the specified card when multiple cards exist', async () => {
     // Add multiple cards
-    const card1 = await addCard('two-sum', 'Two Sum');
-    const card2 = await addCard('valid-parentheses', 'Valid Parentheses');
-    const card3 = await addCard('merge-intervals', 'Merge Intervals');
+    await addCard('two-sum', 'Two Sum');
+    await addCard('valid-parentheses', 'Valid Parentheses');
+    await addCard('merge-intervals', 'Merge Intervals');
 
     // Remove the middle card
     await removeCard('valid-parentheses');
 
     // Verify only the specified card is removed
     const cards = await storage.getItem<Record<string, StoredCard>>(STORAGE_KEYS.cards);
-    const slugToCardId = await storage.getItem<Record<string, string>>(STORAGE_KEYS.slugToCardId);
 
     expect(Object.keys(cards || {}).length).toBe(2);
-    expect(Object.keys(slugToCardId || {}).length).toBe(2);
 
     // Card 1 should still exist
-    expect(cards![card1.id]).toBeDefined();
-    expect(slugToCardId!['two-sum']).toBe(card1.id);
+    expect(cards!['two-sum']).toBeDefined();
 
     // Card 2 should be removed
-    expect(cards![card2.id]).toBeUndefined();
-    expect(slugToCardId!['valid-parentheses']).toBeUndefined();
+    expect(cards!['valid-parentheses']).toBeUndefined();
 
     // Card 3 should still exist
-    expect(cards![card3.id]).toBeDefined();
-    expect(slugToCardId!['merge-intervals']).toBe(card3.id);
-  });
-
-  it('should handle orphaned slug mapping (slug exists but card does not)', async () => {
-    // Manually create an orphaned slug mapping
-    await storage.setItem(STORAGE_KEYS.slugToCardId, { 'orphaned-slug': 'non-existent-id' });
-    await storage.setItem(STORAGE_KEYS.cards, {});
-
-    // Remove should clean up the orphaned mapping
-    await removeCard('orphaned-slug');
-
-    const slugToCardId = await storage.getItem<Record<string, string>>(STORAGE_KEYS.slugToCardId);
-    expect(slugToCardId!['orphaned-slug']).toBeUndefined();
+    expect(cards!['merge-intervals']).toBeDefined();
   });
 
   it('should verify card is actually removed from getAllCards', async () => {

--- a/services/cards.ts
+++ b/services/cards.ts
@@ -3,7 +3,6 @@ import { STORAGE_KEYS } from './storage-keys';
 import { storage } from '#imports';
 
 export interface Card {
-  id: string;
   slug: string;
   name: string;
   createdAt: Date;
@@ -18,16 +17,9 @@ export interface StoredCard extends Omit<Card, 'createdAt' | 'fsrs'> {
   };
 }
 
-async function getStorageData() {
-  const [slugToCardId, cards] = await Promise.all([
-    storage.getItem<Record<string, string>>(STORAGE_KEYS.slugToCardId),
-    storage.getItem<Record<string, StoredCard>>(STORAGE_KEYS.cards),
-  ]);
-
-  return {
-    slugToCardId: slugToCardId ?? {},
-    cards: cards ?? {},
-  };
+async function getCards(): Promise<Record<string, StoredCard>> {
+  const cards = await storage.getItem<Record<string, StoredCard>>(STORAGE_KEYS.cards);
+  return cards ?? {};
 }
 
 export function serializeCard(card: Card): StoredCard {
@@ -56,55 +48,30 @@ export function deserializeCard(stored: StoredCard): Card {
 }
 
 export async function addCard(slug: string, name: string): Promise<Card> {
-  const { slugToCardId, cards } = await getStorageData();
-
-  // If the card already exists, return it
-  const existingId = slugToCardId[slug];
-  if (existingId) {
-    const storedCard = cards[existingId];
-    if (storedCard) {
-      return deserializeCard(storedCard);
-    }
+  const cards = await getCards();
+  if (slug in cards) {
+    return deserializeCard(cards[slug]);
   }
 
-  // Create new card
   const card: Card = {
-    id: crypto.randomUUID(),
     slug,
     name,
     createdAt: new Date(),
     fsrs: createEmptyCard(),
   };
 
-  cards[card.id] = serializeCard(card);
-  slugToCardId[slug] = card.id;
-
-  await storage.setItems([
-    { key: STORAGE_KEYS.cards, value: cards },
-    { key: STORAGE_KEYS.slugToCardId, value: slugToCardId },
-  ]);
-
+  cards[slug] = serializeCard(card);
+  await storage.setItem(STORAGE_KEYS.cards, cards);
   return card;
 }
 
 export async function getAllCards(): Promise<Card[]> {
-  const cards = (await storage.getItem<Record<string, StoredCard>>(STORAGE_KEYS.cards)) ?? {};
+  const cards = await getCards();
   return Object.values(cards).map(deserializeCard);
 }
 
 export async function removeCard(slug: string): Promise<void> {
-  const { slugToCardId, cards } = await getStorageData();
-
-  const cardId = slugToCardId[slug];
-
-  if (cardId) {
-    delete cards[cardId];
-  }
-
-  delete slugToCardId[slug];
-
-  await storage.setItems([
-    { key: STORAGE_KEYS.cards, value: cards },
-    { key: STORAGE_KEYS.slugToCardId, value: slugToCardId },
-  ]);
+  const cards = await getCards();
+  delete cards[slug];
+  await storage.setItem(STORAGE_KEYS.cards, cards);
 }

--- a/services/storage-keys.ts
+++ b/services/storage-keys.ts
@@ -1,6 +1,5 @@
 export const STORAGE_KEYS = {
   cards: 'local:leetreps:cards',
-  slugToCardId: 'local:leetreps:slugToCardId',
 } as const;
 
 export type StorageKey = (typeof STORAGE_KEYS)[keyof typeof STORAGE_KEYS];


### PR DESCRIPTION
## Summary
- Removed redundant `slugToCardId` mapping and `id` field from Card interface
- Simplified storage to use slugs directly as card identifiers
- Updated all CRUD operations and tests to work with the new structure

This reduces storage complexity and improves data access patterns by eliminating the unnecessary indirection layer.