### PR TITLE
refactor: rename editor reset setting

### DIFF
--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -18,8 +18,8 @@ import {
   setAnimationsEnabled,
   getTheme,
   setTheme,
-  getAutoClearLeetcode,
-  setAutoClearLeetcode,
+  getResetEditorOnEveryProblem,
+  setResetEditorOnEveryProblem,
   getBadgeEnabled,
   setBadgeEnabled,
   getLanguage,
@@ -175,11 +175,11 @@ export default defineBackground(() => {
         return handleDataUpdate(() => setTheme(request.value));
       }
 
-      case MessageType.GET_AUTO_CLEAR_LEETCODE:
-        return await getAutoClearLeetcode();
+      case MessageType.GET_RESET_EDITOR_ON_EVERY_PROBLEM:
+        return await getResetEditorOnEveryProblem();
 
-      case MessageType.SET_AUTO_CLEAR_LEETCODE: {
-        return handleDataUpdate(() => setAutoClearLeetcode(request.value));
+      case MessageType.SET_RESET_EDITOR_ON_EVERY_PROBLEM: {
+        return handleDataUpdate(() => setResetEditorOnEveryProblem(request.value));
       }
 
       case MessageType.GET_BADGE_ENABLED:

--- a/entrypoints/popup/views/settings/ProblemAutoClearSection.tsx
+++ b/entrypoints/popup/views/settings/ProblemAutoClearSection.tsx
@@ -1,15 +1,19 @@
-import { useAutoClearLeetcodeQuery, useSetAutoClearLeetcodeMutation } from '@/hooks/useBackgroundQueries';
-import { DEFAULT_AUTO_CLEAR_LEETCODE } from '@/shared/settings';
+import {
+  useResetEditorOnEveryProblemQuery,
+  useSetResetEditorOnEveryProblemMutation,
+} from '@/hooks/useBackgroundQueries';
+import { DEFAULT_RESET_EDITOR_ON_EVERY_PROBLEM } from '@/shared/settings';
 import { useI18n } from '../../contexts/I18nContext';
 import { SettingsSwitch } from './SettingsSwitch';
 
 export function ProblemAutoClearSection() {
   const t = useI18n();
-  const { data: autoClearLeetcode = DEFAULT_AUTO_CLEAR_LEETCODE } = useAutoClearLeetcodeQuery();
-  const setAutoClearLeetcodeMutation = useSetAutoClearLeetcodeMutation();
+  const { data: resetEditorOnEveryProblem = DEFAULT_RESET_EDITOR_ON_EVERY_PROBLEM } =
+    useResetEditorOnEveryProblemQuery();
+  const setResetEditorOnEveryProblemMutation = useSetResetEditorOnEveryProblemMutation();
 
-  const setAutoClearLeetcode = (isSelected: boolean) => {
-    setAutoClearLeetcodeMutation.mutate(isSelected);
+  const setResetEditorOnEveryProblem = (isSelected: boolean) => {
+    setResetEditorOnEveryProblemMutation.mutate(isSelected);
   };
 
   return (
@@ -18,9 +22,9 @@ export function ProblemAutoClearSection() {
       <p className="text-sm text-tertiary mb-4">{t.settings.problemAutoClear.description}</p>
       <div className="space-y-3">
         <SettingsSwitch
-          label={t.settings.problemAutoClear.enableAutoReset}
-          isSelected={autoClearLeetcode}
-          onChange={setAutoClearLeetcode}
+          label={t.settings.problemAutoClear.resetEditorOnEveryProblem}
+          isSelected={resetEditorOnEveryProblem}
+          onChange={setResetEditorOnEveryProblem}
         />
       </div>
     </div>

--- a/hooks/useBackgroundQueries.ts
+++ b/hooks/useBackgroundQueries.ts
@@ -31,7 +31,7 @@ export const queryKeys = {
     dayStartHour: ['settings', 'dayStartHour'] as const,
     animationsEnabled: ['settings', 'animationsEnabled'] as const,
     theme: ['settings', 'theme'] as const,
-    autoClearLeetcode: ['settings', 'autoClearLeetcode'] as const,
+    resetEditorOnEveryProblem: ['settings', 'resetEditorOnEveryProblem'] as const,
     badgeEnabled: ['settings', 'badgeEnabled'] as const,
     language: ['settings', 'language'] as const,
   },
@@ -269,20 +269,20 @@ export function useSetThemeMutation() {
   });
 }
 
-export function useAutoClearLeetcodeQuery() {
+export function useResetEditorOnEveryProblemQuery() {
   return useQuery({
-    queryKey: queryKeys.settings.autoClearLeetcode,
-    queryFn: () => sendMessage({ type: MessageType.GET_AUTO_CLEAR_LEETCODE }),
+    queryKey: queryKeys.settings.resetEditorOnEveryProblem,
+    queryFn: () => sendMessage({ type: MessageType.GET_RESET_EDITOR_ON_EVERY_PROBLEM }),
   });
 }
 
-export function useSetAutoClearLeetcodeMutation() {
+export function useSetResetEditorOnEveryProblemMutation() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: (value: boolean) => sendMessage({ type: MessageType.SET_AUTO_CLEAR_LEETCODE, value }),
+    mutationFn: (value: boolean) => sendMessage({ type: MessageType.SET_RESET_EDITOR_ON_EVERY_PROBLEM, value }),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: queryKeys.settings.autoClearLeetcode });
+      queryClient.invalidateQueries({ queryKey: queryKeys.settings.resetEditorOnEveryProblem });
     },
   });
 }

--- a/services/__tests__/import-export.test.ts
+++ b/services/__tests__/import-export.test.ts
@@ -76,7 +76,7 @@ describe('import-export', () => {
       await storage.setItem(STORAGE_KEYS.dayStartHour, mockSettings.dayStartHour);
       await storage.setItem(STORAGE_KEYS.animationsEnabled, mockSettings.animationsEnabled);
       await storage.setItem(STORAGE_KEYS.theme, mockSettings.theme);
-      await storage.setItem(STORAGE_KEYS.autoClearLeetcode, mockSettings.autoClearLeetcode);
+      await storage.setItem(STORAGE_KEYS.resetEditorOnEveryProblem, mockSettings.autoClearLeetcode);
       await storage.setItem(STORAGE_KEYS.badgeEnabled, mockSettings.badgeEnabled);
       await storage.setItem(STORAGE_KEYS.language, mockSettings.language);
 
@@ -207,7 +207,7 @@ describe('import-export', () => {
       expect(await storage.getItem(STORAGE_KEYS.dayStartHour)).toEqual(2);
       expect(await storage.getItem(STORAGE_KEYS.animationsEnabled)).toEqual(false);
       expect(await storage.getItem(STORAGE_KEYS.theme)).toEqual('light');
-      expect(await storage.getItem(STORAGE_KEYS.autoClearLeetcode)).toEqual(true);
+      expect(await storage.getItem(STORAGE_KEYS.resetEditorOnEveryProblem)).toEqual(true);
       expect(await storage.getItem(STORAGE_KEYS.badgeEnabled)).toEqual(false);
       expect(await storage.getItem(STORAGE_KEYS.language)).toEqual('en');
     });
@@ -335,7 +335,7 @@ describe('import-export', () => {
       await storage.setItem(STORAGE_KEYS.dayStartHour, 3);
       await storage.setItem(STORAGE_KEYS.animationsEnabled, true);
       await storage.setItem(STORAGE_KEYS.theme, 'dark');
-      await storage.setItem(STORAGE_KEYS.autoClearLeetcode, true);
+      await storage.setItem(STORAGE_KEYS.resetEditorOnEveryProblem, true);
       await storage.setItem(STORAGE_KEYS.badgeEnabled, true);
       await storage.setItem(STORAGE_KEYS.language, 'en');
       await storage.setItem(`${STORAGE_KEYS.notes}:${uuid1}` as const, { text: 'note 1' });
@@ -351,7 +351,7 @@ describe('import-export', () => {
       expect(await storage.getItem(STORAGE_KEYS.dayStartHour)).toBeNull();
       expect(await storage.getItem(STORAGE_KEYS.animationsEnabled)).toBeNull();
       expect(await storage.getItem(STORAGE_KEYS.theme)).toBeNull();
-      expect(await storage.getItem(STORAGE_KEYS.autoClearLeetcode)).toBeNull();
+      expect(await storage.getItem(STORAGE_KEYS.resetEditorOnEveryProblem)).toBeNull();
       expect(await storage.getItem(STORAGE_KEYS.badgeEnabled)).toBeNull();
       expect(await storage.getItem(STORAGE_KEYS.language)).toBeNull();
       expect(await storage.getItem(`${STORAGE_KEYS.notes}:${uuid1}` as const)).toBeNull();

--- a/services/__tests__/settings.test.ts
+++ b/services/__tests__/settings.test.ts
@@ -8,8 +8,8 @@ import {
   setAnimationsEnabled,
   getTheme,
   setTheme,
-  getAutoClearLeetcode,
-  setAutoClearLeetcode,
+  getResetEditorOnEveryProblem,
+  setResetEditorOnEveryProblem,
   getLanguage,
 } from '../settings';
 import { STORAGE_KEYS } from '../storage-keys';
@@ -18,7 +18,7 @@ import {
   MIN_NEW_CARDS_PER_DAY,
   MAX_NEW_CARDS_PER_DAY,
   DEFAULT_THEME,
-  DEFAULT_AUTO_CLEAR_LEETCODE,
+  DEFAULT_RESET_EDITOR_ON_EVERY_PROBLEM,
 } from '@/shared/settings';
 
 describe('Settings Service', () => {
@@ -234,14 +234,14 @@ describe('Settings Service', () => {
     });
   });
 
-  describe('auto clear settings', () => {
+  describe('editor reset settings', () => {
     it('should return default values when not set', async () => {
-      expect(await getAutoClearLeetcode()).toBe(DEFAULT_AUTO_CLEAR_LEETCODE);
+      expect(await getResetEditorOnEveryProblem()).toBe(DEFAULT_RESET_EDITOR_ON_EVERY_PROBLEM);
     });
 
-    it('should store and retrieve LeetCode auto clear', async () => {
-      await setAutoClearLeetcode(true);
-      expect(await getAutoClearLeetcode()).toBe(true);
+    it('should store and retrieve reset editor on every problem', async () => {
+      await setResetEditorOnEveryProblem(true);
+      expect(await getResetEditorOnEveryProblem()).toBe(true);
     });
   });
 

--- a/services/import-export.ts
+++ b/services/import-export.ts
@@ -52,7 +52,7 @@ export async function exportData(): Promise<string> {
   const dayStartHour = await storage.getItem<number>(STORAGE_KEYS.dayStartHour);
   const animationsEnabled = await storage.getItem<boolean>(STORAGE_KEYS.animationsEnabled);
   const theme = await storage.getItem<Theme>(STORAGE_KEYS.theme);
-  const autoClearLeetcode = await storage.getItem<boolean>(STORAGE_KEYS.autoClearLeetcode);
+  const resetEditorOnEveryProblem = await storage.getItem<boolean>(STORAGE_KEYS.resetEditorOnEveryProblem);
   const badgeEnabled = await storage.getItem<boolean>(STORAGE_KEYS.badgeEnabled);
   const language = await storage.getItem<Language>(STORAGE_KEYS.language);
 
@@ -79,7 +79,7 @@ export async function exportData(): Promise<string> {
         ...(dayStartHour != null && { dayStartHour }),
         ...(animationsEnabled != null && { animationsEnabled }),
         ...(theme != null && { theme }),
-        ...(autoClearLeetcode != null && { autoClearLeetcode }),
+        ...(resetEditorOnEveryProblem != null && { autoClearLeetcode: resetEditorOnEveryProblem }),
         ...(badgeEnabled != null && { badgeEnabled }),
         ...(language != null && { language }),
       },
@@ -171,7 +171,7 @@ export async function importData(jsonData: string): Promise<void> {
       await storage.setItem(STORAGE_KEYS.theme, data.data.settings.theme);
     }
     if (data.data.settings.autoClearLeetcode != null) {
-      await storage.setItem(STORAGE_KEYS.autoClearLeetcode, data.data.settings.autoClearLeetcode);
+      await storage.setItem(STORAGE_KEYS.resetEditorOnEveryProblem, data.data.settings.autoClearLeetcode);
     }
     if (data.data.settings.badgeEnabled != null) {
       await storage.setItem(STORAGE_KEYS.badgeEnabled, data.data.settings.badgeEnabled);
@@ -207,7 +207,7 @@ export async function resetAllData(): Promise<void> {
   await storage.removeItem(STORAGE_KEYS.dayStartHour);
   await storage.removeItem(STORAGE_KEYS.animationsEnabled);
   await storage.removeItem(STORAGE_KEYS.theme);
-  await storage.removeItem(STORAGE_KEYS.autoClearLeetcode);
+  await storage.removeItem(STORAGE_KEYS.resetEditorOnEveryProblem);
   await storage.removeItem(STORAGE_KEYS.badgeEnabled);
   await storage.removeItem(STORAGE_KEYS.language);
 

--- a/services/settings.ts
+++ b/services/settings.ts
@@ -10,7 +10,7 @@ import {
   MAX_DAY_START_HOUR,
   type Theme,
   DEFAULT_THEME,
-  DEFAULT_AUTO_CLEAR_LEETCODE,
+  DEFAULT_RESET_EDITOR_ON_EVERY_PROBLEM,
   DEFAULT_BADGE_ENABLED,
   type Language,
 } from '@/shared/settings';
@@ -66,13 +66,13 @@ export async function setTheme(value: Theme): Promise<void> {
   await storage.setItem(STORAGE_KEYS.theme, value);
 }
 
-export async function getAutoClearLeetcode(): Promise<boolean> {
-  const value = await storage.getItem<boolean>(STORAGE_KEYS.autoClearLeetcode);
-  return value ?? DEFAULT_AUTO_CLEAR_LEETCODE;
+export async function getResetEditorOnEveryProblem(): Promise<boolean> {
+  const value = await storage.getItem<boolean>(STORAGE_KEYS.resetEditorOnEveryProblem);
+  return value ?? DEFAULT_RESET_EDITOR_ON_EVERY_PROBLEM;
 }
 
-export async function setAutoClearLeetcode(value: boolean): Promise<void> {
-  await storage.setItem(STORAGE_KEYS.autoClearLeetcode, value);
+export async function setResetEditorOnEveryProblem(value: boolean): Promise<void> {
+  await storage.setItem(STORAGE_KEYS.resetEditorOnEveryProblem, value);
 }
 
 export async function getBadgeEnabled(): Promise<boolean> {

--- a/services/storage-keys.ts
+++ b/services/storage-keys.ts
@@ -7,7 +7,7 @@ export const STORAGE_KEYS = {
   dayStartHour: 'sync:leetsrs:dayStartHour',
   animationsEnabled: 'sync:leetsrs:animationsEnabled',
   theme: 'sync:leetsrs:theme',
-  autoClearLeetcode: 'sync:leetsrs:autoClearLeetcode',
+  resetEditorOnEveryProblem: 'sync:leetsrs:autoClearLeetcode',
   badgeEnabled: 'sync:leetsrs:badgeEnabled',
   language: 'sync:leetsrs:language',
   schemaVersion: 'local:leetsrs:schemaVersion',

--- a/shared/i18n/en.ts
+++ b/shared/i18n/en.ts
@@ -165,7 +165,7 @@ const en = {
     problemAutoClear: {
       title: 'Problem Auto Reset',
       description: 'Automatically reset code when opening a LeetCode problem.',
-      enableAutoReset: 'Enable auto reset',
+      resetEditorOnEveryProblem: 'Reset editor on every problem',
     },
 
     leetcodeCn: {

--- a/shared/i18n/hi.ts
+++ b/shared/i18n/hi.ts
@@ -147,7 +147,7 @@ const hi: Translations = {
     problemAutoClear: {
       title: 'प्रॉब्लम ऑटो रीसेट',
       description: 'LeetCode प्रॉब्लम खोलने पर कोड ऑटोमैटिकली रीसेट करें।',
-      enableAutoReset: 'ऑटो रीसेट ऑन करें',
+      resetEditorOnEveryProblem: 'हर प्रश्न पर संपादक रीसेट करें',
     },
 
     leetcodeCn: {

--- a/shared/i18n/pl.ts
+++ b/shared/i18n/pl.ts
@@ -167,7 +167,7 @@ const pl: Translations = {
     problemAutoClear: {
       title: 'Automatyczny reset zadania',
       description: 'Automatycznie resetuj kod przy otwieraniu zadania na LeetCode.',
-      enableAutoReset: 'Włącz automatyczny reset',
+      resetEditorOnEveryProblem: 'Resetuj edytor dla każdego zadania',
     },
 
     leetcodeCn: {

--- a/shared/i18n/zh-CN.ts
+++ b/shared/i18n/zh-CN.ts
@@ -148,7 +148,7 @@ const zhCN: Translations = {
     problemAutoClear: {
       title: '题目自动重置',
       description: '打开 LeetCode 题目时自动重置代码。',
-      enableAutoReset: '启用自动重置',
+      resetEditorOnEveryProblem: '每道题都重置编辑器',
     },
 
     leetcodeCn: {

--- a/shared/messages.ts
+++ b/shared/messages.ts
@@ -34,8 +34,8 @@ export const MessageType = {
   SET_ANIMATIONS_ENABLED: 'SET_ANIMATIONS_ENABLED',
   GET_THEME: 'GET_THEME',
   SET_THEME: 'SET_THEME',
-  GET_AUTO_CLEAR_LEETCODE: 'GET_AUTO_CLEAR_LEETCODE',
-  SET_AUTO_CLEAR_LEETCODE: 'SET_AUTO_CLEAR_LEETCODE',
+  GET_RESET_EDITOR_ON_EVERY_PROBLEM: 'GET_RESET_EDITOR_ON_EVERY_PROBLEM',
+  SET_RESET_EDITOR_ON_EVERY_PROBLEM: 'SET_RESET_EDITOR_ON_EVERY_PROBLEM',
   GET_BADGE_ENABLED: 'GET_BADGE_ENABLED',
   SET_BADGE_ENABLED: 'SET_BADGE_ENABLED',
   GET_LANGUAGE: 'GET_LANGUAGE',
@@ -78,8 +78,8 @@ export type MessageRequest =
   | { type: typeof MessageType.SET_ANIMATIONS_ENABLED; value: boolean }
   | { type: typeof MessageType.GET_THEME }
   | { type: typeof MessageType.SET_THEME; value: Theme }
-  | { type: typeof MessageType.GET_AUTO_CLEAR_LEETCODE }
-  | { type: typeof MessageType.SET_AUTO_CLEAR_LEETCODE; value: boolean }
+  | { type: typeof MessageType.GET_RESET_EDITOR_ON_EVERY_PROBLEM }
+  | { type: typeof MessageType.SET_RESET_EDITOR_ON_EVERY_PROBLEM; value: boolean }
   | { type: typeof MessageType.GET_BADGE_ENABLED }
   | { type: typeof MessageType.SET_BADGE_ENABLED; value: boolean }
   | { type: typeof MessageType.GET_LANGUAGE }
@@ -121,8 +121,8 @@ export type MessageResponseMap = {
   [MessageType.SET_ANIMATIONS_ENABLED]: void;
   [MessageType.GET_THEME]: Theme;
   [MessageType.SET_THEME]: void;
-  [MessageType.GET_AUTO_CLEAR_LEETCODE]: boolean;
-  [MessageType.SET_AUTO_CLEAR_LEETCODE]: void;
+  [MessageType.GET_RESET_EDITOR_ON_EVERY_PROBLEM]: boolean;
+  [MessageType.SET_RESET_EDITOR_ON_EVERY_PROBLEM]: void;
   [MessageType.GET_BADGE_ENABLED]: boolean;
   [MessageType.SET_BADGE_ENABLED]: void;
   [MessageType.GET_LANGUAGE]: Language;

--- a/shared/settings.ts
+++ b/shared/settings.ts
@@ -6,7 +6,7 @@ export const DEFAULT_DAY_START_HOUR = 0;
 export const MIN_DAY_START_HOUR = 0;
 export const MAX_DAY_START_HOUR = 23;
 
-export const DEFAULT_AUTO_CLEAR_LEETCODE = false;
+export const DEFAULT_RESET_EDITOR_ON_EVERY_PROBLEM = false;
 export const DEFAULT_BADGE_ENABLED = true;
 export type Theme = 'light' | 'dark';
 export const DEFAULT_THEME: Theme = 'dark';

--- a/utils/content/__tests__/auto-reset.test.ts
+++ b/utils/content/__tests__/auto-reset.test.ts
@@ -136,7 +136,7 @@ describe('setupLeetcodeAutoReset', () => {
     expect(confirmClick).toHaveBeenCalledTimes(1);
   });
 
-  it('should do nothing when auto clear is disabled', async () => {
+  it('should do nothing when reset on every problem is disabled', async () => {
     vi.mocked(sendMessage).mockResolvedValue(false);
     const resetButton = renderResetButton('class');
     const resetClick = vi.spyOn(resetButton, 'click');

--- a/utils/content/auto-reset.ts
+++ b/utils/content/auto-reset.ts
@@ -57,8 +57,8 @@ export function setupLeetcodeAutoReset(): () => void {
 
     isResetting = true;
     try {
-      const autoClearEnabled = await sendMessage({ type: MessageType.GET_AUTO_CLEAR_LEETCODE });
-      if (!autoClearEnabled) {
+      const resetEveryProblem = await sendMessage({ type: MessageType.GET_RESET_EDITOR_ON_EVERY_PROBLEM });
+      if (!resetEveryProblem) {
         return;
       }
 


### PR DESCRIPTION
Stack 1/3.

Renames the existing reset setting without changing storage or export formats.

Tests: npm test, npm run compile

BEGIN_COMMIT_OVERRIDE
refactor: rename editor reset setting
END_COMMIT_OVERRIDE