### PR TITLE
feat: add spaced repetition card rating with ts-fsrs

### DIFF
--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -1,4 +1,4 @@
-import { addCard, getAllCards, removeCard } from '@/services/cards';
+import { addCard, getAllCards, removeCard, rateCard } from '@/services/cards';
 import { browser } from 'wxt/browser';
 import { MessageType, type MessageRequest } from '@/services/messages';
 
@@ -13,6 +13,9 @@ export default defineBackground(() => {
 
       case MessageType.REMOVE_CARD:
         return await removeCard(request.slug);
+
+      case MessageType.RATE_CARD:
+        return await rateCard(request.slug, request.rating);
 
       default: {
         // This should never happen with proper typing - exhaustive check

--- a/entrypoints/popup/debug/DebugCard.tsx
+++ b/entrypoints/popup/debug/DebugCard.tsx
@@ -1,14 +1,37 @@
 import { useState } from 'react';
 import type { Card } from '@/services/cards';
+import { sendMessage, MessageType } from '@/services/messages';
+import { Rating } from 'ts-fsrs';
 import './DebugPanel.css';
 
 interface DebugCardProps {
   card: Card;
   onRemove: (slug: string) => void;
+  onUpdate: (card: Card) => void;
 }
 
-export function DebugCard({ card, onRemove }: DebugCardProps) {
+export function DebugCard({ card, onRemove, onUpdate }: DebugCardProps) {
   const [isExpanded, setIsExpanded] = useState(false);
+  const [isRating, setIsRating] = useState(false);
+
+  const handleRate = async (rating: Rating) => {
+    // Skip Rating.Manual as it's not a valid grade
+    if (rating === Rating.Manual) return;
+
+    setIsRating(true);
+    try {
+      const updatedCard = await sendMessage({
+        type: MessageType.RATE_CARD,
+        slug: card.slug,
+        rating: rating,
+      });
+      onUpdate(updatedCard);
+    } catch (error) {
+      console.error('Failed to rate card:', error);
+    } finally {
+      setIsRating(false);
+    }
+  };
 
   return (
     <div className="debug-panel-card">
@@ -77,10 +100,46 @@ export function DebugCard({ card, onRemove }: DebugCardProps) {
         )}
       </div>
 
+      {/* Rating Buttons */}
+      <div style={{ marginTop: '8px', display: 'flex', gap: '4px' }}>
+        <button
+          onClick={() => handleRate(Rating.Again)}
+          className="debug-panel-button"
+          style={{ flex: 1, fontSize: '11px', padding: '4px', backgroundColor: '#d32f2f' }}
+          disabled={isRating}
+        >
+          Again
+        </button>
+        <button
+          onClick={() => handleRate(Rating.Hard)}
+          className="debug-panel-button"
+          style={{ flex: 1, fontSize: '11px', padding: '4px', backgroundColor: '#f57c00' }}
+          disabled={isRating}
+        >
+          Hard
+        </button>
+        <button
+          onClick={() => handleRate(Rating.Good)}
+          className="debug-panel-button"
+          style={{ flex: 1, fontSize: '11px', padding: '4px', backgroundColor: '#388e3c' }}
+          disabled={isRating}
+        >
+          Good
+        </button>
+        <button
+          onClick={() => handleRate(Rating.Easy)}
+          className="debug-panel-button"
+          style={{ flex: 1, fontSize: '11px', padding: '4px', backgroundColor: '#1976d2' }}
+          disabled={isRating}
+        >
+          Easy
+        </button>
+      </div>
+
       <button
         onClick={() => onRemove(card.slug)}
         className="debug-panel-button"
-        style={{ marginTop: '8px', width: '100%' }}
+        style={{ marginTop: '4px', width: '100%' }}
       >
         Remove
       </button>

--- a/entrypoints/popup/debug/DebugPanel.tsx
+++ b/entrypoints/popup/debug/DebugPanel.tsx
@@ -59,6 +59,10 @@ export function DebugPanel() {
     }
   };
 
+  const handleUpdateCard = (updatedCard: Card) => {
+    setCards((prevCards) => prevCards.map((card) => (card.slug === updatedCard.slug ? updatedCard : card)));
+  };
+
   return (
     <div className="debug-panel">
       <h2 className="debug-panel-title">🔧 DEBUG PANEL</h2>
@@ -84,7 +88,7 @@ export function DebugPanel() {
         ) : (
           <div className="debug-panel-cards-container">
             {cards.map((card) => (
-              <DebugCard key={card.slug} card={card} onRemove={handleRemoveCard} />
+              <DebugCard key={card.slug} card={card} onRemove={handleRemoveCard} onUpdate={handleUpdateCard} />
             ))}
           </div>
         )}

--- a/services/messages.ts
+++ b/services/messages.ts
@@ -1,24 +1,28 @@
 import { browser } from 'wxt/browser';
 import type { Card } from './cards';
+import type { Grade } from 'ts-fsrs';
 
 // Message type constants
 export const MessageType = {
   ADD_CARD: 'ADD_CARD',
   GET_ALL_CARDS: 'GET_ALL_CARDS',
   REMOVE_CARD: 'REMOVE_CARD',
+  RATE_CARD: 'RATE_CARD',
 } as const;
 
 // Message request types as discriminated union
 export type MessageRequest =
   | { type: typeof MessageType.ADD_CARD; slug: string; name: string }
   | { type: typeof MessageType.GET_ALL_CARDS }
-  | { type: typeof MessageType.REMOVE_CARD; slug: string };
+  | { type: typeof MessageType.REMOVE_CARD; slug: string }
+  | { type: typeof MessageType.RATE_CARD; slug: string; rating: Grade };
 
 // Type mapping for request to response
 export type MessageResponseMap = {
   [MessageType.ADD_CARD]: Card;
   [MessageType.GET_ALL_CARDS]: Card[];
   [MessageType.REMOVE_CARD]: void;
+  [MessageType.RATE_CARD]: Card;
 };
 
 /**


### PR DESCRIPTION
## Summary
- Add `rateCard()` function to rate cards using ts-fsrs spaced repetition algorithm
- Integrate rating functionality into message system and background script
- Add rating buttons (Again, Hard, Good, Easy) to debug panel UI

## Changes
- Implement FSRS-based card rating with configurable parameters (maximum_interval: 1000)
- Extract `createCard()` helper to eliminate code duplication
- Add comprehensive test coverage for rating functionality
- Wire up rating through message passing system
- Add visual rating buttons with color-coded difficulty levels in debug panel

Closes #13