### PR TITLE
feat: clear editor when opening a due review

### DIFF
--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -20,6 +20,8 @@ import {
   setTheme,
   getAutoClearLeetcode,
   setAutoClearLeetcode,
+  getClearEditorOnReview,
+  setClearEditorOnReview,
   getBadgeEnabled,
   setBadgeEnabled,
   getLanguage,
@@ -29,6 +31,7 @@ import { browser } from 'wxt/browser';
 import { MessageType, type MessageRequest } from '@/shared/messages';
 import { runMigrations, migrations } from '@/services/migrations';
 import { exportData, importData, resetAllData } from '@/services/import-export';
+import { getClearEditorOnReviewDecision } from '@/services/clear-editor-on-review';
 import {
   getGistSyncConfig,
   setGistSyncConfig,
@@ -181,6 +184,16 @@ export default defineBackground(() => {
       case MessageType.SET_AUTO_CLEAR_LEETCODE: {
         return handleDataUpdate(() => setAutoClearLeetcode(request.value));
       }
+
+      case MessageType.GET_CLEAR_EDITOR_ON_REVIEW:
+        return await getClearEditorOnReview();
+
+      case MessageType.SET_CLEAR_EDITOR_ON_REVIEW: {
+        return handleDataUpdate(() => setClearEditorOnReview(request.value));
+      }
+
+      case MessageType.GET_CLEAR_EDITOR_ON_REVIEW_DECISION:
+        return await getClearEditorOnReviewDecision(request.slug, request.domain);
 
       case MessageType.GET_BADGE_ENABLED:
         return await getBadgeEnabled();

--- a/entrypoints/content.ts
+++ b/entrypoints/content.ts
@@ -3,6 +3,7 @@ import {
   extractProblemData,
   getCurrentDomain,
   RatingMenu,
+  setupClearEditorOnReview,
   setupLeetcodeAutoReset,
   Tooltip,
 } from '@/utils/content';
@@ -14,8 +15,12 @@ import type { ProblemData } from '@/shared/problem-data';
 
 export default defineContentScript({
   matches: ['*://*.leetcode.com/*', '*://*.leetcode.cn/*'],
-  runAt: 'document_idle',
+  runAt: 'document_start',
   async main() {
+    setupClearEditorOnReview();
+
+    await whenDocumentBodyIsReady();
+
     // Wake up service worker so it's ready when user interacts
     try {
       await sendMessage({ type: MessageType.PING });
@@ -26,6 +31,24 @@ export default defineContentScript({
     setupLeetcodeAutoReset();
   },
 });
+
+function whenDocumentBodyIsReady(): Promise<void> {
+  if (document.body) {
+    return Promise.resolve();
+  }
+
+  return new Promise((resolve) => {
+    const observer = new MutationObserver(() => {
+      if (!document.body) {
+        return;
+      }
+
+      observer.disconnect();
+      resolve();
+    });
+    observer.observe(document.documentElement, { childList: true });
+  });
+}
 
 function toProblemDescriptor(problemData: ProblemData): ProblemDescriptor {
   return {

--- a/entrypoints/popup/views/settings/ProblemAutoClearSection.tsx
+++ b/entrypoints/popup/views/settings/ProblemAutoClearSection.tsx
@@ -1,15 +1,26 @@
-import { useAutoClearLeetcodeQuery, useSetAutoClearLeetcodeMutation } from '@/hooks/useBackgroundQueries';
-import { DEFAULT_AUTO_CLEAR_LEETCODE } from '@/shared/settings';
+import {
+  useAutoClearLeetcodeQuery,
+  useClearEditorOnReviewQuery,
+  useSetAutoClearLeetcodeMutation,
+  useSetClearEditorOnReviewMutation,
+} from '@/hooks/useBackgroundQueries';
+import { DEFAULT_AUTO_CLEAR_LEETCODE, DEFAULT_CLEAR_EDITOR_ON_REVIEW } from '@/shared/settings';
 import { useI18n } from '../../contexts/I18nContext';
 import { SettingsSwitch } from './SettingsSwitch';
 
 export function ProblemAutoClearSection() {
   const t = useI18n();
   const { data: autoClearLeetcode = DEFAULT_AUTO_CLEAR_LEETCODE } = useAutoClearLeetcodeQuery();
+  const { data: clearEditorOnReview = DEFAULT_CLEAR_EDITOR_ON_REVIEW } = useClearEditorOnReviewQuery();
   const setAutoClearLeetcodeMutation = useSetAutoClearLeetcodeMutation();
+  const setClearEditorOnReviewMutation = useSetClearEditorOnReviewMutation();
 
   const setAutoClearLeetcode = (isSelected: boolean) => {
     setAutoClearLeetcodeMutation.mutate(isSelected);
+  };
+
+  const setClearEditorOnReview = (isSelected: boolean) => {
+    setClearEditorOnReviewMutation.mutate(isSelected);
   };
 
   return (
@@ -21,6 +32,11 @@ export function ProblemAutoClearSection() {
           label={t.settings.problemAutoClear.enableAutoReset}
           isSelected={autoClearLeetcode}
           onChange={setAutoClearLeetcode}
+        />
+        <SettingsSwitch
+          label={t.settings.problemAutoClear.clearEditorOnReview}
+          isSelected={clearEditorOnReview}
+          onChange={setClearEditorOnReview}
         />
       </div>
     </div>

--- a/hooks/useBackgroundQueries.ts
+++ b/hooks/useBackgroundQueries.ts
@@ -32,6 +32,7 @@ export const queryKeys = {
     animationsEnabled: ['settings', 'animationsEnabled'] as const,
     theme: ['settings', 'theme'] as const,
     autoClearLeetcode: ['settings', 'autoClearLeetcode'] as const,
+    clearEditorOnReview: ['settings', 'clearEditorOnReview'] as const,
     badgeEnabled: ['settings', 'badgeEnabled'] as const,
     language: ['settings', 'language'] as const,
   },
@@ -283,6 +284,24 @@ export function useSetAutoClearLeetcodeMutation() {
     mutationFn: (value: boolean) => sendMessage({ type: MessageType.SET_AUTO_CLEAR_LEETCODE, value }),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: queryKeys.settings.autoClearLeetcode });
+    },
+  });
+}
+
+export function useClearEditorOnReviewQuery() {
+  return useQuery({
+    queryKey: queryKeys.settings.clearEditorOnReview,
+    queryFn: () => sendMessage({ type: MessageType.GET_CLEAR_EDITOR_ON_REVIEW }),
+  });
+}
+
+export function useSetClearEditorOnReviewMutation() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (value: boolean) => sendMessage({ type: MessageType.SET_CLEAR_EDITOR_ON_REVIEW, value }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.settings.clearEditorOnReview });
     },
   });
 }

--- a/services/__tests__/clear-editor-on-review.test.ts
+++ b/services/__tests__/clear-editor-on-review.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { fakeBrowser } from 'wxt/testing/fake-browser';
+import { storage } from 'wxt/utils/storage';
+import { createEmptyCard, State as FsrsState } from 'ts-fsrs';
+import { getClearEditorOnReviewDecision } from '../clear-editor-on-review';
+import { serializeCard, type StoredCard } from '../cards';
+import { setClearEditorOnReview } from '../settings';
+import { STORAGE_KEYS } from '../storage-keys';
+import type { Card } from '@/shared/cards';
+
+describe('clear editor on review decision', () => {
+  beforeEach(() => {
+    fakeBrowser.reset();
+  });
+
+  it('should default to not clearing when the setting is off', async () => {
+    await storeCard(makeCard({ slug: 'two-sum', state: FsrsState.Review, due: new Date('2025-01-01') }));
+
+    await expect(getClearEditorOnReviewDecision('two-sum', 'leetcode.com')).resolves.toEqual({ shouldClear: false });
+  });
+
+  it('should clear a due review card when the setting is enabled', async () => {
+    await setClearEditorOnReview(true);
+    await storeCard(
+      makeCard({
+        slug: 'two-sum',
+        leetcodeId: '1',
+        state: FsrsState.Review,
+        due: new Date('2025-01-01'),
+      })
+    );
+
+    await expect(getClearEditorOnReviewDecision('two-sum', 'leetcode.com')).resolves.toEqual({
+      shouldClear: true,
+      questionFrontendId: '1',
+    });
+  });
+
+  it('should not clear cards that are not currently due', async () => {
+    await setClearEditorOnReview(true);
+    await storeCard(makeCard({ slug: 'two-sum', state: FsrsState.Review, due: new Date('2999-01-01') }));
+
+    await expect(getClearEditorOnReviewDecision('two-sum', 'leetcode.com')).resolves.toEqual({ shouldClear: false });
+  });
+
+  it('should not clear unscheduled new cards', async () => {
+    await setClearEditorOnReview(true);
+    await storeCard(makeCard({ slug: 'two-sum', state: FsrsState.New, due: new Date('2025-01-01') }));
+
+    await expect(getClearEditorOnReviewDecision('two-sum', 'leetcode.com')).resolves.toEqual({ shouldClear: false });
+  });
+
+  it.each([FsrsState.Learning, FsrsState.Relearning])(
+    'should not clear a card being worked on in state %s',
+    async (state) => {
+      await setClearEditorOnReview(true);
+      await storeCard(makeCard({ slug: 'two-sum', state, due: new Date('2025-01-01') }));
+
+      await expect(getClearEditorOnReviewDecision('two-sum', 'leetcode.com')).resolves.toEqual({ shouldClear: false });
+    }
+  );
+
+  it('should not clear paused cards', async () => {
+    await setClearEditorOnReview(true);
+    await storeCard(
+      makeCard({
+        slug: 'two-sum',
+        state: FsrsState.Review,
+        due: new Date('2025-01-01'),
+        paused: true,
+      })
+    );
+
+    await expect(getClearEditorOnReviewDecision('two-sum', 'leetcode.com')).resolves.toEqual({ shouldClear: false });
+  });
+
+  it('should not clear problems without a matching card', async () => {
+    await setClearEditorOnReview(true);
+
+    await expect(getClearEditorOnReviewDecision('two-sum', 'leetcode.com')).resolves.toEqual({ shouldClear: false });
+  });
+
+  it('should not clear a card from another LeetCode domain', async () => {
+    await setClearEditorOnReview(true);
+    await storeCard(makeCard({ slug: 'two-sum', state: FsrsState.Review, due: new Date('2025-01-01') }));
+
+    await expect(getClearEditorOnReviewDecision('two-sum', 'leetcode.cn')).resolves.toEqual({ shouldClear: false });
+  });
+});
+
+async function storeCard(card: Card): Promise<void> {
+  const cards = ((await storage.getItem(STORAGE_KEYS.cards)) ?? {}) as Record<string, StoredCard>;
+  cards[card.slug] = serializeCard(card);
+  await storage.setItem(STORAGE_KEYS.cards, cards);
+}
+
+function makeCard({
+  slug,
+  leetcodeId = '1',
+  state,
+  due,
+  paused = false,
+}: {
+  slug: string;
+  leetcodeId?: string;
+  state: FsrsState;
+  due: Date;
+  paused?: boolean;
+}): Card {
+  return {
+    id: `${slug}-id`,
+    slug,
+    name: 'Two Sum',
+    leetcodeId,
+    difficulty: 'Easy',
+    domain: 'leetcode.com',
+    createdAt: new Date('2024-01-01'),
+    fsrs: {
+      ...createEmptyCard(),
+      state,
+      due,
+      last_review: state === FsrsState.New ? undefined : new Date('2024-01-01'),
+    },
+    paused,
+  };
+}

--- a/services/__tests__/import-export.test.ts
+++ b/services/__tests__/import-export.test.ts
@@ -64,6 +64,7 @@ describe('import-export', () => {
         animationsEnabled: true,
         theme: 'dark' as const,
         autoClearLeetcode: true,
+        clearEditorOnReview: true,
         badgeEnabled: true,
         language: 'en' as const,
       };
@@ -77,6 +78,7 @@ describe('import-export', () => {
       await storage.setItem(STORAGE_KEYS.animationsEnabled, mockSettings.animationsEnabled);
       await storage.setItem(STORAGE_KEYS.theme, mockSettings.theme);
       await storage.setItem(STORAGE_KEYS.autoClearLeetcode, mockSettings.autoClearLeetcode);
+      await storage.setItem(STORAGE_KEYS.clearEditorOnReview, mockSettings.clearEditorOnReview);
       await storage.setItem(STORAGE_KEYS.badgeEnabled, mockSettings.badgeEnabled);
       await storage.setItem(STORAGE_KEYS.language, mockSettings.language);
 
@@ -187,6 +189,7 @@ describe('import-export', () => {
           animationsEnabled: false,
           theme: 'light' as const,
           autoClearLeetcode: true,
+          clearEditorOnReview: true,
           badgeEnabled: false,
           language: 'en' as const,
         },
@@ -208,6 +211,7 @@ describe('import-export', () => {
       expect(await storage.getItem(STORAGE_KEYS.animationsEnabled)).toEqual(false);
       expect(await storage.getItem(STORAGE_KEYS.theme)).toEqual('light');
       expect(await storage.getItem(STORAGE_KEYS.autoClearLeetcode)).toEqual(true);
+      expect(await storage.getItem(STORAGE_KEYS.clearEditorOnReview)).toEqual(true);
       expect(await storage.getItem(STORAGE_KEYS.badgeEnabled)).toEqual(false);
       expect(await storage.getItem(STORAGE_KEYS.language)).toEqual('en');
     });

--- a/services/__tests__/migrations.test.ts
+++ b/services/__tests__/migrations.test.ts
@@ -226,7 +226,27 @@ describe('migrations', () => {
     it('should handle empty or missing cards storage', async () => {
       await runMigrations(migrations);
 
-      expect(await getCurrentSchemaVersion()).toBe(1);
+      expect(await getCurrentSchemaVersion()).toBe(2);
+    });
+  });
+
+  describe('migration v2: clear editor on review setting', () => {
+    it('should initialize the setting as disabled', async () => {
+      await setSchemaVersion(1);
+
+      await runMigrations(migrations);
+
+      expect(await storage.getItem(STORAGE_KEYS.clearEditorOnReview)).toBe(false);
+      expect(await getCurrentSchemaVersion()).toBe(2);
+    });
+
+    it('should not overwrite an existing setting', async () => {
+      await setSchemaVersion(1);
+      await storage.setItem(STORAGE_KEYS.clearEditorOnReview, true);
+
+      await runMigrations(migrations);
+
+      expect(await storage.getItem(STORAGE_KEYS.clearEditorOnReview)).toBe(true);
     });
   });
 });

--- a/services/__tests__/settings.test.ts
+++ b/services/__tests__/settings.test.ts
@@ -10,6 +10,8 @@ import {
   setTheme,
   getAutoClearLeetcode,
   setAutoClearLeetcode,
+  getClearEditorOnReview,
+  setClearEditorOnReview,
   getLanguage,
 } from '../settings';
 import { STORAGE_KEYS } from '../storage-keys';
@@ -19,6 +21,7 @@ import {
   MAX_NEW_CARDS_PER_DAY,
   DEFAULT_THEME,
   DEFAULT_AUTO_CLEAR_LEETCODE,
+  DEFAULT_CLEAR_EDITOR_ON_REVIEW,
 } from '@/shared/settings';
 
 describe('Settings Service', () => {
@@ -237,11 +240,17 @@ describe('Settings Service', () => {
   describe('auto clear settings', () => {
     it('should return default values when not set', async () => {
       expect(await getAutoClearLeetcode()).toBe(DEFAULT_AUTO_CLEAR_LEETCODE);
+      expect(await getClearEditorOnReview()).toBe(DEFAULT_CLEAR_EDITOR_ON_REVIEW);
     });
 
     it('should store and retrieve LeetCode auto clear', async () => {
       await setAutoClearLeetcode(true);
       expect(await getAutoClearLeetcode()).toBe(true);
+    });
+
+    it('should store and retrieve clear editor on review', async () => {
+      await setClearEditorOnReview(true);
+      expect(await getClearEditorOnReview()).toBe(true);
     });
   });
 

--- a/services/clear-editor-on-review.ts
+++ b/services/clear-editor-on-review.ts
@@ -1,0 +1,33 @@
+import { State as FsrsState } from 'ts-fsrs';
+import { getAllCards, isDueByDate } from './cards';
+import { getClearEditorOnReview, getDayStartHour } from './settings';
+import type { LeetcodeDomain } from '@/shared/cards';
+import type { ClearEditorOnReviewDecision } from '@/shared/messages';
+
+export async function getClearEditorOnReviewDecision(
+  slug: string,
+  domain: LeetcodeDomain
+): Promise<ClearEditorOnReviewDecision> {
+  const enabled = await getClearEditorOnReview();
+  if (!enabled) {
+    return { shouldClear: false };
+  }
+
+  const cards = await getAllCards();
+  const card = cards.find((candidate) => candidate.slug === slug && candidate.domain === domain);
+  // Learning and relearning cards represent work in progress. Only an already
+  // scheduled review should start with LeetCode's default editor contents.
+  if (!card || card.paused || card.fsrs.state !== FsrsState.Review) {
+    return { shouldClear: false };
+  }
+
+  const dayStartHour = await getDayStartHour();
+  if (!isDueByDate(card, new Date(), dayStartHour)) {
+    return { shouldClear: false };
+  }
+
+  return {
+    shouldClear: true,
+    questionFrontendId: card.leetcodeId,
+  };
+}

--- a/services/import-export.ts
+++ b/services/import-export.ts
@@ -21,6 +21,7 @@ export interface ExportData {
       animationsEnabled?: boolean;
       theme?: Theme;
       autoClearLeetcode?: boolean;
+      clearEditorOnReview?: boolean;
       badgeEnabled?: boolean;
       language?: Language;
     };
@@ -53,6 +54,7 @@ export async function exportData(): Promise<string> {
   const animationsEnabled = await storage.getItem<boolean>(STORAGE_KEYS.animationsEnabled);
   const theme = await storage.getItem<Theme>(STORAGE_KEYS.theme);
   const autoClearLeetcode = await storage.getItem<boolean>(STORAGE_KEYS.autoClearLeetcode);
+  const clearEditorOnReview = await storage.getItem<boolean>(STORAGE_KEYS.clearEditorOnReview);
   const badgeEnabled = await storage.getItem<boolean>(STORAGE_KEYS.badgeEnabled);
   const language = await storage.getItem<Language>(STORAGE_KEYS.language);
 
@@ -80,6 +82,7 @@ export async function exportData(): Promise<string> {
         ...(animationsEnabled != null && { animationsEnabled }),
         ...(theme != null && { theme }),
         ...(autoClearLeetcode != null && { autoClearLeetcode }),
+        ...(clearEditorOnReview != null && { clearEditorOnReview }),
         ...(badgeEnabled != null && { badgeEnabled }),
         ...(language != null && { language }),
       },
@@ -173,6 +176,9 @@ export async function importData(jsonData: string): Promise<void> {
     if (data.data.settings.autoClearLeetcode != null) {
       await storage.setItem(STORAGE_KEYS.autoClearLeetcode, data.data.settings.autoClearLeetcode);
     }
+    if (data.data.settings.clearEditorOnReview != null) {
+      await storage.setItem(STORAGE_KEYS.clearEditorOnReview, data.data.settings.clearEditorOnReview);
+    }
     if (data.data.settings.badgeEnabled != null) {
       await storage.setItem(STORAGE_KEYS.badgeEnabled, data.data.settings.badgeEnabled);
     }
@@ -208,6 +214,7 @@ export async function resetAllData(): Promise<void> {
   await storage.removeItem(STORAGE_KEYS.animationsEnabled);
   await storage.removeItem(STORAGE_KEYS.theme);
   await storage.removeItem(STORAGE_KEYS.autoClearLeetcode);
+  await storage.removeItem(STORAGE_KEYS.clearEditorOnReview);
   await storage.removeItem(STORAGE_KEYS.badgeEnabled);
   await storage.removeItem(STORAGE_KEYS.language);
 

--- a/services/migrations.ts
+++ b/services/migrations.ts
@@ -60,4 +60,14 @@ export const migrations: Migration[] = [
       }
     },
   },
+  {
+    version: 2,
+    description: 'Initialize the clear editor on review setting as disabled',
+    migrate: async () => {
+      const value = await storage.getItem<boolean>(STORAGE_KEYS.clearEditorOnReview);
+      if (value == null) {
+        await storage.setItem(STORAGE_KEYS.clearEditorOnReview, false);
+      }
+    },
+  },
 ];

--- a/services/settings.ts
+++ b/services/settings.ts
@@ -11,6 +11,7 @@ import {
   type Theme,
   DEFAULT_THEME,
   DEFAULT_AUTO_CLEAR_LEETCODE,
+  DEFAULT_CLEAR_EDITOR_ON_REVIEW,
   DEFAULT_BADGE_ENABLED,
   type Language,
 } from '@/shared/settings';
@@ -73,6 +74,15 @@ export async function getAutoClearLeetcode(): Promise<boolean> {
 
 export async function setAutoClearLeetcode(value: boolean): Promise<void> {
   await storage.setItem(STORAGE_KEYS.autoClearLeetcode, value);
+}
+
+export async function getClearEditorOnReview(): Promise<boolean> {
+  const value = await storage.getItem<boolean>(STORAGE_KEYS.clearEditorOnReview);
+  return value ?? DEFAULT_CLEAR_EDITOR_ON_REVIEW;
+}
+
+export async function setClearEditorOnReview(value: boolean): Promise<void> {
+  await storage.setItem(STORAGE_KEYS.clearEditorOnReview, value);
 }
 
 export async function getBadgeEnabled(): Promise<boolean> {

--- a/services/storage-keys.ts
+++ b/services/storage-keys.ts
@@ -8,6 +8,7 @@ export const STORAGE_KEYS = {
   animationsEnabled: 'sync:leetsrs:animationsEnabled',
   theme: 'sync:leetsrs:theme',
   autoClearLeetcode: 'sync:leetsrs:autoClearLeetcode',
+  clearEditorOnReview: 'sync:leetsrs:clearEditorOnReview',
   badgeEnabled: 'sync:leetsrs:badgeEnabled',
   language: 'sync:leetsrs:language',
   schemaVersion: 'local:leetsrs:schemaVersion',

--- a/shared/i18n/en.ts
+++ b/shared/i18n/en.ts
@@ -166,6 +166,7 @@ const en = {
       title: 'Problem Auto Reset',
       description: 'Automatically reset code when opening a LeetCode problem.',
       enableAutoReset: 'Enable auto reset',
+      clearEditorOnReview: 'Clear editor on review',
     },
 
     leetcodeCn: {

--- a/shared/i18n/hi.ts
+++ b/shared/i18n/hi.ts
@@ -148,6 +148,7 @@ const hi: Translations = {
       title: 'प्रॉब्लम ऑटो रीसेट',
       description: 'LeetCode प्रॉब्लम खोलने पर कोड ऑटोमैटिकली रीसेट करें।',
       enableAutoReset: 'ऑटो रीसेट ऑन करें',
+      clearEditorOnReview: 'रिव्यू पर एडिटर साफ़ करें',
     },
 
     leetcodeCn: {

--- a/shared/i18n/pl.ts
+++ b/shared/i18n/pl.ts
@@ -168,6 +168,7 @@ const pl: Translations = {
       title: 'Automatyczny reset zadania',
       description: 'Automatycznie resetuj kod przy otwieraniu zadania na LeetCode.',
       enableAutoReset: 'Włącz automatyczny reset',
+      clearEditorOnReview: 'Wyczyść edytor przy powtórce',
     },
 
     leetcodeCn: {

--- a/shared/i18n/zh-CN.ts
+++ b/shared/i18n/zh-CN.ts
@@ -149,6 +149,7 @@ const zhCN: Translations = {
       title: '题目自动重置',
       description: '打开 LeetCode 题目时自动重置代码。',
       enableAutoReset: '启用自动重置',
+      clearEditorOnReview: '复习时清空编辑器',
     },
 
     leetcodeCn: {

--- a/shared/messages.ts
+++ b/shared/messages.ts
@@ -1,5 +1,5 @@
 import { browser } from 'wxt/browser';
-import type { Card, ProblemDescriptor, RateCardInput } from '@/shared/cards';
+import type { Card, LeetcodeDomain, ProblemDescriptor, RateCardInput } from '@/shared/cards';
 import type { State as FsrsState } from 'ts-fsrs';
 import type { DailyStats, UpcomingReviewStats } from '@/services/stats';
 import type { Note } from '@/shared/notes';
@@ -36,6 +36,9 @@ export const MessageType = {
   SET_THEME: 'SET_THEME',
   GET_AUTO_CLEAR_LEETCODE: 'GET_AUTO_CLEAR_LEETCODE',
   SET_AUTO_CLEAR_LEETCODE: 'SET_AUTO_CLEAR_LEETCODE',
+  GET_CLEAR_EDITOR_ON_REVIEW: 'GET_CLEAR_EDITOR_ON_REVIEW',
+  SET_CLEAR_EDITOR_ON_REVIEW: 'SET_CLEAR_EDITOR_ON_REVIEW',
+  GET_CLEAR_EDITOR_ON_REVIEW_DECISION: 'GET_CLEAR_EDITOR_ON_REVIEW_DECISION',
   GET_BADGE_ENABLED: 'GET_BADGE_ENABLED',
   SET_BADGE_ENABLED: 'SET_BADGE_ENABLED',
   GET_LANGUAGE: 'GET_LANGUAGE',
@@ -55,6 +58,11 @@ export const MessageType = {
   VALIDATE_PAT: 'VALIDATE_PAT',
   VALIDATE_GIST_ID: 'VALIDATE_GIST_ID',
 } as const;
+
+export interface ClearEditorOnReviewDecision {
+  shouldClear: boolean;
+  questionFrontendId?: string;
+}
 
 // Message request types as discriminated union
 export type MessageRequest =
@@ -80,6 +88,13 @@ export type MessageRequest =
   | { type: typeof MessageType.SET_THEME; value: Theme }
   | { type: typeof MessageType.GET_AUTO_CLEAR_LEETCODE }
   | { type: typeof MessageType.SET_AUTO_CLEAR_LEETCODE; value: boolean }
+  | { type: typeof MessageType.GET_CLEAR_EDITOR_ON_REVIEW }
+  | { type: typeof MessageType.SET_CLEAR_EDITOR_ON_REVIEW; value: boolean }
+  | {
+      type: typeof MessageType.GET_CLEAR_EDITOR_ON_REVIEW_DECISION;
+      slug: string;
+      domain: LeetcodeDomain;
+    }
   | { type: typeof MessageType.GET_BADGE_ENABLED }
   | { type: typeof MessageType.SET_BADGE_ENABLED; value: boolean }
   | { type: typeof MessageType.GET_LANGUAGE }
@@ -123,6 +138,9 @@ export type MessageResponseMap = {
   [MessageType.SET_THEME]: void;
   [MessageType.GET_AUTO_CLEAR_LEETCODE]: boolean;
   [MessageType.SET_AUTO_CLEAR_LEETCODE]: void;
+  [MessageType.GET_CLEAR_EDITOR_ON_REVIEW]: boolean;
+  [MessageType.SET_CLEAR_EDITOR_ON_REVIEW]: void;
+  [MessageType.GET_CLEAR_EDITOR_ON_REVIEW_DECISION]: ClearEditorOnReviewDecision;
   [MessageType.GET_BADGE_ENABLED]: boolean;
   [MessageType.SET_BADGE_ENABLED]: void;
   [MessageType.GET_LANGUAGE]: Language;

--- a/shared/settings.ts
+++ b/shared/settings.ts
@@ -7,6 +7,7 @@ export const MIN_DAY_START_HOUR = 0;
 export const MAX_DAY_START_HOUR = 23;
 
 export const DEFAULT_AUTO_CLEAR_LEETCODE = false;
+export const DEFAULT_CLEAR_EDITOR_ON_REVIEW = false;
 export const DEFAULT_BADGE_ENABLED = true;
 export type Theme = 'light' | 'dark';
 export const DEFAULT_THEME: Theme = 'dark';

--- a/utils/content/__tests__/editor-state.test.ts
+++ b/utils/content/__tests__/editor-state.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
+  RESET_CONFIRMATION_TIMEOUT_MS,
   clickResetConfirmation,
   findEditorSettingsControl,
   findResetToDefaultCodeDefinition,
@@ -24,7 +25,9 @@ describe('due-review editor reset fallback', () => {
   afterEach(() => {
     vi.restoreAllMocks();
     vi.unstubAllGlobals();
+    Reflect.deleteProperty(window, 'next');
     history.replaceState({}, '', '/');
+    vi.useRealTimers();
   });
 
   it('finds settings controls by accessible semantics and resets through LeetCode UI', async () => {
@@ -35,6 +38,7 @@ describe('due-review editor reset fallback', () => {
     action.textContent = 'Reset to Default Code Definition';
     const confirmationDialog = document.createElement('div');
     confirmationDialog.setAttribute('role', 'dialog');
+    confirmationDialog.textContent = 'Reset to Default Code Definition?';
     const confirm = document.createElement('button');
     confirm.textContent = 'Reset';
     confirmationDialog.append(confirm);
@@ -66,8 +70,65 @@ describe('due-review editor reset fallback', () => {
     pageReset.addEventListener('click', click);
     document.body.append(pageReset);
 
-    expect(clickResetConfirmation(document)).toBe(false);
+    expect(clickResetConfirmation(document, new Set())).toBe(false);
     expect(click).not.toHaveBeenCalled();
+  });
+
+  it('only confirms a new, visible reset dialog from this reset operation', () => {
+    const hiddenDialog = document.createElement('div');
+    hiddenDialog.setAttribute('role', 'dialog');
+    hiddenDialog.hidden = true;
+    hiddenDialog.textContent = 'Reset to Default Code Definition';
+    const hiddenReset = document.createElement('button');
+    hiddenReset.textContent = 'Reset';
+    const hiddenClick = vi.fn();
+    hiddenReset.addEventListener('click', hiddenClick);
+    hiddenDialog.append(hiddenReset);
+
+    const unrelatedDialog = document.createElement('div');
+    unrelatedDialog.setAttribute('role', 'dialog');
+    unrelatedDialog.textContent = 'Reset to Default Code Definition';
+    const unrelatedReset = document.createElement('button');
+    unrelatedReset.textContent = 'Reset';
+    const unrelatedClick = vi.fn();
+    unrelatedReset.addEventListener('click', unrelatedClick);
+    unrelatedDialog.append(unrelatedReset);
+
+    const confirmationDialog = document.createElement('div');
+    confirmationDialog.setAttribute('role', 'dialog');
+    confirmationDialog.textContent = 'Reset to Default Code Definition?';
+    const confirmation = document.createElement('button');
+    confirmation.textContent = 'Confirm';
+    const confirmationClick = vi.fn();
+    confirmation.addEventListener('click', confirmationClick);
+    confirmationDialog.append(confirmation);
+    document.body.append(hiddenDialog, unrelatedDialog, confirmationDialog);
+
+    expect(clickResetConfirmation(document, new Set([hiddenDialog, unrelatedDialog]))).toBe(true);
+    expect(hiddenClick).not.toHaveBeenCalled();
+    expect(unrelatedClick).not.toHaveBeenCalled();
+    expect(confirmationClick).toHaveBeenCalledOnce();
+  });
+
+  it('stops observing shortly after a reset click when no confirmation appears', async () => {
+    vi.useFakeTimers();
+    const disconnect = vi.spyOn(MutationObserver.prototype, 'disconnect');
+    const settings = document.createElement('button');
+    settings.setAttribute('aria-label', 'Editor settings');
+    const resetAction = document.createElement('button');
+    resetAction.setAttribute('role', 'menuitem');
+    resetAction.textContent = 'Reset to Default Code Definition';
+    const actionClick = vi.fn();
+    settings.addEventListener('click', () => document.body.append(resetAction));
+    resetAction.addEventListener('click', actionClick);
+    document.body.append(settings);
+
+    const dispose = waitForEditorAndReset();
+    expect(actionClick).toHaveBeenCalledOnce();
+
+    await vi.advanceTimersByTimeAsync(RESET_CONFIRMATION_TIMEOUT_MS);
+    expect(disconnect).toHaveBeenCalled();
+    dispose();
   });
 
   it('waits for editor UI after SPA navigation and only resets a due decision', async () => {
@@ -95,6 +156,28 @@ describe('due-review editor reset fallback', () => {
 
     await vi.waitFor(() => expect(resetClick).toHaveBeenCalledOnce());
     expect(settingsClick).toHaveBeenCalledOnce();
+    expect(sendMessage).toHaveBeenLastCalledWith({
+      type: 'GET_CLEAR_EDITOR_ON_REVIEW_DECISION',
+      slug: 'second-problem',
+      domain: 'leetcode.com',
+    });
+    dispose();
+  });
+
+  it('uses the path slug rather than a stale Next router slug after navigation', async () => {
+    history.replaceState({}, '', '/problems/first-problem/');
+    Object.defineProperty(window, 'next', {
+      configurable: true,
+      value: { router: { query: { slug: 'first-problem' } } },
+    });
+    vi.mocked(sendMessage).mockResolvedValue({ shouldClear: false });
+
+    const dispose = setupClearEditorOnReview();
+    await vi.waitFor(() => expect(sendMessage).toHaveBeenCalledOnce());
+
+    history.pushState({}, '', '/problems/second-problem/description/');
+    await vi.waitFor(() => expect(sendMessage).toHaveBeenCalledTimes(2));
+
     expect(sendMessage).toHaveBeenLastCalledWith({
       type: 'GET_CLEAR_EDITOR_ON_REVIEW_DECISION',
       slug: 'second-problem',

--- a/utils/content/__tests__/editor-state.test.ts
+++ b/utils/content/__tests__/editor-state.test.ts
@@ -1,0 +1,88 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  clearLeetcodeEditorState,
+  getLeetcodeEditorStateKeys,
+  isLeetcodeEditorStateKey,
+  setupClearEditorOnReview,
+} from '../editor-state';
+import { sendMessage } from '@/shared/messages';
+
+// @vitest-environment happy-dom
+
+vi.mock('@/shared/messages', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/shared/messages')>()),
+  sendMessage: vi.fn(),
+}));
+
+describe('LeetCode editor state keys', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    history.replaceState({}, '', '/');
+  });
+
+  it('should match legacy frontend-id editor keys', () => {
+    expect(isLeetcodeEditorStateKey('1_python3_code', { questionFrontendId: '1' })).toBe(true);
+    expect(isLeetcodeEditorStateKey('11_python3_code', { questionFrontendId: '1' })).toBe(false);
+    expect(isLeetcodeEditorStateKey('1_python3_testcase', { questionFrontendId: '1' })).toBe(false);
+  });
+
+  it('should match ugc editor keys by backend question id', () => {
+    expect(isLeetcodeEditorStateKey('ugc_user-slug_123_python3_code', { questionId: '123' })).toBe(true);
+    expect(isLeetcodeEditorStateKey('ugc_user-slug_123_javascript_code', { questionId: '123' })).toBe(true);
+    expect(isLeetcodeEditorStateKey('ugc_user-slug_123_python3_testcase', { questionId: '123' })).toBe(false);
+    expect(isLeetcodeEditorStateKey('ugc_user-slug_1234_python3_code', { questionId: '123' })).toBe(false);
+  });
+
+  it('should return only matching storage keys', () => {
+    localStorage.setItem('1_python3_code', '"draft"');
+    localStorage.setItem('ugc_user-slug_123_python3_code', '{"code":"draft"}');
+    localStorage.setItem('1_python3_testcase', '[]');
+    localStorage.setItem('2_python3_code', '"other"');
+
+    expect(getLeetcodeEditorStateKeys(localStorage, { questionFrontendId: '1', questionId: '123' }).sort()).toEqual([
+      '1_python3_code',
+      'ugc_user-slug_123_python3_code',
+    ]);
+  });
+
+  it('should clear only editor state for the requested problem', () => {
+    localStorage.setItem('1_python3_code', '"draft"');
+    localStorage.setItem('ugc_user-slug_123_python3_code', '{"code":"draft"}');
+    localStorage.setItem('2_python3_code', '"other"');
+
+    expect(clearLeetcodeEditorState({ questionFrontendId: '1', questionId: '123' }).sort()).toEqual([
+      '1_python3_code',
+      'ugc_user-slug_123_python3_code',
+    ]);
+    expect(localStorage.getItem('1_python3_code')).toBeNull();
+    expect(localStorage.getItem('ugc_user-slug_123_python3_code')).toBeNull();
+    expect(localStorage.getItem('2_python3_code')).toBe('"other"');
+  });
+
+  it('should clear the destination problem during SPA navigation', async () => {
+    vi.useFakeTimers();
+    history.replaceState({}, '', '/problems/first-problem/');
+    vi.mocked(sendMessage)
+      .mockResolvedValueOnce({ shouldClear: false })
+      .mockResolvedValueOnce({ shouldClear: true, questionFrontendId: '2' });
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false } as Response));
+    localStorage.setItem('1_python3_code', 'first draft');
+    localStorage.setItem('2_python3_code', 'second draft');
+
+    const dispose = setupClearEditorOnReview();
+    await vi.advanceTimersByTimeAsync(0);
+
+    history.pushState({}, '', '/problems/second-problem/');
+    await vi.advanceTimersByTimeAsync(250);
+
+    expect(localStorage.getItem('1_python3_code')).toBe('first draft');
+    expect(localStorage.getItem('2_python3_code')).toBeNull();
+    dispose();
+  });
+});

--- a/utils/content/__tests__/editor-state.test.ts
+++ b/utils/content/__tests__/editor-state.test.ts
@@ -1,9 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
-  clearLeetcodeEditorState,
-  getLeetcodeEditorStateKeys,
-  isLeetcodeEditorStateKey,
+  clickResetConfirmation,
+  findEditorSettingsControl,
+  findResetToDefaultCodeDefinition,
   setupClearEditorOnReview,
+  waitForEditorAndReset,
 } from '../editor-state';
 import { sendMessage } from '@/shared/messages';
 
@@ -14,75 +15,107 @@ vi.mock('@/shared/messages', async (importOriginal) => ({
   sendMessage: vi.fn(),
 }));
 
-describe('LeetCode editor state keys', () => {
+describe('due-review editor reset fallback', () => {
   beforeEach(() => {
-    localStorage.clear();
+    document.body.innerHTML = '';
+    history.replaceState({}, '', '/');
   });
 
   afterEach(() => {
-    vi.useRealTimers();
     vi.restoreAllMocks();
     vi.unstubAllGlobals();
     history.replaceState({}, '', '/');
   });
 
-  it('should match legacy frontend-id editor keys', () => {
-    expect(isLeetcodeEditorStateKey('1_python3_code', { questionFrontendId: '1' })).toBe(true);
-    expect(isLeetcodeEditorStateKey('11_python3_code', { questionFrontendId: '1' })).toBe(false);
-    expect(isLeetcodeEditorStateKey('1_python3_testcase', { questionFrontendId: '1' })).toBe(false);
+  it('finds settings controls by accessible semantics and resets through LeetCode UI', async () => {
+    const settings = document.createElement('button');
+    settings.setAttribute('aria-label', 'Editor settings');
+    const action = document.createElement('button');
+    action.setAttribute('role', 'menuitem');
+    action.textContent = 'Reset to Default Code Definition';
+    const confirmationDialog = document.createElement('div');
+    confirmationDialog.setAttribute('role', 'dialog');
+    const confirm = document.createElement('button');
+    confirm.textContent = 'Reset';
+    confirmationDialog.append(confirm);
+
+    const settingsClick = vi.fn(() => document.body.append(action));
+    const actionClick = vi.fn(() => document.body.append(confirmationDialog));
+    const confirmClick = vi.fn();
+    settings.addEventListener('click', settingsClick);
+    action.addEventListener('click', actionClick);
+    confirm.addEventListener('click', confirmClick);
+
+    document.body.append(settings);
+    expect(findEditorSettingsControl(document)).toBe(settings);
+    expect(findResetToDefaultCodeDefinition(document)).toBeNull();
+
+    const dispose = waitForEditorAndReset();
+    await vi.waitFor(() => expect(actionClick).toHaveBeenCalledOnce());
+    await vi.waitFor(() => expect(confirmClick).toHaveBeenCalledOnce());
+
+    expect(settingsClick).toHaveBeenCalledOnce();
+    expect(findResetToDefaultCodeDefinition(document)).toBe(action);
+    dispose();
   });
 
-  it('should match ugc editor keys by backend question id', () => {
-    expect(isLeetcodeEditorStateKey('ugc_user-slug_123_python3_code', { questionId: '123' })).toBe(true);
-    expect(isLeetcodeEditorStateKey('ugc_user-slug_123_javascript_code', { questionId: '123' })).toBe(true);
-    expect(isLeetcodeEditorStateKey('ugc_user-slug_123_python3_testcase', { questionId: '123' })).toBe(false);
-    expect(isLeetcodeEditorStateKey('ugc_user-slug_1234_python3_code', { questionId: '123' })).toBe(false);
+  it('does not click a destructive action outside a confirmation dialog', () => {
+    const pageReset = document.createElement('button');
+    pageReset.textContent = 'Reset';
+    const click = vi.fn();
+    pageReset.addEventListener('click', click);
+    document.body.append(pageReset);
+
+    expect(clickResetConfirmation(document)).toBe(false);
+    expect(click).not.toHaveBeenCalled();
   });
 
-  it('should return only matching storage keys', () => {
-    localStorage.setItem('1_python3_code', '"draft"');
-    localStorage.setItem('ugc_user-slug_123_python3_code', '{"code":"draft"}');
-    localStorage.setItem('1_python3_testcase', '[]');
-    localStorage.setItem('2_python3_code', '"other"');
-
-    expect(getLeetcodeEditorStateKeys(localStorage, { questionFrontendId: '1', questionId: '123' }).sort()).toEqual([
-      '1_python3_code',
-      'ugc_user-slug_123_python3_code',
-    ]);
-  });
-
-  it('should clear only editor state for the requested problem', () => {
-    localStorage.setItem('1_python3_code', '"draft"');
-    localStorage.setItem('ugc_user-slug_123_python3_code', '{"code":"draft"}');
-    localStorage.setItem('2_python3_code', '"other"');
-
-    expect(clearLeetcodeEditorState({ questionFrontendId: '1', questionId: '123' }).sort()).toEqual([
-      '1_python3_code',
-      'ugc_user-slug_123_python3_code',
-    ]);
-    expect(localStorage.getItem('1_python3_code')).toBeNull();
-    expect(localStorage.getItem('ugc_user-slug_123_python3_code')).toBeNull();
-    expect(localStorage.getItem('2_python3_code')).toBe('"other"');
-  });
-
-  it('should clear the destination problem during SPA navigation', async () => {
-    vi.useFakeTimers();
+  it('waits for editor UI after SPA navigation and only resets a due decision', async () => {
     history.replaceState({}, '', '/problems/first-problem/');
     vi.mocked(sendMessage)
       .mockResolvedValueOnce({ shouldClear: false })
       .mockResolvedValueOnce({ shouldClear: true, questionFrontendId: '2' });
-    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false } as Response));
-    localStorage.setItem('1_python3_code', 'first draft');
-    localStorage.setItem('2_python3_code', 'second draft');
 
     const dispose = setupClearEditorOnReview();
-    await vi.advanceTimersByTimeAsync(0);
+    await vi.waitFor(() => expect(sendMessage).toHaveBeenCalledOnce());
 
-    history.pushState({}, '', '/problems/second-problem/');
-    await vi.advanceTimersByTimeAsync(250);
+    history.pushState({}, '', '/problems/second-problem/description/');
+    await vi.waitFor(() => expect(sendMessage).toHaveBeenCalledTimes(2));
 
-    expect(localStorage.getItem('1_python3_code')).toBe('first draft');
-    expect(localStorage.getItem('2_python3_code')).toBeNull();
+    const settings = document.createElement('button');
+    settings.title = 'Code settings';
+    const resetAction = document.createElement('button');
+    resetAction.setAttribute('role', 'menuitem');
+    resetAction.textContent = 'Reset to Default Code Definition';
+    const settingsClick = vi.fn(() => document.body.append(resetAction));
+    const resetClick = vi.fn();
+    settings.addEventListener('click', settingsClick);
+    resetAction.addEventListener('click', resetClick);
+    document.body.append(settings);
+
+    await vi.waitFor(() => expect(resetClick).toHaveBeenCalledOnce());
+    expect(settingsClick).toHaveBeenCalledOnce();
+    expect(sendMessage).toHaveBeenLastCalledWith({
+      type: 'GET_CLEAR_EDITOR_ON_REVIEW_DECISION',
+      slug: 'second-problem',
+      domain: 'leetcode.com',
+    });
+    dispose();
+  });
+
+  it('does not wait for or open the editor when the decision is not due', async () => {
+    history.replaceState({}, '', '/problems/not-due/');
+    vi.mocked(sendMessage).mockResolvedValue({ shouldClear: false });
+    const settings = document.createElement('button');
+    settings.setAttribute('aria-label', 'Editor settings');
+    const settingsClick = vi.fn();
+    settings.addEventListener('click', settingsClick);
+    document.body.append(settings);
+
+    const dispose = setupClearEditorOnReview();
+    await vi.waitFor(() => expect(sendMessage).toHaveBeenCalledOnce());
+
+    expect(settingsClick).not.toHaveBeenCalled();
     dispose();
   });
 });

--- a/utils/content/editor-state.ts
+++ b/utils/content/editor-state.ts
@@ -1,83 +1,70 @@
 import { MessageType, sendMessage } from '@/shared/messages';
-import { getCurrentDomain, getCurrentProblemSlug, getGraphQLUrl } from './domain';
+import { getCurrentDomain, getCurrentProblemSlug } from './domain';
 
-const SLUG_CHECK_INTERVAL_MS = 250;
+const NAVIGATION_EVENT = 'leetsrs:navigation';
+const RESET_ACTION_PATTERN = /^reset\s+to\s+default\s+code\s+definition$/i;
+const SETTINGS_CONTROL_SELECTOR = [
+  '[data-cy*="editor" i][data-cy*="setting" i]',
+  '[data-testid*="editor" i][data-testid*="setting" i]',
+  '[aria-label*="editor settings" i]',
+  '[aria-label*="code settings" i]',
+  '[aria-label*="editor actions" i]',
+  '[data-tooltip*="editor settings" i]',
+  '[title*="editor settings" i]',
+].join(', ');
+const INTERACTIVE_SELECTOR = 'button, [role="button"], [role="menuitem"], [role="menuitemradio"]';
 
-export interface LeetcodeEditorStateIdentifiers {
-  questionFrontendId?: string;
-  questionId?: string;
-}
-
-export function getLeetcodeEditorStateKeys(
-  storageArea: Storage,
-  identifiers: LeetcodeEditorStateIdentifiers
-): string[] {
-  const keys: string[] = [];
-
-  for (let index = 0; index < storageArea.length; index += 1) {
-    const key = storageArea.key(index);
-    if (!key || !isLeetcodeEditorStateKey(key, identifiers)) {
-      continue;
-    }
-    keys.push(key);
-  }
-
-  return keys;
-}
-
-export function isLeetcodeEditorStateKey(key: string, identifiers: LeetcodeEditorStateIdentifiers): boolean {
-  if (identifiers.questionFrontendId && key.startsWith(`${identifiers.questionFrontendId}_`) && key.endsWith('_code')) {
-    return true;
-  }
-
-  if (identifiers.questionId) {
-    const ugcPattern = new RegExp(`^ugc_.+_${escapeRegExp(identifiers.questionId)}_[^_]+_code$`);
-    return ugcPattern.test(key);
-  }
-
-  return false;
-}
-
-export function clearLeetcodeEditorState(identifiers: LeetcodeEditorStateIdentifiers): string[] {
-  const keys = getLeetcodeEditorStateKeys(localStorage, identifiers);
-  for (const key of keys) {
-    localStorage.removeItem(key);
-  }
-  return keys;
-}
-
+/**
+ * Installs a navigation-aware reset flow for due review cards.
+ *
+ * LeetCode owns the editor's saved state, so this deliberately invokes its
+ * reset action rather than guessing at or deleting browser storage entries.
+ */
 export function setupClearEditorOnReview(): () => void {
-  let lastProcessedSlug: string | null = null;
+  let routeKey: string | null = null;
+  let disposePendingReset: (() => void) | undefined;
 
-  const checkCurrentProblem = () => {
+  const processCurrentRoute = () => {
+    const nextRouteKey = `${window.location.pathname}${window.location.search}`;
+    if (nextRouteKey === routeKey) {
+      return;
+    }
+
+    routeKey = nextRouteKey;
+    disposePendingReset?.();
+    disposePendingReset = undefined;
+
     const slug = getCurrentProblemSlug();
     if (!slug) {
-      lastProcessedSlug = null;
       return;
     }
 
-    if (slug === lastProcessedSlug) {
-      return;
-    }
-
-    lastProcessedSlug = slug;
-    void clearEditorIfDueForReview(slug);
+    const requestedRouteKey = nextRouteKey;
+    void requestDueReviewReset(slug, () => currentRouteKey() === requestedRouteKey).then((dispose) => {
+      if (currentRouteKey() === requestedRouteKey) {
+        disposePendingReset = dispose;
+      } else {
+        dispose();
+      }
+    });
   };
 
-  checkCurrentProblem();
-
-  const intervalId = window.setInterval(checkCurrentProblem, SLUG_CHECK_INTERVAL_MS);
-  window.addEventListener('popstate', checkCurrentProblem);
-  window.addEventListener('pageshow', checkCurrentProblem);
+  const restoreHistory = observeHistoryNavigation();
+  window.addEventListener(NAVIGATION_EVENT, processCurrentRoute);
+  window.addEventListener('popstate', processCurrentRoute);
+  window.addEventListener('pageshow', processCurrentRoute);
+  processCurrentRoute();
 
   return () => {
-    window.clearInterval(intervalId);
-    window.removeEventListener('popstate', checkCurrentProblem);
-    window.removeEventListener('pageshow', checkCurrentProblem);
+    disposePendingReset?.();
+    restoreHistory();
+    window.removeEventListener(NAVIGATION_EVENT, processCurrentRoute);
+    window.removeEventListener('popstate', processCurrentRoute);
+    window.removeEventListener('pageshow', processCurrentRoute);
   };
 }
 
-async function clearEditorIfDueForReview(slug: string): Promise<void> {
+async function requestDueReviewReset(slug: string, isCurrentRoute: () => boolean): Promise<() => void> {
   try {
     const decision = await sendMessage({
       type: MessageType.GET_CLEAR_EDITOR_ON_REVIEW_DECISION,
@@ -85,63 +72,153 @@ async function clearEditorIfDueForReview(slug: string): Promise<void> {
       domain: getCurrentDomain(),
     });
 
-    if (!decision.shouldClear) {
+    if (!decision.shouldClear || !isCurrentRoute()) {
+      return () => undefined;
+    }
+
+    return waitForEditorAndReset(isCurrentRoute);
+  } catch (error) {
+    console.error('Failed to reset LeetCode editor for due review:', error);
+    return () => undefined;
+  }
+}
+
+/** Waits for LeetCode's editor controls without polling, then resets once. */
+export function waitForEditorAndReset(isCurrentRoute: () => boolean = () => true): () => void {
+  let complete = false;
+  let observer: MutationObserver | undefined;
+  let settingsOpened = false;
+  let resetRequested = false;
+
+  const stop = () => {
+    complete = true;
+    observer?.disconnect();
+  };
+
+  const tryReset = () => {
+    if (complete || !isCurrentRoute()) {
+      stop();
       return;
     }
 
-    clearLeetcodeEditorState({ questionFrontendId: decision.questionFrontendId });
-
-    const questionId = await fetchQuestionId(slug);
-    if (questionId) {
-      clearLeetcodeEditorState({ questionId });
+    if (resetRequested) {
+      // A confirmation dialog may be rendered by React after the menu action
+      // click. Keep observing mutations so it is confirmed when it appears.
+      if (clickResetConfirmation(document)) {
+        stop();
+      }
+      return;
     }
-  } catch (error) {
-    console.error('Failed to clear LeetCode editor state:', error);
+
+    const settingsControl = findEditorSettingsControl(document);
+    if (!settingsControl) {
+      return;
+    }
+
+    if (!settingsOpened) {
+      settingsControl.click();
+      settingsOpened = true;
+    }
+
+    const resetAction = findResetToDefaultCodeDefinition(document);
+    if (!resetAction) {
+      return;
+    }
+
+    resetRequested = true;
+    resetAction.click();
+    if (clickResetConfirmation(document)) {
+      stop();
+    }
+  };
+
+  tryReset();
+  if (!complete) {
+    observer = new MutationObserver(tryReset);
+    observer.observe(document.documentElement, { childList: true, subtree: true });
   }
+
+  return stop;
 }
 
-async function fetchQuestionId(titleSlug: string): Promise<string | undefined> {
-  try {
-    const csrfToken = document.cookie
-      .split('; ')
-      .find((row) => row.startsWith('csrftoken='))
-      ?.split('=')[1];
-
-    const headers: HeadersInit = {
-      'Content-Type': 'application/json',
-    };
-    if (csrfToken) {
-      headers['X-CSRFToken'] = csrfToken;
-    }
-
-    const response = await fetch(getGraphQLUrl(), {
-      method: 'POST',
-      headers,
-      body: JSON.stringify({
-        operationName: 'questionDetail',
-        query: `
-          query questionDetail($titleSlug: String!) {
-            question(titleSlug: $titleSlug) {
-              questionId
-            }
-          }
-        `,
-        variables: { titleSlug },
-      }),
-    });
-
-    if (!response.ok) {
-      return undefined;
-    }
-
-    const data = await response.json();
-    const questionId = data?.data?.question?.questionId;
-    return typeof questionId === 'string' ? questionId : undefined;
-  } catch {
-    return undefined;
+/** Finds the editor's settings/actions control via stable semantics, not CSS classes. */
+export function findEditorSettingsControl(root: ParentNode): HTMLElement | null {
+  const labelledControl = Array.from(root.querySelectorAll<HTMLElement>(SETTINGS_CONTROL_SELECTOR)).find(isInteractive);
+  if (labelledControl) {
+    return labelledControl;
   }
+
+  return (
+    Array.from(root.querySelectorAll<HTMLElement>(INTERACTIVE_SELECTOR)).find((element) => {
+      const label = accessibleLabel(element);
+      return /\b(settings|actions)\b/i.test(label) && /\b(editor|code)\b/i.test(label);
+    }) ?? null
+  );
 }
 
-function escapeRegExp(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+/** Finds LeetCode's English reset command once the settings menu is open. */
+export function findResetToDefaultCodeDefinition(root: ParentNode): HTMLElement | null {
+  return (
+    Array.from(root.querySelectorAll<HTMLElement>(INTERACTIVE_SELECTOR)).find((element) => {
+      return RESET_ACTION_PATTERN.test(accessibleLabel(element));
+    }) ?? null
+  );
+}
+
+/** Confirms the reset only in a visible dialog, when LeetCode presents one. */
+export function clickResetConfirmation(root: ParentNode): boolean {
+  const dialog = root.querySelector<HTMLElement>('[role="dialog"], [aria-modal="true"]');
+  if (!dialog) {
+    return false;
+  }
+
+  const confirmation = Array.from(dialog.querySelectorAll<HTMLElement>(INTERACTIVE_SELECTOR)).find((element) => {
+    return /^(reset|confirm)$/i.test(accessibleLabel(element));
+  });
+  if (!confirmation) {
+    return false;
+  }
+
+  confirmation.click();
+  return true;
+}
+
+function observeHistoryNavigation(): () => void {
+  const historyWithOriginals = history as History & {
+    pushState: History['pushState'];
+    replaceState: History['replaceState'];
+  };
+  const originalPushState = historyWithOriginals.pushState;
+  const originalReplaceState = historyWithOriginals.replaceState;
+
+  const dispatchNavigation = () => window.dispatchEvent(new Event(NAVIGATION_EVENT));
+  historyWithOriginals.pushState = function (...args) {
+    originalPushState.apply(this, args);
+    dispatchNavigation();
+  };
+  historyWithOriginals.replaceState = function (...args) {
+    originalReplaceState.apply(this, args);
+    dispatchNavigation();
+  };
+
+  return () => {
+    historyWithOriginals.pushState = originalPushState;
+    historyWithOriginals.replaceState = originalReplaceState;
+  };
+}
+
+function accessibleLabel(element: HTMLElement): string {
+  return [element.getAttribute('aria-label'), element.getAttribute('title'), element.textContent]
+    .filter((value): value is string => Boolean(value))
+    .join(' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function isInteractive(element: HTMLElement): boolean {
+  return element.matches(INTERACTIVE_SELECTOR);
+}
+
+function currentRouteKey(): string {
+  return `${window.location.pathname}${window.location.search}`;
 }

--- a/utils/content/editor-state.ts
+++ b/utils/content/editor-state.ts
@@ -1,8 +1,10 @@
 import { MessageType, sendMessage } from '@/shared/messages';
-import { getCurrentDomain, getCurrentProblemSlug } from './domain';
+import { getCurrentDomain } from './domain';
 
 const NAVIGATION_EVENT = 'leetsrs:navigation';
 const RESET_ACTION_PATTERN = /^reset\s+to\s+default\s+code\s+definition$/i;
+const RESET_CONFIRMATION_PATTERN = /\breset\b|\bdefault code\b/i;
+export const RESET_CONFIRMATION_TIMEOUT_MS = 1_000;
 const SETTINGS_CONTROL_SELECTOR = [
   '[data-cy*="editor" i][data-cy*="setting" i]',
   '[data-testid*="editor" i][data-testid*="setting" i]',
@@ -34,13 +36,13 @@ export function setupClearEditorOnReview(): () => void {
     disposePendingReset?.();
     disposePendingReset = undefined;
 
-    const slug = getCurrentProblemSlug();
+    const slug = getProblemSlugFromRouteKey(nextRouteKey);
     if (!slug) {
       return;
     }
 
     const requestedRouteKey = nextRouteKey;
-    void requestDueReviewReset(slug, () => currentRouteKey() === requestedRouteKey).then((dispose) => {
+    void requestDueReviewReset(slug, () => isCurrentProblemRoute(requestedRouteKey, slug)).then((dispose) => {
       if (currentRouteKey() === requestedRouteKey) {
         disposePendingReset = dispose;
       } else {
@@ -87,12 +89,17 @@ async function requestDueReviewReset(slug: string, isCurrentRoute: () => boolean
 export function waitForEditorAndReset(isCurrentRoute: () => boolean = () => true): () => void {
   let complete = false;
   let observer: MutationObserver | undefined;
+  let confirmationTimeout: ReturnType<typeof setTimeout> | undefined;
   let settingsOpened = false;
   let resetRequested = false;
+  let dialogsBeforeReset = new Set<HTMLElement>();
 
   const stop = () => {
     complete = true;
     observer?.disconnect();
+    if (confirmationTimeout !== undefined) {
+      clearTimeout(confirmationTimeout);
+    }
   };
 
   const tryReset = () => {
@@ -104,7 +111,7 @@ export function waitForEditorAndReset(isCurrentRoute: () => boolean = () => true
     if (resetRequested) {
       // A confirmation dialog may be rendered by React after the menu action
       // click. Keep observing mutations so it is confirmed when it appears.
-      if (clickResetConfirmation(document)) {
+      if (clickResetConfirmation(document, dialogsBeforeReset)) {
         stop();
       }
       return;
@@ -126,8 +133,10 @@ export function waitForEditorAndReset(isCurrentRoute: () => boolean = () => true
     }
 
     resetRequested = true;
+    dialogsBeforeReset = new Set(findDialogs(document));
+    confirmationTimeout = setTimeout(stop, RESET_CONFIRMATION_TIMEOUT_MS);
     resetAction.click();
-    if (clickResetConfirmation(document)) {
+    if (clickResetConfirmation(document, dialogsBeforeReset)) {
       stop();
     }
   };
@@ -165,16 +174,25 @@ export function findResetToDefaultCodeDefinition(root: ParentNode): HTMLElement 
   );
 }
 
-/** Confirms the reset only in a visible dialog, when LeetCode presents one. */
-export function clickResetConfirmation(root: ParentNode): boolean {
-  const dialog = root.querySelector<HTMLElement>('[role="dialog"], [aria-modal="true"]');
+/**
+ * Confirms only a visible reset dialog created after this reset action began.
+ * Existing dialogs are deliberately excluded so an unrelated destructive UI
+ * cannot be acknowledged by the extension.
+ */
+export function clickResetConfirmation(root: ParentNode, dialogsBeforeReset: ReadonlySet<HTMLElement>): boolean {
+  const dialog = findDialogs(root).find(
+    (candidate) =>
+      !dialogsBeforeReset.has(candidate) &&
+      isVisible(candidate) &&
+      RESET_CONFIRMATION_PATTERN.test(accessibleLabel(candidate))
+  );
   if (!dialog) {
     return false;
   }
 
-  const confirmation = Array.from(dialog.querySelectorAll<HTMLElement>(INTERACTIVE_SELECTOR)).find((element) => {
-    return /^(reset|confirm)$/i.test(accessibleLabel(element));
-  });
+  const confirmation = Array.from(dialog.querySelectorAll<HTMLElement>(INTERACTIVE_SELECTOR)).find(
+    (element) => isVisible(element) && /^(reset|confirm)$/i.test(accessibleLabel(element))
+  );
   if (!confirmation) {
     return false;
   }
@@ -221,4 +239,27 @@ function isInteractive(element: HTMLElement): boolean {
 
 function currentRouteKey(): string {
   return `${window.location.pathname}${window.location.search}`;
+}
+
+function getProblemSlugFromRouteKey(routeKey: string): string | null {
+  const pathname = routeKey.split('?')[0];
+  const pathMatch = pathname.match(/\/problems\/([^/]+)/);
+  return pathMatch ? pathMatch[1] : null;
+}
+
+function isCurrentProblemRoute(routeKey: string, slug: string): boolean {
+  return currentRouteKey() === routeKey && getProblemSlugFromRouteKey(currentRouteKey()) === slug;
+}
+
+function findDialogs(root: ParentNode): HTMLElement[] {
+  return Array.from(root.querySelectorAll<HTMLElement>('[role="dialog"], [aria-modal="true"]'));
+}
+
+function isVisible(element: HTMLElement): boolean {
+  if (!element.isConnected || element.hidden || element.getAttribute('aria-hidden') === 'true') {
+    return false;
+  }
+
+  const style = window.getComputedStyle(element);
+  return style.display !== 'none' && style.visibility !== 'hidden';
 }

--- a/utils/content/editor-state.ts
+++ b/utils/content/editor-state.ts
@@ -1,0 +1,147 @@
+import { MessageType, sendMessage } from '@/shared/messages';
+import { getCurrentDomain, getCurrentProblemSlug, getGraphQLUrl } from './domain';
+
+const SLUG_CHECK_INTERVAL_MS = 250;
+
+export interface LeetcodeEditorStateIdentifiers {
+  questionFrontendId?: string;
+  questionId?: string;
+}
+
+export function getLeetcodeEditorStateKeys(
+  storageArea: Storage,
+  identifiers: LeetcodeEditorStateIdentifiers
+): string[] {
+  const keys: string[] = [];
+
+  for (let index = 0; index < storageArea.length; index += 1) {
+    const key = storageArea.key(index);
+    if (!key || !isLeetcodeEditorStateKey(key, identifiers)) {
+      continue;
+    }
+    keys.push(key);
+  }
+
+  return keys;
+}
+
+export function isLeetcodeEditorStateKey(key: string, identifiers: LeetcodeEditorStateIdentifiers): boolean {
+  if (identifiers.questionFrontendId && key.startsWith(`${identifiers.questionFrontendId}_`) && key.endsWith('_code')) {
+    return true;
+  }
+
+  if (identifiers.questionId) {
+    const ugcPattern = new RegExp(`^ugc_.+_${escapeRegExp(identifiers.questionId)}_[^_]+_code$`);
+    return ugcPattern.test(key);
+  }
+
+  return false;
+}
+
+export function clearLeetcodeEditorState(identifiers: LeetcodeEditorStateIdentifiers): string[] {
+  const keys = getLeetcodeEditorStateKeys(localStorage, identifiers);
+  for (const key of keys) {
+    localStorage.removeItem(key);
+  }
+  return keys;
+}
+
+export function setupClearEditorOnReview(): () => void {
+  let lastProcessedSlug: string | null = null;
+
+  const checkCurrentProblem = () => {
+    const slug = getCurrentProblemSlug();
+    if (!slug) {
+      lastProcessedSlug = null;
+      return;
+    }
+
+    if (slug === lastProcessedSlug) {
+      return;
+    }
+
+    lastProcessedSlug = slug;
+    void clearEditorIfDueForReview(slug);
+  };
+
+  checkCurrentProblem();
+
+  const intervalId = window.setInterval(checkCurrentProblem, SLUG_CHECK_INTERVAL_MS);
+  window.addEventListener('popstate', checkCurrentProblem);
+  window.addEventListener('pageshow', checkCurrentProblem);
+
+  return () => {
+    window.clearInterval(intervalId);
+    window.removeEventListener('popstate', checkCurrentProblem);
+    window.removeEventListener('pageshow', checkCurrentProblem);
+  };
+}
+
+async function clearEditorIfDueForReview(slug: string): Promise<void> {
+  try {
+    const decision = await sendMessage({
+      type: MessageType.GET_CLEAR_EDITOR_ON_REVIEW_DECISION,
+      slug,
+      domain: getCurrentDomain(),
+    });
+
+    if (!decision.shouldClear) {
+      return;
+    }
+
+    clearLeetcodeEditorState({ questionFrontendId: decision.questionFrontendId });
+
+    const questionId = await fetchQuestionId(slug);
+    if (questionId) {
+      clearLeetcodeEditorState({ questionId });
+    }
+  } catch (error) {
+    console.error('Failed to clear LeetCode editor state:', error);
+  }
+}
+
+async function fetchQuestionId(titleSlug: string): Promise<string | undefined> {
+  try {
+    const csrfToken = document.cookie
+      .split('; ')
+      .find((row) => row.startsWith('csrftoken='))
+      ?.split('=')[1];
+
+    const headers: HeadersInit = {
+      'Content-Type': 'application/json',
+    };
+    if (csrfToken) {
+      headers['X-CSRFToken'] = csrfToken;
+    }
+
+    const response = await fetch(getGraphQLUrl(), {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({
+        operationName: 'questionDetail',
+        query: `
+          query questionDetail($titleSlug: String!) {
+            question(titleSlug: $titleSlug) {
+              questionId
+            }
+          }
+        `,
+        variables: { titleSlug },
+      }),
+    });
+
+    if (!response.ok) {
+      return undefined;
+    }
+
+    const data = await response.json();
+    const questionId = data?.data?.question?.questionId;
+    return typeof questionId === 'string' ? questionId : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}

--- a/utils/content/index.ts
+++ b/utils/content/index.ts
@@ -1,4 +1,5 @@
 export * from './auto-reset';
+export * from './editor-state';
 export * from './button';
 export * from './constants';
 export * from './domain';


### PR DESCRIPTION
Closes #117

## Summary
- add an opt-in **Clear editor on review** setting (default off)
- reset LeetCode's editor only for unpaused Review cards that are currently due
- use LeetCode's own **Reset to Default Code Definition** UI action after the editor loads
- handle SPA navigation and keep drafts intact for cards that are not due, paused, new, learning, relearning, or absent
- include setting migration, import/export support, translations, and focused tests

## Testing
- `npx --yes --package=node@24 -- npx vitest run utils/content/__tests__/editor-state.test.ts services/__tests__/clear-editor-on-review.test.ts`
- `npx --yes --package=node@24 -- npx tsc --noEmit`
- `npx --yes --package=node@24 -- npx eslint . --ext .ts,.tsx,.js,.jsx`
- `npx --yes --package=node@24 -- npx wxt build`

The full test suite has one existing time-sensitive failure in `services/__tests__/cards.test.ts` (`getReviewQueue > should include cards due today regardless of time`); it is unrelated to these changes.

## Caveat
The fallback deliberately depends on LeetCode's English reset action and confirmation semantics, so a LeetCode UI/localization change may require an update.