### PR TITLE
refactor: rename editor reset export key

### DIFF
--- a/services/__tests__/import-export.test.ts
+++ b/services/__tests__/import-export.test.ts
@@ -63,7 +63,7 @@ describe('import-export', () => {
         dayStartHour: 4,
         animationsEnabled: true,
         theme: 'dark' as const,
-        autoClearLeetcode: true,
+        resetEditorOnEveryProblem: true,
         badgeEnabled: true,
         language: 'en' as const,
       };
@@ -76,7 +76,7 @@ describe('import-export', () => {
       await storage.setItem(STORAGE_KEYS.dayStartHour, mockSettings.dayStartHour);
       await storage.setItem(STORAGE_KEYS.animationsEnabled, mockSettings.animationsEnabled);
       await storage.setItem(STORAGE_KEYS.theme, mockSettings.theme);
-      await storage.setItem(STORAGE_KEYS.resetEditorOnEveryProblem, mockSettings.autoClearLeetcode);
+      await storage.setItem(STORAGE_KEYS.resetEditorOnEveryProblem, mockSettings.resetEditorOnEveryProblem);
       await storage.setItem(STORAGE_KEYS.badgeEnabled, mockSettings.badgeEnabled);
       await storage.setItem(STORAGE_KEYS.language, mockSettings.language);
 
@@ -186,7 +186,7 @@ describe('import-export', () => {
           dayStartHour: 2,
           animationsEnabled: false,
           theme: 'light' as const,
-          autoClearLeetcode: true,
+          resetEditorOnEveryProblem: true,
           badgeEnabled: false,
           language: 'en' as const,
         },
@@ -210,6 +210,21 @@ describe('import-export', () => {
       expect(await storage.getItem(STORAGE_KEYS.resetEditorOnEveryProblem)).toEqual(true);
       expect(await storage.getItem(STORAGE_KEYS.badgeEnabled)).toEqual(false);
       expect(await storage.getItem(STORAGE_KEYS.language)).toEqual('en');
+    });
+
+    it('should import the legacy autoClearLeetcode setting', async () => {
+      const { resetEditorOnEveryProblem: _, ...legacySettings } = validExportData.data.settings;
+      const legacyData = {
+        ...validExportData,
+        data: {
+          ...validExportData.data,
+          settings: { ...legacySettings, autoClearLeetcode: true },
+        },
+      };
+
+      await importData(JSON.stringify(legacyData));
+
+      expect(await storage.getItem(STORAGE_KEYS.resetEditorOnEveryProblem)).toBe(true);
     });
 
     it('should clear existing data before importing', async () => {

--- a/services/import-export.ts
+++ b/services/import-export.ts
@@ -20,7 +20,7 @@ export interface ExportData {
       dayStartHour?: number;
       animationsEnabled?: boolean;
       theme?: Theme;
-      autoClearLeetcode?: boolean;
+      resetEditorOnEveryProblem?: boolean;
       badgeEnabled?: boolean;
       language?: Language;
     };
@@ -30,6 +30,12 @@ export interface ExportData {
     };
   };
 }
+
+type ImportData = Omit<ExportData, 'data'> & {
+  data: Omit<ExportData['data'], 'settings'> & {
+    settings: ExportData['data']['settings'] & { autoClearLeetcode?: boolean };
+  };
+};
 
 export async function exportData(): Promise<string> {
   // Gather all data from storage
@@ -79,7 +85,7 @@ export async function exportData(): Promise<string> {
         ...(dayStartHour != null && { dayStartHour }),
         ...(animationsEnabled != null && { animationsEnabled }),
         ...(theme != null && { theme }),
-        ...(resetEditorOnEveryProblem != null && { autoClearLeetcode: resetEditorOnEveryProblem }),
+        ...(resetEditorOnEveryProblem != null && { resetEditorOnEveryProblem }),
         ...(badgeEnabled != null && { badgeEnabled }),
         ...(language != null && { language }),
       },
@@ -95,7 +101,7 @@ export async function exportData(): Promise<string> {
 
 export async function importData(jsonData: string): Promise<void> {
   // Parse and validate JSON
-  let data: ExportData;
+  let data: ImportData;
   try {
     data = JSON.parse(jsonData);
   } catch {
@@ -170,8 +176,10 @@ export async function importData(jsonData: string): Promise<void> {
     if (data.data.settings.theme != null) {
       await storage.setItem(STORAGE_KEYS.theme, data.data.settings.theme);
     }
-    if (data.data.settings.autoClearLeetcode != null) {
-      await storage.setItem(STORAGE_KEYS.resetEditorOnEveryProblem, data.data.settings.autoClearLeetcode);
+    const resetEditorOnEveryProblem =
+      data.data.settings.resetEditorOnEveryProblem ?? data.data.settings.autoClearLeetcode;
+    if (resetEditorOnEveryProblem != null) {
+      await storage.setItem(STORAGE_KEYS.resetEditorOnEveryProblem, resetEditorOnEveryProblem);
     }
     if (data.data.settings.badgeEnabled != null) {
       await storage.setItem(STORAGE_KEYS.badgeEnabled, data.data.settings.badgeEnabled);


### PR DESCRIPTION
Stack 2/3. Depends on #119.

Exports the new key while retaining legacy import support.

Tests: npm test, npm run compile

BEGIN_COMMIT_OVERRIDE
refactor: rename editor reset export key
END_COMMIT_OVERRIDE