### PR TITLE
Fix GitHub link to the repository in the settings view

### DIFF
--- a/entrypoints/popup/views/settings/SettingsView.tsx
+++ b/entrypoints/popup/views/settings/SettingsView.tsx
@@ -281,7 +281,7 @@ function AboutSection() {
         <span className="text-tertiary">© 2025 Matt Drake</span>
         <span className="text-tertiary">•</span>
         <a
-          href="https://github.com/mtdrake/leetsrs"
+          href="https://github.com/mattcdrake/leetsrs"
           target="_blank"
           rel="noopener noreferrer"
           className="text-accent hover:underline flex items-center gap-1"


### PR DESCRIPTION
PS: there are also the same problem on the website, but I didn't find the repository for the website

<img width="1422" height="945" alt="image" src="https://github.com/user-attachments/assets/344c97d4-1e38-423b-8217-0a669b6c33c5" />
