### PR TITLE
chore: rebrand from LeetReps to LeetSRS

### DIFF
--- a/entrypoints/popup/components/Header.tsx
+++ b/entrypoints/popup/components/Header.tsx
@@ -5,7 +5,7 @@ interface HeaderProps {
 export function Header({ children }: HeaderProps) {
   return (
     <div className="flex items-center justify-between px-4 py-2 bg-secondary border-b border-current">
-      <h1 className="text-xl font-bold text-primary">LeetReps</h1>
+      <h1 className="text-xl font-bold text-primary">LeetSRS</h1>
       {children}
     </div>
   );

--- a/entrypoints/popup/components/__tests__/Header.test.tsx
+++ b/entrypoints/popup/components/__tests__/Header.test.tsx
@@ -6,10 +6,10 @@ import { describe, it, expect } from 'vitest';
 import { Header } from '../Header';
 
 describe('Header', () => {
-  it('renders the LeetReps title', () => {
+  it('renders the LeetSRS title', () => {
     render(<Header />);
 
-    const title = screen.getByRole('heading', { name: 'LeetReps', level: 1 });
+    const title = screen.getByRole('heading', { name: 'LeetSRS', level: 1 });
     expect(title).toBeInTheDocument();
     expect(title).toHaveClass('text-xl', 'font-bold', 'text-primary');
   });

--- a/entrypoints/popup/contexts/ThemeContext.tsx
+++ b/entrypoints/popup/contexts/ThemeContext.tsx
@@ -12,7 +12,7 @@ const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
 export function ThemeProvider({ children }: { children: ReactNode }) {
   const [theme, setTheme] = useState<Theme>(() => {
     // Check localStorage or system preference
-    const stored = localStorage.getItem('leetreps-theme');
+    const stored = localStorage.getItem('leetsrs-theme');
     if (stored === 'light' || stored === 'dark') return stored;
 
     // Check system preference
@@ -34,7 +34,7 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
     body.classList.add(theme);
 
     // Save to localStorage
-    localStorage.setItem('leetreps-theme', theme);
+    localStorage.setItem('leetsrs-theme', theme);
   }, [theme]);
 
   const toggleTheme = () => {

--- a/services/__tests__/storage-keys.test.ts
+++ b/services/__tests__/storage-keys.test.ts
@@ -24,8 +24,8 @@ describe('Storage Keys', () => {
       const longId = 'a'.repeat(100);
       const key = getNoteStorageKey(longId);
 
-      expect(key).toBe(`local:leetreps:notes:${longId}`);
-      expect(key.length).toBe('local:leetreps:notes:'.length + 100);
+      expect(key).toBe(`local:leetsrs:notes:${longId}`);
+      expect(key.length).toBe('local:leetsrs:notes:'.length + 100);
     });
   });
 });

--- a/services/storage-keys.ts
+++ b/services/storage-keys.ts
@@ -1,11 +1,11 @@
 export const STORAGE_KEYS = {
-  cards: 'local:leetreps:cards',
-  stats: 'local:leetreps:stats',
-  notes: 'local:leetreps:notes',
+  cards: 'local:leetsrs:cards',
+  stats: 'local:leetsrs:stats',
+  notes: 'local:leetsrs:notes',
 } as const;
 
 export type StorageKey = (typeof STORAGE_KEYS)[keyof typeof STORAGE_KEYS];
 
-export function getNoteStorageKey(cardId: string): `local:leetreps:notes:${string}` {
+export function getNoteStorageKey(cardId: string): `local:leetsrs:notes:${string}` {
   return `${STORAGE_KEYS.notes}:${cardId}`;
 }


### PR DESCRIPTION
## Summary
- Rebranded extension from LeetReps to LeetSRS across the codebase
- Updated storage keys to use new name

## Changes
- Header component title
- Storage key prefixes (leetreps_* → leetsrs_*)
- Test files to match new branding

🤖 Generated with [Claude Code](https://claude.ai/code)