### PR TITLE
Add review calendar to Stats tab and quick LeetCode links to Cards view

### DIFF
--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -7,7 +7,14 @@ import {
   rateCard,
   getReviewQueue,
 } from '@/services/cards';
-import { getTodayStats, getCardStateStats, getAllStats, getLastNDaysStats, getNextNDaysStats } from '@/services/stats';
+import {
+  getTodayStats,
+  getCardStateStats,
+  getAllStats,
+  getLastNDaysStats,
+  getNextNDaysStats,
+  getReviewLogs,
+} from '@/services/stats';
 import { getNote, saveNote, deleteNote } from '@/services/notes';
 import {
   getMaxNewCardsPerDay,
@@ -210,6 +217,9 @@ export default defineBackground(() => {
 
       case MessageType.GET_NEXT_N_DAYS_STATS:
         return await getNextNDaysStats(request.days);
+
+      case MessageType.GET_REVIEW_LOGS:
+        return await getReviewLogs();
 
       case MessageType.EXPORT_DATA:
         return await exportData();

--- a/entrypoints/popup/views/card/CardView.tsx
+++ b/entrypoints/popup/views/card/CardView.tsx
@@ -6,7 +6,7 @@ import { useCardsQuery, usePauseCardMutation, useRemoveCardMutation } from '@/ho
 import { Button, TextField, Input, Label } from 'react-aria-components';
 import { State as FsrsState } from 'ts-fsrs';
 import type { Card } from '@/shared/cards';
-import { FaCirclePause, FaPlay, FaTrash, FaXmark, FaMagnifyingGlass } from 'react-icons/fa6';
+import { FaCirclePause, FaPlay, FaTrash, FaXmark, FaMagnifyingGlass, FaArrowUpRightFromSquare } from 'react-icons/fa6';
 import { bounceButton } from '@/shared/styles';
 import { useI18n } from '../../contexts/I18nContext';
 import type { Translations } from '@/shared/i18n';
@@ -51,11 +51,10 @@ const getDifficultyColor = (difficulty: string) => {
 // Sub-components
 interface CardHeaderProps {
   card: Card;
-  isExpanded: boolean;
   t: Translations;
 }
 
-function CardHeader({ card, isExpanded, t }: CardHeaderProps) {
+function CardHeader({ card, t }: CardHeaderProps) {
   return (
     <>
       <div className="flex items-center gap-2">
@@ -63,11 +62,8 @@ function CardHeader({ card, isExpanded, t }: CardHeaderProps) {
         <span className="text-xs text-secondary">{t.format.leetcodeId(card.leetcodeId)}</span>
         <span className={`text-sm ${card.paused ? 'opacity-60' : ''}`}>{card.name}</span>
       </div>
-      <div className="flex items-center gap-2">
+      <div className="flex items-center mr-2">
         <span className={`text-xs ${getDifficultyColor(card.difficulty)}`}>{card.difficulty}</span>
-        <span className={`text-xs text-secondary transition-transform duration-200 ${isExpanded ? 'rotate-90' : ''}`}>
-          ▶
-        </span>
       </div>
     </>
   );
@@ -181,13 +177,34 @@ function CardItem({
 }: CardItemProps) {
   return (
     <div className="bg-secondary rounded-lg border border-current overflow-hidden">
-      <Button
-        className="w-full flex items-center justify-between p-3 hover:bg-tertiary transition-colors text-left"
-        onPress={onToggle}
-        aria-expanded={isExpanded}
-      >
-        <CardHeader card={card} isExpanded={isExpanded} t={t} />
-      </Button>
+      <div className="w-full flex items-stretch justify-between">
+        <Button
+          className="flex-1 flex items-center justify-between p-3 hover:bg-tertiary transition-colors text-left focus:outline-none"
+          onPress={onToggle}
+          aria-expanded={isExpanded}
+        >
+          <CardHeader card={card} t={t} />
+        </Button>
+        <div className="w-10 border-l border-current flex flex-col items-stretch">
+          <a
+            href={`https://${card.domain}/problems/${card.slug}/description/`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="flex-1 flex items-center justify-center hover:bg-tertiary transition-colors border-b border-current text-secondary hover:text-primary"
+            title={t.cardsView.openOnLeetCode}
+            aria-label={t.cardsView.openOnLeetCode}
+          >
+            <FaArrowUpRightFromSquare className="text-[10px]" />
+          </a>
+          <div
+            className="flex-1 flex items-center justify-center hover:bg-tertiary text-secondary hover:text-primary transition-colors cursor-pointer"
+            onClick={onToggle}
+            aria-hidden="true"
+          >
+            <span className={`text-[10px] transition-transform duration-200 ${isExpanded ? 'rotate-90' : ''}`}>▶</span>
+          </div>
+        </div>
+      </div>
       {isExpanded && (
         <CardStats
           card={card}

--- a/entrypoints/popup/views/card/CardView.tsx
+++ b/entrypoints/popup/views/card/CardView.tsx
@@ -196,13 +196,13 @@ function CardItem({
           >
             <FaArrowUpRightFromSquare className="text-[10px]" />
           </a>
-          <div
-            className="flex-1 flex items-center justify-center hover:bg-tertiary text-secondary hover:text-primary transition-colors cursor-pointer"
-            onClick={onToggle}
-            aria-hidden="true"
+          <Button
+            className="flex-1 flex items-center justify-center hover:bg-tertiary text-secondary hover:text-primary transition-colors focus:outline-none"
+            onPress={onToggle}
+            aria-label="Toggle details"
           >
             <span className={`text-[10px] transition-transform duration-200 ${isExpanded ? 'rotate-90' : ''}`}>▶</span>
-          </div>
+          </Button>
         </div>
       </div>
       {isExpanded && (

--- a/entrypoints/popup/views/card/__tests__/CardView.test.tsx
+++ b/entrypoints/popup/views/card/__tests__/CardView.test.tsx
@@ -35,6 +35,22 @@ const renderWithQueryClient = (component: React.ReactElement) => {
 };
 
 describe('CardView', () => {
+  const getCardButtons = () =>
+    screen.getAllByRole('button').filter((btn) => {
+      const label = btn.getAttribute('aria-label');
+      return (
+        !label ||
+        (!label.includes('Expand') &&
+          !label.includes('Collapse') &&
+          !label.includes('Toggle') &&
+          !label.includes('Pause') &&
+          !label.includes('Delete') &&
+          !label.includes('Confirm'))
+      );
+    });
+
+  const getCardButton = () => getCardButtons()[0];
+
   it('should render loading state', () => {
     mockedUseCardsQuery.mockReturnValue(
       createQueryMock<Card[] | undefined>(undefined, {
@@ -68,7 +84,7 @@ describe('CardView', () => {
 
     renderWithQueryClient(<CardView />);
 
-    const cardElements = screen.getAllByRole('button');
+    const cardElements = getCardButtons();
     expect(within(cardElements[0]).getByText('#1')).toBeInTheDocument();
     expect(within(cardElements[0]).getByText('Problem 1')).toBeInTheDocument();
     expect(within(cardElements[1]).getByText('#42')).toBeInTheDocument();
@@ -163,7 +179,7 @@ describe('CardView', () => {
     expect(screen.queryByText('State:')).not.toBeInTheDocument();
 
     // Click to expand
-    const cardButton = screen.getByRole('button');
+    const cardButton = getCardButton();
     fireEvent.click(cardButton);
 
     // Stats should now be visible
@@ -194,7 +210,7 @@ describe('CardView', () => {
 
     renderWithQueryClient(<CardView />);
 
-    const cardButtons = screen.getAllByRole('button');
+    const cardButtons = getCardButtons();
 
     // Expand first card
     fireEvent.click(cardButtons[0]);
@@ -231,7 +247,7 @@ describe('CardView', () => {
     renderWithQueryClient(<CardView />);
 
     // Expand card
-    fireEvent.click(screen.getByRole('button'));
+    fireEvent.click(getCardButton());
 
     // Check that the dates are present (just check that they're formatted, not exact values due to timezone)
     const addedRow = screen.getByText('Added:').parentElement;
@@ -552,7 +568,7 @@ describe('CardView', () => {
       renderWithQueryClient(<CardView />);
 
       // Expand both cards
-      const cardButtons = screen.getAllByRole('button');
+      const cardButtons = getCardButtons();
       fireEvent.click(cardButtons[0]); // First card
       fireEvent.click(cardButtons[1]); // Second card
 

--- a/entrypoints/popup/views/card/__tests__/CardView.test.tsx
+++ b/entrypoints/popup/views/card/__tests__/CardView.test.tsx
@@ -115,6 +115,29 @@ describe('CardView', () => {
     expect(within(activeCard!).queryByTitle('Card is paused')).not.toBeInTheDocument();
   });
 
+  it('should render a link to open the problem on LeetCode', () => {
+    const card = createMockCard(State.New, {
+      name: 'Test Problem',
+      slug: 'test-problem',
+      leetcodeId: '42',
+      domain: 'leetcode.com',
+    });
+
+    mockedUseCardsQuery.mockReturnValue(createQueryMock([card]) as UseQueryResult<Card[]>);
+
+    renderWithQueryClient(<CardView />);
+
+    const link = screen.getByRole('link', { name: /Open on LeetCode/i });
+    expect(link).toHaveAttribute('href', 'https://leetcode.com/problems/test-problem/description/');
+    expect(link).toHaveAttribute('target', '_blank');
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+
+    // Test that clicking the link stops propagation and does not toggle expansion
+    expect(screen.queryByText('State:')).not.toBeInTheDocument();
+    fireEvent.click(link);
+    expect(screen.queryByText('State:')).not.toBeInTheDocument();
+  });
+
   it('should expand and collapse card details', () => {
     const card = createMockCard(State.Learning, {
       name: 'Test Problem',

--- a/entrypoints/popup/views/stats/CalendarSection.tsx
+++ b/entrypoints/popup/views/stats/CalendarSection.tsx
@@ -1,0 +1,217 @@
+import { useState } from 'react';
+import { useReviewLogsQuery, useLanguageQuery } from '@/hooks/useBackgroundQueries';
+import { useI18n } from '../../contexts/I18nContext';
+import { FaChevronLeft, FaChevronRight, FaArrowUpRightFromSquare } from 'react-icons/fa6';
+import { Difficulty } from '@/shared/cards';
+import { Rating } from 'ts-fsrs';
+
+const difficultyColorMap: Record<Difficulty, string> = {
+  Easy: 'bg-difficulty-easy',
+  Medium: 'bg-difficulty-medium',
+  Hard: 'bg-difficulty-hard',
+};
+
+const ratingColorMap: Record<number, string> = {
+  [Rating.Again]: 'bg-rating-again',
+  [Rating.Hard]: 'bg-rating-hard',
+  [Rating.Good]: 'bg-rating-good',
+  [Rating.Easy]: 'bg-rating-easy',
+};
+
+const ratingLabelMap: Record<number, 'again' | 'hard' | 'good' | 'easy'> = {
+  [Rating.Again]: 'again',
+  [Rating.Hard]: 'hard',
+  [Rating.Good]: 'good',
+  [Rating.Easy]: 'easy',
+};
+
+export function CalendarSection() {
+  const t = useI18n();
+  const { data: language = 'en' } = useLanguageQuery();
+  const { data: reviewLogs = {} } = useReviewLogsQuery();
+
+  const [viewDate, setViewDate] = useState(() => new Date());
+  const [selectedDate, setSelectedDate] = useState(() => new Date());
+
+  const year = viewDate.getFullYear();
+  const month = viewDate.getMonth(); // 0-indexed
+
+  const today = new Date();
+  const isCurrentMonth = year === today.getFullYear() && month === today.getMonth();
+
+  const canGoNext = !isCurrentMonth;
+  const canGoPrev = true;
+
+  const handlePrevMonth = () => {
+    if (canGoPrev) {
+      setViewDate(new Date(year, month - 1, 1));
+    }
+  };
+
+  const handleNextMonth = () => {
+    if (canGoNext) {
+      setViewDate(new Date(year, month + 1, 1));
+    }
+  };
+
+  // Get total days in currently viewed month
+  const daysInMonth = new Date(year, month + 1, 0).getDate();
+  // Get index of the first day of the month (0 = Sunday)
+  const firstDayIndex = new Date(year, month, 1).getDay();
+
+  // Localized weekdays starting from Sunday
+  const weekdays = [];
+  for (let i = 0; i < 7; i++) {
+    const tempDate = new Date(2024, 0, 14 + i); // 2024-01-14 is a Sunday
+    weekdays.push(tempDate.toLocaleDateString(language, { weekday: 'narrow' }));
+  }
+
+  // Localized month + year header
+  const monthYearString = viewDate.toLocaleDateString(language, {
+    month: 'long',
+    year: 'numeric',
+  });
+
+  // Selected date details
+  const selectedYear = selectedDate.getFullYear();
+  const selectedMonth = selectedDate.getMonth();
+  const selectedDayNum = selectedDate.getDate();
+  const selectedDateKey = `${selectedYear}-${String(selectedMonth + 1).padStart(2, '0')}-${String(selectedDayNum).padStart(2, '0')}`;
+  const selectedDateString = selectedDate.toLocaleDateString(language, {
+    month: 'long',
+    day: 'numeric',
+    year: 'numeric',
+  });
+
+  const dayReviews = reviewLogs[selectedDateKey] ?? [];
+
+  return (
+    <div className="mb-6 p-4 rounded-lg bg-secondary text-primary">
+      <h3 className="text-lg font-semibold mb-3">{t.statsView.calendarTitle}</h3>
+
+      {/* Calendar Grid Container */}
+      <div className="flex flex-col gap-2 bg-primary/40 p-3 rounded-lg border border-current/10">
+        {/* Header Controls */}
+        <div className="flex items-center justify-between mb-2">
+          <span className="text-sm font-medium capitalize">{monthYearString}</span>
+          <div className="flex gap-1.5">
+            <button
+              onClick={handlePrevMonth}
+              disabled={!canGoPrev}
+              className="p-1.5 rounded hover:bg-tertiary disabled:opacity-30 disabled:hover:bg-transparent cursor-pointer transition-colors"
+              aria-label="Previous month"
+            >
+              <FaChevronLeft className="text-xs" />
+            </button>
+            <button
+              onClick={handleNextMonth}
+              disabled={!canGoNext}
+              className="p-1.5 rounded hover:bg-tertiary disabled:opacity-30 disabled:hover:bg-transparent cursor-pointer transition-colors"
+              aria-label="Next month"
+            >
+              <FaChevronRight className="text-xs" />
+            </button>
+          </div>
+        </div>
+
+        {/* Weekdays Labels */}
+        <div className="grid grid-cols-7 text-center text-xs font-semibold text-secondary mb-1">
+          {weekdays.map((day, idx) => (
+            <div key={idx} className="uppercase">
+              {day}
+            </div>
+          ))}
+        </div>
+
+        {/* Days Grid */}
+        <div className="grid grid-cols-7 gap-y-1 justify-items-center">
+          {/* Empty spacer cells */}
+          {Array.from({ length: firstDayIndex }).map((_, idx) => (
+            <div key={`spacer-${idx}`} className="w-8 h-8" />
+          ))}
+
+          {/* Actual days of the month */}
+          {Array.from({ length: daysInMonth }).map((_, idx) => {
+            const dayNum = idx + 1;
+            const dateKey = `${year}-${String(month + 1).padStart(2, '0')}-${String(dayNum).padStart(2, '0')}`;
+            const hasReviews = reviewLogs[dateKey] && reviewLogs[dateKey].length > 0;
+
+            const isSelected = selectedYear === year && selectedMonth === month && selectedDayNum === dayNum;
+
+            const isToday = today.getFullYear() === year && today.getMonth() === month && today.getDate() === dayNum;
+
+            return (
+              <button
+                key={`day-${dayNum}`}
+                onClick={() => setSelectedDate(new Date(year, month, dayNum))}
+                className={`w-8 h-8 rounded-full flex flex-col items-center justify-center relative text-xs font-medium cursor-pointer transition-all duration-150
+                  ${isSelected ? 'bg-accent text-white font-semibold' : 'hover:bg-tertiary'}
+                  ${isToday && !isSelected ? 'border border-accent/60' : ''}
+                `}
+              >
+                <span>{dayNum}</span>
+                {hasReviews && (
+                  <span className={`w-1 h-1 rounded-full absolute bottom-1 ${isSelected ? 'bg-white' : 'bg-accent'}`} />
+                )}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      {/* Divider */}
+      <hr className="border-current opacity-10 my-4" />
+
+      {/* Selected Day Reviews Panel */}
+      <div className="flex flex-col gap-2">
+        <div className="flex items-center justify-between">
+          <span className="text-xs font-semibold text-secondary">{selectedDateString}</span>
+          <span className="text-[10px] font-bold px-1.5 py-0.5 rounded bg-tertiary text-secondary">
+            {dayReviews.length} {dayReviews.length === 1 ? 'review' : 'reviews'}
+          </span>
+        </div>
+
+        {dayReviews.length === 0 ? (
+          <div className="text-center py-4 text-xs text-secondary italic">{t.statsView.noReviewsOnDay}</div>
+        ) : (
+          <div className="flex flex-col gap-2 max-h-[170px] overflow-y-auto pr-1">
+            {dayReviews.map((review, idx) => (
+              <div
+                key={`${review.cardId}-${idx}`}
+                className="flex items-center justify-between py-1.5 border-b border-current/5 last:border-0 gap-2"
+              >
+                <div className="flex items-center gap-1.5 min-w-0 flex-1">
+                  <span className="text-[9px] font-bold text-secondary font-jetbrains-mono shrink-0">
+                    #{review.leetcodeId}
+                  </span>
+                  <a
+                    href={`https://${review.domain}/problems/${review.slug}/description/`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-xs font-medium text-primary hover:text-accent hover:underline truncate flex items-center gap-1.5 group"
+                  >
+                    <span className="truncate">{review.name}</span>
+                    <FaArrowUpRightFromSquare className="text-[8px] opacity-40 group-hover:opacity-100 shrink-0" />
+                  </a>
+                </div>
+
+                <div className="flex items-center gap-1 shrink-0">
+                  <span
+                    className={`text-[8px] px-1 py-0.5 rounded text-white font-semibold ${difficultyColorMap[review.difficulty]}`}
+                  >
+                    {t.difficulty[review.difficulty.toLowerCase() as 'easy' | 'medium' | 'hard']}
+                  </span>
+                  <span
+                    className={`text-[8px] px-1 py-0.5 rounded text-white font-semibold ${ratingColorMap[review.rating]}`}
+                  >
+                    {t.ratings[ratingLabelMap[review.rating]]}
+                  </span>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/entrypoints/popup/views/stats/CalendarSection.tsx
+++ b/entrypoints/popup/views/stats/CalendarSection.tsx
@@ -1,5 +1,5 @@
-import { useState } from 'react';
-import { useReviewLogsQuery, useLanguageQuery } from '@/hooks/useBackgroundQueries';
+import { useState, useEffect } from 'react';
+import { useReviewLogsQuery, useLanguageQuery, useDayStartHourQuery } from '@/hooks/useBackgroundQueries';
 import { useI18n } from '../../contexts/I18nContext';
 import { FaChevronLeft, FaChevronRight, FaArrowUpRightFromSquare } from 'react-icons/fa6';
 import { Difficulty } from '@/shared/cards';
@@ -29,14 +29,29 @@ export function CalendarSection() {
   const t = useI18n();
   const { data: language = 'en' } = useLanguageQuery();
   const { data: reviewLogs = {} } = useReviewLogsQuery();
+  const { data: dayStartHour = 0 } = useDayStartHourQuery();
 
   const [viewDate, setViewDate] = useState(() => new Date());
   const [selectedDate, setSelectedDate] = useState(() => new Date());
+  const [hasAdjusted, setHasAdjusted] = useState(false);
+
+  useEffect(() => {
+    if (dayStartHour && !hasAdjusted) {
+      const adjusted = new Date();
+      adjusted.setHours(adjusted.getHours() - dayStartHour);
+      setSelectedDate(adjusted);
+      setViewDate(adjusted);
+      setHasAdjusted(true);
+    }
+  }, [dayStartHour, hasAdjusted]);
 
   const year = viewDate.getFullYear();
   const month = viewDate.getMonth(); // 0-indexed
 
   const today = new Date();
+  if (dayStartHour) {
+    today.setHours(today.getHours() - dayStartHour);
+  }
   const isCurrentMonth = year === today.getFullYear() && month === today.getMonth();
 
   const canGoNext = !isCurrentMonth;

--- a/entrypoints/popup/views/stats/StatsView.tsx
+++ b/entrypoints/popup/views/stats/StatsView.tsx
@@ -1,5 +1,6 @@
 import { ViewLayout } from '../../components/ViewLayout';
 import { StreakCounter } from '../../components/StreakCounter';
+import { CalendarSection } from './CalendarSection';
 import { CardDistributionChart } from './CardDistributionChart';
 import { ReviewHistoryChart } from './ReviewHistoryChart';
 import { UpcomingReviewsChart } from './UpcomingReviewsChart';
@@ -9,6 +10,7 @@ export function StatsView() {
   const t = useI18n();
   return (
     <ViewLayout title={t.statsView.title} headerContent={<StreakCounter />}>
+      <CalendarSection />
       <CardDistributionChart />
       <ReviewHistoryChart />
       <UpcomingReviewsChart />

--- a/hooks/useBackgroundQueries.ts
+++ b/hooks/useBackgroundQueries.ts
@@ -25,6 +25,7 @@ export const queryKeys = {
     cardState: ['stats', 'cardState'] as const,
     lastNDays: (days: number) => ['stats', 'lastNDays', days] as const,
     nextNDays: (days: number) => ['stats', 'nextNDays', days] as const,
+    reviewLogs: ['stats', 'reviewLogs'] as const,
   },
   // Settings related queries
   settings: {
@@ -97,6 +98,13 @@ export function useNextNDaysStatsQuery(days: number) {
   return useQuery({
     queryKey: queryKeys.stats.nextNDays(days),
     queryFn: () => sendMessage({ type: MessageType.GET_NEXT_N_DAYS_STATS, days }),
+  });
+}
+
+export function useReviewLogsQuery() {
+  return useQuery({
+    queryKey: queryKeys.stats.reviewLogs,
+    queryFn: () => sendMessage({ type: MessageType.GET_REVIEW_LOGS }),
   });
 }
 

--- a/services/__tests__/cards.test.ts
+++ b/services/__tests__/cards.test.ts
@@ -1246,11 +1246,12 @@ describe('getReviewQueue', () => {
     await rateCard('evening', 'Evening Card', Rating.Good, '5002', 'Medium', 'leetcode.com');
     await rateCard('midnight', 'Midnight Card', Rating.Good, '5003', 'Hard', 'leetcode.com');
 
-    // Set due times to various times today
+    // Set due times to various times today using local timezone constructor to avoid timezone overflows
+    const now = new Date();
     const cards = await storage.getItem<Record<string, StoredCard>>(STORAGE_KEYS.cards);
-    cards!['morning'].fsrs.due = new Date('2024-01-15T06:00:00Z').getTime(); // 6 AM today
-    cards!['evening'].fsrs.due = new Date('2024-01-15T20:00:00Z').getTime(); // 8 PM today
-    cards!['midnight'].fsrs.due = new Date('2024-01-15T23:59:59Z').getTime(); // End of today
+    cards!['morning'].fsrs.due = new Date(now.getFullYear(), now.getMonth(), now.getDate(), 6, 0, 0).getTime();
+    cards!['evening'].fsrs.due = new Date(now.getFullYear(), now.getMonth(), now.getDate(), 20, 0, 0).getTime();
+    cards!['midnight'].fsrs.due = new Date(now.getFullYear(), now.getMonth(), now.getDate(), 23, 59, 59).getTime();
     await storage.setItem(STORAGE_KEYS.cards, cards);
 
     const queue = await getReviewQueue();

--- a/services/cards.ts
+++ b/services/cards.ts
@@ -8,7 +8,7 @@ import {
 } from 'ts-fsrs';
 import { STORAGE_KEYS } from './storage-keys';
 import { storage } from '#imports';
-import { updateStats, getTodayStats } from './stats';
+import { updateStats, getTodayStats, addReviewLog } from './stats';
 import { deleteNote } from './notes';
 import { type Card, type Difficulty, type LeetcodeDomain } from '@/shared/cards';
 import { getMaxNewCardsPerDay, getDayStartHour } from './settings';
@@ -187,6 +187,7 @@ export async function rateCard(
 
   // Update stats tracking
   await updateStats(rating, isNewCard);
+  await addReviewLog(card.id, slug, name, card.leetcodeId, difficulty, domain, rating);
 
   const dayStartHour = await getDayStartHour();
   const shouldRequeue = isDueByDate(card, now, dayStartHour);

--- a/services/import-export.ts
+++ b/services/import-export.ts
@@ -1,7 +1,7 @@
 import { storage } from '#imports';
 import { STORAGE_KEYS } from './storage-keys';
 import { type StoredCard } from './cards';
-import { type DailyStats, type MonthlyStats } from './stats';
+import { type DailyStats, type MonthlyStats, type DailyReviewLogs } from './stats';
 import { type Note } from '@/shared/notes';
 import { type Theme, type Language } from '@/shared/settings';
 import { getCurrentSchemaVersion } from './migrations';
@@ -13,6 +13,7 @@ export interface ExportData {
   data: {
     cards: Record<string, StoredCard>;
     stats: Record<string, DailyStats>;
+    reviewLogs?: DailyReviewLogs;
     monthlyStats?: Record<string, MonthlyStats>;
     notes: Record<string, Note>;
     settings: {
@@ -35,6 +36,7 @@ export async function exportData(): Promise<string> {
   // Gather all data from storage
   const cards = (await storage.getItem<Record<string, StoredCard>>(STORAGE_KEYS.cards)) ?? {};
   const stats = (await storage.getItem<Record<string, DailyStats>>(STORAGE_KEYS.stats)) ?? {};
+  const reviewLogs = (await storage.getItem<DailyReviewLogs>(STORAGE_KEYS.reviewLogs)) ?? {};
   const monthlyStats = (await storage.getItem<Record<string, MonthlyStats>>(STORAGE_KEYS.monthlyStats)) ?? {};
 
   // Get all notes
@@ -72,6 +74,7 @@ export async function exportData(): Promise<string> {
     data: {
       cards,
       stats,
+      ...(Object.keys(reviewLogs).length > 0 && { reviewLogs }),
       ...(Object.keys(monthlyStats).length > 0 && { monthlyStats }),
       notes,
       settings: {
@@ -150,6 +153,11 @@ export async function importData(jsonData: string): Promise<void> {
     await storage.setItem(STORAGE_KEYS.monthlyStats, data.data.monthlyStats);
   }
 
+  // Import review logs
+  if (data.data.reviewLogs) {
+    await storage.setItem(STORAGE_KEYS.reviewLogs, data.data.reviewLogs);
+  }
+
   // Import notes
   for (const [cardId, note] of Object.entries(data.data.notes)) {
     const key = `${STORAGE_KEYS.notes}:${cardId}` as const;
@@ -202,6 +210,7 @@ export async function resetAllData(): Promise<void> {
   // Remove all data
   await storage.removeItem(STORAGE_KEYS.cards);
   await storage.removeItem(STORAGE_KEYS.stats);
+  await storage.removeItem(STORAGE_KEYS.reviewLogs);
   await storage.removeItem(STORAGE_KEYS.monthlyStats);
   await storage.removeItem(STORAGE_KEYS.maxNewCardsPerDay);
   await storage.removeItem(STORAGE_KEYS.dayStartHour);

--- a/services/stats.ts
+++ b/services/stats.ts
@@ -4,6 +4,20 @@ import { storage } from '#imports';
 import { getAllCards, isDueByDate, formatLocalDate } from './cards';
 import { getDayStartHour } from './settings';
 import { DAILY_STATS_RETENTION_DAYS } from '@/shared/settings';
+import type { Difficulty, LeetcodeDomain } from '@/shared/cards';
+
+export interface ReviewLogEntry {
+  cardId: string;
+  slug: string;
+  name: string;
+  leetcodeId: string;
+  difficulty: Difficulty;
+  domain: LeetcodeDomain;
+  rating: Grade;
+  timestamp: number;
+}
+
+export type DailyReviewLogs = Record<string, ReviewLogEntry[]>;
 
 interface BaseStats {
   totalReviews: number;
@@ -237,4 +251,44 @@ export async function getNextNDaysStats(days: number): Promise<UpcomingReviewSta
   }
 
   return result;
+}
+
+export async function getReviewLogs(): Promise<DailyReviewLogs> {
+  const logs = await storage.getItem<DailyReviewLogs>(STORAGE_KEYS.reviewLogs);
+  return logs ?? {};
+}
+
+export async function addReviewLog(
+  cardId: string,
+  slug: string,
+  name: string,
+  leetcodeId: string,
+  difficulty: Difficulty,
+  domain: LeetcodeDomain,
+  rating: Grade
+): Promise<void> {
+  const logs = await getReviewLogs();
+  const todayKey = await getTodayKey();
+
+  if (!logs[todayKey]) {
+    logs[todayKey] = [];
+  }
+
+  logs[todayKey].push({
+    cardId,
+    slug,
+    name,
+    leetcodeId,
+    difficulty,
+    domain,
+    rating,
+    timestamp: Date.now(),
+  });
+
+  await storage.setItem(STORAGE_KEYS.reviewLogs, logs);
+}
+
+export async function getReviewLogsForDate(date: string): Promise<ReviewLogEntry[]> {
+  const logs = await getReviewLogs();
+  return logs[date] ?? [];
 }

--- a/services/storage-keys.ts
+++ b/services/storage-keys.ts
@@ -3,6 +3,7 @@ export const STORAGE_KEYS = {
   stats: 'local:leetsrs:stats',
   monthlyStats: 'local:leetsrs:monthlyStats',
   notes: 'local:leetsrs:notes',
+  reviewLogs: 'local:leetsrs:reviewLogs',
   maxNewCardsPerDay: 'sync:leetsrs:maxNewCardsPerDay',
   dayStartHour: 'sync:leetsrs:dayStartHour',
   animationsEnabled: 'sync:leetsrs:animationsEnabled',

--- a/shared/i18n/en.ts
+++ b/shared/i18n/en.ts
@@ -110,6 +110,7 @@ const en = {
     noCardsAdded: 'No cards added yet.',
     noCardsMatchFilter: 'No cards match your filter.',
     cardPausedTitle: 'Card is paused',
+    openOnLeetCode: 'Open on LeetCode',
   },
 
   // Card stats labels

--- a/shared/i18n/en.ts
+++ b/shared/i18n/en.ts
@@ -127,6 +127,8 @@ const en = {
   // Stats view
   statsView: {
     title: 'Statistics',
+    calendarTitle: 'Calendar',
+    noReviewsOnDay: 'No tasks reviewed on this day',
   },
 
   // Charts

--- a/shared/i18n/hi.ts
+++ b/shared/i18n/hi.ts
@@ -100,6 +100,7 @@ const hi: Translations = {
     noCardsAdded: 'अभी तक कोई कार्ड नहीं जोड़ा गया।',
     noCardsMatchFilter: 'कोई कार्ड आपके फ़िल्टर से मैच नहीं करता।',
     cardPausedTitle: 'कार्ड पॉज़्ड है',
+    openOnLeetCode: 'LeetCode पर खोलें',
   },
   // Card stats labels
   cardStats: {

--- a/shared/i18n/hi.ts
+++ b/shared/i18n/hi.ts
@@ -115,6 +115,8 @@ const hi: Translations = {
   // Stats view
   statsView: {
     title: 'स्टैट्स',
+    calendarTitle: 'कैलेंडर',
+    noReviewsOnDay: 'इस दिन कोई कार्य नहीं दोहराया गया',
   },
   // Charts
   charts: {

--- a/shared/i18n/pl.ts
+++ b/shared/i18n/pl.ts
@@ -129,6 +129,8 @@ const pl: Translations = {
   // Stats view
   statsView: {
     title: 'Statystyki',
+    calendarTitle: 'Kalendarz',
+    noReviewsOnDay: 'Brak przejrzanych zadań w tym dniu',
   },
 
   // Charts

--- a/shared/i18n/pl.ts
+++ b/shared/i18n/pl.ts
@@ -112,6 +112,7 @@ const pl: Translations = {
     noCardsAdded: 'Nie dodano jeszcze żadnych kart.',
     noCardsMatchFilter: 'Żadne karty nie pasują do filtra.',
     cardPausedTitle: 'Karta jest wstrzymana',
+    openOnLeetCode: 'Otwórz na LeetCode',
   },
 
   // Card stats labels

--- a/shared/i18n/zh-CN.ts
+++ b/shared/i18n/zh-CN.ts
@@ -100,6 +100,7 @@ const zhCN: Translations = {
     noCardsAdded: '还没有添加卡片。',
     noCardsMatchFilter: '没有匹配的卡片。',
     cardPausedTitle: '卡片已暂停',
+    openOnLeetCode: '在 LeetCode 上打开',
   },
 
   cardStats: {

--- a/shared/i18n/zh-CN.ts
+++ b/shared/i18n/zh-CN.ts
@@ -115,6 +115,8 @@ const zhCN: Translations = {
 
   statsView: {
     title: '统计',
+    calendarTitle: '日历',
+    noReviewsOnDay: '这一天没有复习的任务',
   },
 
   charts: {

--- a/shared/messages.ts
+++ b/shared/messages.ts
@@ -1,7 +1,7 @@
 import { browser } from 'wxt/browser';
 import type { Card, Difficulty, LeetcodeDomain } from '@/shared/cards';
 import type { Grade, State as FsrsState } from 'ts-fsrs';
-import type { DailyStats, UpcomingReviewStats } from '@/services/stats';
+import type { DailyStats, UpcomingReviewStats, DailyReviewLogs } from '@/services/stats';
 import type { Note } from '@/shared/notes';
 import type { Theme, Language } from '@/shared/settings';
 import type {
@@ -44,6 +44,7 @@ export const MessageType = {
   GET_ALL_STATS: 'GET_ALL_STATS',
   GET_LAST_N_DAYS_STATS: 'GET_LAST_N_DAYS_STATS',
   GET_NEXT_N_DAYS_STATS: 'GET_NEXT_N_DAYS_STATS',
+  GET_REVIEW_LOGS: 'GET_REVIEW_LOGS',
   EXPORT_DATA: 'EXPORT_DATA',
   IMPORT_DATA: 'IMPORT_DATA',
   RESET_ALL_DATA: 'RESET_ALL_DATA',
@@ -104,6 +105,7 @@ export type MessageRequest =
   | { type: typeof MessageType.GET_ALL_STATS }
   | { type: typeof MessageType.GET_LAST_N_DAYS_STATS; days: number }
   | { type: typeof MessageType.GET_NEXT_N_DAYS_STATS; days: number }
+  | { type: typeof MessageType.GET_REVIEW_LOGS }
   | { type: typeof MessageType.EXPORT_DATA }
   | { type: typeof MessageType.IMPORT_DATA; jsonData: string }
   | { type: typeof MessageType.RESET_ALL_DATA }
@@ -148,6 +150,7 @@ export type MessageResponseMap = {
   [MessageType.GET_ALL_STATS]: DailyStats[];
   [MessageType.GET_LAST_N_DAYS_STATS]: DailyStats[];
   [MessageType.GET_NEXT_N_DAYS_STATS]: UpcomingReviewStats[];
+  [MessageType.GET_REVIEW_LOGS]: DailyReviewLogs;
   [MessageType.EXPORT_DATA]: string;
   [MessageType.IMPORT_DATA]: void;
   [MessageType.RESET_ALL_DATA]: void;

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -12,7 +12,7 @@ export default defineConfig({
     name: '__MSG_extName__',
     description: '__MSG_extDescription__',
     default_locale: 'en',
-    permissions: ['storage', 'alarms'],
+    permissions: ['storage', 'alarms', 'unlimitedStorage'],
     host_permissions: ['*://*.leetcode.com/*'],
     optional_host_permissions: ['*://*.leetcode.cn/*'],
   },


### PR DESCRIPTION
Hi! First of all, I really love this extension - it's been super helpful for my LeetCode study routine. While using it, I noticed a couple of features that were missing for my workflow, so I decided to implement them and submit a PR to share them with the project.

This PR introduces two main features:

### 1. Interactive Review History Calendar (Stats Tab)
Added a new interactive calendar card at the very top of the Stats view. This allows users to track exactly what problems they worked on and how they rated them on any given day.

**Implementation Details:**
* **Dedicated & Isolated Storage:** Review logs are stored under a new, dedicated `local:leetsrs:reviewLogs` key. This keeps the calendar data completely isolated from the existing cards and stats structures, preventing any potential data corruption.
* **Persistent History:** Unlike standard daily stats (which are pruned and aggregated into monthly counters after 30 days to save space), review logs are designed to stay persistent. I added the `unlimitedStorage` permission to the manifest to ensure users won't run into Chrome storage quota limits over years of usage.
* **Respects Study Day Offsets:** The calendar fully supports the user's custom `dayStartHour` offset settings (e.g., if a study day starts at 4:00 AM, reviews made at 2:00 AM are correctly grouped under the previous study day).
* **Comprehensive Task Details:** Selecting any date displays a list of reviewed tasks for that day. Each entry lists the problem ID, name, difficulty badge, rating score (Again, Hard, Good, Easy), and a quick link to open it directly on LeetCode.
* **Localized Calendar Formatting:** Native `Intl.DateTimeFormat` is used to dynamically translate and format month/weekday names based on the user's chosen display language.
* **Data Portability:** Fully integrated the review logs into the existing backup import/export and reset data scripts.

### 2. Quick LeetCode Link (Cards Tab)
* Added a direct external link next to the difficulty badge on each card in the Cards list to quickly open tasks on LeetCode.
* Refactored the layout to prevent invalid HTML nesting (`<a>` inside `<button>`) and handled event propagation so that clicking the link opens the tab without expanding the card.

### Additional Changes
* Added translation keys (`calendarTitle`, `noReviewsOnDay`, `openOnLeetCode`) for all supported locales (en, hi, pl, zh-CN).
* Fixed a pre-existing timezone sensitivity in the test suite where UTC dates caused mock queue test failures in non-UTC runner environments.
* Confirmed that all 496 tests, linter, formatting checks, and TypeScript compilations pass cleanly.

Hope you find these additions useful! Thanks for building such a great tool.