### PR TITLE
feat: reset editor for due cards

### DIFF
--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -20,6 +20,8 @@ import {
   setTheme,
   getResetEditorOnEveryProblem,
   setResetEditorOnEveryProblem,
+  getResetEditorOnDueReview,
+  setResetEditorOnDueReview,
   getBadgeEnabled,
   setBadgeEnabled,
   getLanguage,
@@ -39,6 +41,7 @@ import {
   validateGistId,
 } from '@/services/github-sync';
 import { markDataUpdated } from '@/services/data-tracker';
+import { shouldResetEditor } from '@/services/editor-reset';
 
 const SYNC_ALARM_NAME = 'gist-sync';
 const SYNC_INTERVAL_MINUTES = 1;
@@ -181,6 +184,15 @@ export default defineBackground(() => {
       case MessageType.SET_RESET_EDITOR_ON_EVERY_PROBLEM: {
         return handleDataUpdate(() => setResetEditorOnEveryProblem(request.value));
       }
+
+      case MessageType.GET_RESET_EDITOR_ON_DUE_REVIEW:
+        return await getResetEditorOnDueReview();
+
+      case MessageType.SET_RESET_EDITOR_ON_DUE_REVIEW:
+        return handleDataUpdate(() => setResetEditorOnDueReview(request.value));
+
+      case MessageType.SHOULD_RESET_EDITOR:
+        return await shouldResetEditor(request.slug, request.domain);
 
       case MessageType.GET_BADGE_ENABLED:
         return await getBadgeEnabled();

--- a/entrypoints/popup/views/settings/ProblemAutoClearSection.tsx
+++ b/entrypoints/popup/views/settings/ProblemAutoClearSection.tsx
@@ -1,8 +1,10 @@
 import {
   useResetEditorOnEveryProblemQuery,
+  useResetEditorOnDueReviewQuery,
   useSetResetEditorOnEveryProblemMutation,
+  useSetResetEditorOnDueReviewMutation,
 } from '@/hooks/useBackgroundQueries';
-import { DEFAULT_RESET_EDITOR_ON_EVERY_PROBLEM } from '@/shared/settings';
+import { DEFAULT_RESET_EDITOR_ON_DUE_REVIEW, DEFAULT_RESET_EDITOR_ON_EVERY_PROBLEM } from '@/shared/settings';
 import { useI18n } from '../../contexts/I18nContext';
 import { SettingsSwitch } from './SettingsSwitch';
 
@@ -10,7 +12,9 @@ export function ProblemAutoClearSection() {
   const t = useI18n();
   const { data: resetEditorOnEveryProblem = DEFAULT_RESET_EDITOR_ON_EVERY_PROBLEM } =
     useResetEditorOnEveryProblemQuery();
+  const { data: resetEditorOnDueReview = DEFAULT_RESET_EDITOR_ON_DUE_REVIEW } = useResetEditorOnDueReviewQuery();
   const setResetEditorOnEveryProblemMutation = useSetResetEditorOnEveryProblemMutation();
+  const setResetEditorOnDueReviewMutation = useSetResetEditorOnDueReviewMutation();
 
   const setResetEditorOnEveryProblem = (isSelected: boolean) => {
     setResetEditorOnEveryProblemMutation.mutate(isSelected);
@@ -25,6 +29,11 @@ export function ProblemAutoClearSection() {
           label={t.settings.problemAutoClear.resetEditorOnEveryProblem}
           isSelected={resetEditorOnEveryProblem}
           onChange={setResetEditorOnEveryProblem}
+        />
+        <SettingsSwitch
+          label={t.settings.problemAutoClear.resetEditorOnDueReview}
+          isSelected={resetEditorOnDueReview}
+          onChange={(value) => setResetEditorOnDueReviewMutation.mutate(value)}
         />
       </div>
     </div>

--- a/hooks/useBackgroundQueries.ts
+++ b/hooks/useBackgroundQueries.ts
@@ -32,6 +32,7 @@ export const queryKeys = {
     animationsEnabled: ['settings', 'animationsEnabled'] as const,
     theme: ['settings', 'theme'] as const,
     resetEditorOnEveryProblem: ['settings', 'resetEditorOnEveryProblem'] as const,
+    resetEditorOnDueReview: ['settings', 'resetEditorOnDueReview'] as const,
     badgeEnabled: ['settings', 'badgeEnabled'] as const,
     language: ['settings', 'language'] as const,
   },
@@ -284,6 +285,22 @@ export function useSetResetEditorOnEveryProblemMutation() {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: queryKeys.settings.resetEditorOnEveryProblem });
     },
+  });
+}
+
+export function useResetEditorOnDueReviewQuery() {
+  return useQuery({
+    queryKey: queryKeys.settings.resetEditorOnDueReview,
+    queryFn: () => sendMessage({ type: MessageType.GET_RESET_EDITOR_ON_DUE_REVIEW }),
+  });
+}
+
+export function useSetResetEditorOnDueReviewMutation() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (value: boolean) => sendMessage({ type: MessageType.SET_RESET_EDITOR_ON_DUE_REVIEW, value }),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: queryKeys.settings.resetEditorOnDueReview }),
   });
 }
 

--- a/services/__tests__/editor-reset.test.ts
+++ b/services/__tests__/editor-reset.test.ts
@@ -1,0 +1,67 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { fakeBrowser } from 'wxt/testing/fake-browser';
+import { storage } from 'wxt/utils/storage';
+import { createEmptyCard, State as FsrsState } from 'ts-fsrs';
+import { shouldResetEditor } from '../editor-reset';
+import { serializeCard } from '../cards';
+import { setResetEditorOnDueReview, setResetEditorOnEveryProblem } from '../settings';
+import { STORAGE_KEYS } from '../storage-keys';
+import type { Card } from '@/shared/cards';
+
+describe('shouldResetEditor', () => {
+  beforeEach(() => fakeBrowser.reset());
+
+  it('resets every problem when the global setting is enabled', async () => {
+    await setResetEditorOnEveryProblem(true);
+    await expect(shouldResetEditor('two-sum', 'leetcode.com')).resolves.toBe(true);
+  });
+
+  it.each([FsrsState.New, FsrsState.Learning, FsrsState.Review, FsrsState.Relearning])(
+    'resets a due card in state %s',
+    async (state) => {
+      await setResetEditorOnDueReview(true);
+      await storeCard(makeCard({ state }));
+      await expect(shouldResetEditor('two-sum', 'leetcode.com')).resolves.toBe(true);
+    }
+  );
+
+  it.each([
+    ['disabled', {}, false],
+    ['not due', { due: new Date('2999-01-01') }, true],
+    ['paused', { paused: true }, true],
+  ])('does not reset a %s card', async (_name, overrides, enableSetting) => {
+    if (enableSetting) await setResetEditorOnDueReview(true);
+    await storeCard(makeCard(overrides));
+    await expect(shouldResetEditor('two-sum', 'leetcode.com')).resolves.toBe(false);
+  });
+
+  it('does not reset a card from the other LeetCode domain', async () => {
+    await setResetEditorOnDueReview(true);
+    await storeCard(makeCard());
+    await expect(shouldResetEditor('two-sum', 'leetcode.cn')).resolves.toBe(false);
+  });
+});
+
+async function storeCard(card: Card): Promise<void> {
+  await storage.setItem(STORAGE_KEYS.cards, { [card.slug]: serializeCard(card) });
+}
+
+function makeCard(overrides: Partial<{ due: Date; state: FsrsState; paused: boolean }> = {}): Card {
+  const state = overrides.state ?? FsrsState.Review;
+  return {
+    id: 'two-sum-id',
+    slug: 'two-sum',
+    name: 'Two Sum',
+    leetcodeId: '1',
+    difficulty: 'Easy',
+    domain: 'leetcode.com',
+    createdAt: new Date('2024-01-01'),
+    fsrs: {
+      ...createEmptyCard(),
+      state,
+      due: overrides.due ?? new Date('2025-01-01'),
+      last_review: state === FsrsState.New ? undefined : new Date('2024-01-01'),
+    },
+    paused: overrides.paused ?? false,
+  };
+}

--- a/services/__tests__/import-export.test.ts
+++ b/services/__tests__/import-export.test.ts
@@ -64,6 +64,7 @@ describe('import-export', () => {
         animationsEnabled: true,
         theme: 'dark' as const,
         resetEditorOnEveryProblem: true,
+        resetEditorOnDueReview: true,
         badgeEnabled: true,
         language: 'en' as const,
       };
@@ -77,6 +78,7 @@ describe('import-export', () => {
       await storage.setItem(STORAGE_KEYS.animationsEnabled, mockSettings.animationsEnabled);
       await storage.setItem(STORAGE_KEYS.theme, mockSettings.theme);
       await storage.setItem(STORAGE_KEYS.resetEditorOnEveryProblem, mockSettings.resetEditorOnEveryProblem);
+      await storage.setItem(STORAGE_KEYS.resetEditorOnDueReview, mockSettings.resetEditorOnDueReview);
       await storage.setItem(STORAGE_KEYS.badgeEnabled, mockSettings.badgeEnabled);
       await storage.setItem(STORAGE_KEYS.language, mockSettings.language);
 
@@ -187,6 +189,7 @@ describe('import-export', () => {
           animationsEnabled: false,
           theme: 'light' as const,
           resetEditorOnEveryProblem: true,
+          resetEditorOnDueReview: true,
           badgeEnabled: false,
           language: 'en' as const,
         },
@@ -208,6 +211,7 @@ describe('import-export', () => {
       expect(await storage.getItem(STORAGE_KEYS.animationsEnabled)).toEqual(false);
       expect(await storage.getItem(STORAGE_KEYS.theme)).toEqual('light');
       expect(await storage.getItem(STORAGE_KEYS.resetEditorOnEveryProblem)).toEqual(true);
+      expect(await storage.getItem(STORAGE_KEYS.resetEditorOnDueReview)).toEqual(true);
       expect(await storage.getItem(STORAGE_KEYS.badgeEnabled)).toEqual(false);
       expect(await storage.getItem(STORAGE_KEYS.language)).toEqual('en');
     });
@@ -351,6 +355,7 @@ describe('import-export', () => {
       await storage.setItem(STORAGE_KEYS.animationsEnabled, true);
       await storage.setItem(STORAGE_KEYS.theme, 'dark');
       await storage.setItem(STORAGE_KEYS.resetEditorOnEveryProblem, true);
+      await storage.setItem(STORAGE_KEYS.resetEditorOnDueReview, true);
       await storage.setItem(STORAGE_KEYS.badgeEnabled, true);
       await storage.setItem(STORAGE_KEYS.language, 'en');
       await storage.setItem(`${STORAGE_KEYS.notes}:${uuid1}` as const, { text: 'note 1' });
@@ -367,6 +372,7 @@ describe('import-export', () => {
       expect(await storage.getItem(STORAGE_KEYS.animationsEnabled)).toBeNull();
       expect(await storage.getItem(STORAGE_KEYS.theme)).toBeNull();
       expect(await storage.getItem(STORAGE_KEYS.resetEditorOnEveryProblem)).toBeNull();
+      expect(await storage.getItem(STORAGE_KEYS.resetEditorOnDueReview)).toBeNull();
       expect(await storage.getItem(STORAGE_KEYS.badgeEnabled)).toBeNull();
       expect(await storage.getItem(STORAGE_KEYS.language)).toBeNull();
       expect(await storage.getItem(`${STORAGE_KEYS.notes}:${uuid1}` as const)).toBeNull();

--- a/services/__tests__/settings.test.ts
+++ b/services/__tests__/settings.test.ts
@@ -10,6 +10,8 @@ import {
   setTheme,
   getResetEditorOnEveryProblem,
   setResetEditorOnEveryProblem,
+  getResetEditorOnDueReview,
+  setResetEditorOnDueReview,
   getLanguage,
 } from '../settings';
 import { STORAGE_KEYS } from '../storage-keys';
@@ -19,6 +21,7 @@ import {
   MAX_NEW_CARDS_PER_DAY,
   DEFAULT_THEME,
   DEFAULT_RESET_EDITOR_ON_EVERY_PROBLEM,
+  DEFAULT_RESET_EDITOR_ON_DUE_REVIEW,
 } from '@/shared/settings';
 
 describe('Settings Service', () => {
@@ -237,11 +240,17 @@ describe('Settings Service', () => {
   describe('editor reset settings', () => {
     it('should return default values when not set', async () => {
       expect(await getResetEditorOnEveryProblem()).toBe(DEFAULT_RESET_EDITOR_ON_EVERY_PROBLEM);
+      expect(await getResetEditorOnDueReview()).toBe(DEFAULT_RESET_EDITOR_ON_DUE_REVIEW);
     });
 
     it('should store and retrieve reset editor on every problem', async () => {
       await setResetEditorOnEveryProblem(true);
       expect(await getResetEditorOnEveryProblem()).toBe(true);
+    });
+
+    it('should store and retrieve reset editor on due review', async () => {
+      await setResetEditorOnDueReview(true);
+      expect(await getResetEditorOnDueReview()).toBe(true);
     });
   });
 

--- a/services/editor-reset.ts
+++ b/services/editor-reset.ts
@@ -1,0 +1,19 @@
+import { getAllCards, isDueByDate } from './cards';
+import { getDayStartHour, getResetEditorOnDueReview, getResetEditorOnEveryProblem } from './settings';
+import type { LeetcodeDomain } from '@/shared/cards';
+
+export async function shouldResetEditor(slug: string, domain: LeetcodeDomain): Promise<boolean> {
+  if (await getResetEditorOnEveryProblem()) {
+    return true;
+  }
+  if (!(await getResetEditorOnDueReview())) {
+    return false;
+  }
+
+  const card = (await getAllCards()).find((candidate) => candidate.slug === slug && candidate.domain === domain);
+  if (!card || card.paused) {
+    return false;
+  }
+
+  return isDueByDate(card, new Date(), await getDayStartHour());
+}

--- a/services/import-export.ts
+++ b/services/import-export.ts
@@ -21,6 +21,7 @@ export interface ExportData {
       animationsEnabled?: boolean;
       theme?: Theme;
       resetEditorOnEveryProblem?: boolean;
+      resetEditorOnDueReview?: boolean;
       badgeEnabled?: boolean;
       language?: Language;
     };
@@ -59,6 +60,7 @@ export async function exportData(): Promise<string> {
   const animationsEnabled = await storage.getItem<boolean>(STORAGE_KEYS.animationsEnabled);
   const theme = await storage.getItem<Theme>(STORAGE_KEYS.theme);
   const resetEditorOnEveryProblem = await storage.getItem<boolean>(STORAGE_KEYS.resetEditorOnEveryProblem);
+  const resetEditorOnDueReview = await storage.getItem<boolean>(STORAGE_KEYS.resetEditorOnDueReview);
   const badgeEnabled = await storage.getItem<boolean>(STORAGE_KEYS.badgeEnabled);
   const language = await storage.getItem<Language>(STORAGE_KEYS.language);
 
@@ -86,6 +88,7 @@ export async function exportData(): Promise<string> {
         ...(animationsEnabled != null && { animationsEnabled }),
         ...(theme != null && { theme }),
         ...(resetEditorOnEveryProblem != null && { resetEditorOnEveryProblem }),
+        ...(resetEditorOnDueReview != null && { resetEditorOnDueReview }),
         ...(badgeEnabled != null && { badgeEnabled }),
         ...(language != null && { language }),
       },
@@ -181,6 +184,9 @@ export async function importData(jsonData: string): Promise<void> {
     if (resetEditorOnEveryProblem != null) {
       await storage.setItem(STORAGE_KEYS.resetEditorOnEveryProblem, resetEditorOnEveryProblem);
     }
+    if (data.data.settings.resetEditorOnDueReview != null) {
+      await storage.setItem(STORAGE_KEYS.resetEditorOnDueReview, data.data.settings.resetEditorOnDueReview);
+    }
     if (data.data.settings.badgeEnabled != null) {
       await storage.setItem(STORAGE_KEYS.badgeEnabled, data.data.settings.badgeEnabled);
     }
@@ -216,6 +222,7 @@ export async function resetAllData(): Promise<void> {
   await storage.removeItem(STORAGE_KEYS.animationsEnabled);
   await storage.removeItem(STORAGE_KEYS.theme);
   await storage.removeItem(STORAGE_KEYS.resetEditorOnEveryProblem);
+  await storage.removeItem(STORAGE_KEYS.resetEditorOnDueReview);
   await storage.removeItem(STORAGE_KEYS.badgeEnabled);
   await storage.removeItem(STORAGE_KEYS.language);
 

--- a/services/settings.ts
+++ b/services/settings.ts
@@ -11,6 +11,7 @@ import {
   type Theme,
   DEFAULT_THEME,
   DEFAULT_RESET_EDITOR_ON_EVERY_PROBLEM,
+  DEFAULT_RESET_EDITOR_ON_DUE_REVIEW,
   DEFAULT_BADGE_ENABLED,
   type Language,
 } from '@/shared/settings';
@@ -73,6 +74,15 @@ export async function getResetEditorOnEveryProblem(): Promise<boolean> {
 
 export async function setResetEditorOnEveryProblem(value: boolean): Promise<void> {
   await storage.setItem(STORAGE_KEYS.resetEditorOnEveryProblem, value);
+}
+
+export async function getResetEditorOnDueReview(): Promise<boolean> {
+  const value = await storage.getItem<boolean>(STORAGE_KEYS.resetEditorOnDueReview);
+  return value ?? DEFAULT_RESET_EDITOR_ON_DUE_REVIEW;
+}
+
+export async function setResetEditorOnDueReview(value: boolean): Promise<void> {
+  await storage.setItem(STORAGE_KEYS.resetEditorOnDueReview, value);
 }
 
 export async function getBadgeEnabled(): Promise<boolean> {

--- a/services/storage-keys.ts
+++ b/services/storage-keys.ts
@@ -8,6 +8,7 @@ export const STORAGE_KEYS = {
   animationsEnabled: 'sync:leetsrs:animationsEnabled',
   theme: 'sync:leetsrs:theme',
   resetEditorOnEveryProblem: 'sync:leetsrs:autoClearLeetcode',
+  resetEditorOnDueReview: 'sync:leetsrs:resetEditorOnDueReview',
   badgeEnabled: 'sync:leetsrs:badgeEnabled',
   language: 'sync:leetsrs:language',
   schemaVersion: 'local:leetsrs:schemaVersion',

--- a/shared/i18n/en.ts
+++ b/shared/i18n/en.ts
@@ -166,6 +166,7 @@ const en = {
       title: 'Problem Auto Reset',
       description: 'Automatically reset code when opening a LeetCode problem.',
       resetEditorOnEveryProblem: 'Reset editor on every problem',
+      resetEditorOnDueReview: 'Reset editor on due review',
     },
 
     leetcodeCn: {

--- a/shared/i18n/hi.ts
+++ b/shared/i18n/hi.ts
@@ -148,6 +148,7 @@ const hi: Translations = {
       title: 'प्रॉब्लम ऑटो रीसेट',
       description: 'LeetCode प्रॉब्लम खोलने पर कोड ऑटोमैटिकली रीसेट करें।',
       resetEditorOnEveryProblem: 'हर प्रश्न पर संपादक रीसेट करें',
+      resetEditorOnDueReview: 'नियत समीक्षा पर संपादक रीसेट करें',
     },
 
     leetcodeCn: {

--- a/shared/i18n/pl.ts
+++ b/shared/i18n/pl.ts
@@ -168,6 +168,7 @@ const pl: Translations = {
       title: 'Automatyczny reset zadania',
       description: 'Automatycznie resetuj kod przy otwieraniu zadania na LeetCode.',
       resetEditorOnEveryProblem: 'Resetuj edytor dla każdego zadania',
+      resetEditorOnDueReview: 'Resetuj edytor przy wymaganej powtórce',
     },
 
     leetcodeCn: {

--- a/shared/i18n/zh-CN.ts
+++ b/shared/i18n/zh-CN.ts
@@ -149,6 +149,7 @@ const zhCN: Translations = {
       title: '题目自动重置',
       description: '打开 LeetCode 题目时自动重置代码。',
       resetEditorOnEveryProblem: '每道题都重置编辑器',
+      resetEditorOnDueReview: '复习到期时重置编辑器',
     },
 
     leetcodeCn: {

--- a/shared/messages.ts
+++ b/shared/messages.ts
@@ -1,5 +1,5 @@
 import { browser } from 'wxt/browser';
-import type { Card, ProblemDescriptor, RateCardInput } from '@/shared/cards';
+import type { Card, LeetcodeDomain, ProblemDescriptor, RateCardInput } from '@/shared/cards';
 import type { State as FsrsState } from 'ts-fsrs';
 import type { DailyStats, UpcomingReviewStats } from '@/services/stats';
 import type { Note } from '@/shared/notes';
@@ -36,6 +36,9 @@ export const MessageType = {
   SET_THEME: 'SET_THEME',
   GET_RESET_EDITOR_ON_EVERY_PROBLEM: 'GET_RESET_EDITOR_ON_EVERY_PROBLEM',
   SET_RESET_EDITOR_ON_EVERY_PROBLEM: 'SET_RESET_EDITOR_ON_EVERY_PROBLEM',
+  GET_RESET_EDITOR_ON_DUE_REVIEW: 'GET_RESET_EDITOR_ON_DUE_REVIEW',
+  SET_RESET_EDITOR_ON_DUE_REVIEW: 'SET_RESET_EDITOR_ON_DUE_REVIEW',
+  SHOULD_RESET_EDITOR: 'SHOULD_RESET_EDITOR',
   GET_BADGE_ENABLED: 'GET_BADGE_ENABLED',
   SET_BADGE_ENABLED: 'SET_BADGE_ENABLED',
   GET_LANGUAGE: 'GET_LANGUAGE',
@@ -80,6 +83,9 @@ export type MessageRequest =
   | { type: typeof MessageType.SET_THEME; value: Theme }
   | { type: typeof MessageType.GET_RESET_EDITOR_ON_EVERY_PROBLEM }
   | { type: typeof MessageType.SET_RESET_EDITOR_ON_EVERY_PROBLEM; value: boolean }
+  | { type: typeof MessageType.GET_RESET_EDITOR_ON_DUE_REVIEW }
+  | { type: typeof MessageType.SET_RESET_EDITOR_ON_DUE_REVIEW; value: boolean }
+  | { type: typeof MessageType.SHOULD_RESET_EDITOR; slug: string; domain: LeetcodeDomain }
   | { type: typeof MessageType.GET_BADGE_ENABLED }
   | { type: typeof MessageType.SET_BADGE_ENABLED; value: boolean }
   | { type: typeof MessageType.GET_LANGUAGE }
@@ -123,6 +129,9 @@ export type MessageResponseMap = {
   [MessageType.SET_THEME]: void;
   [MessageType.GET_RESET_EDITOR_ON_EVERY_PROBLEM]: boolean;
   [MessageType.SET_RESET_EDITOR_ON_EVERY_PROBLEM]: void;
+  [MessageType.GET_RESET_EDITOR_ON_DUE_REVIEW]: boolean;
+  [MessageType.SET_RESET_EDITOR_ON_DUE_REVIEW]: void;
+  [MessageType.SHOULD_RESET_EDITOR]: boolean;
   [MessageType.GET_BADGE_ENABLED]: boolean;
   [MessageType.SET_BADGE_ENABLED]: void;
   [MessageType.GET_LANGUAGE]: Language;

--- a/shared/settings.ts
+++ b/shared/settings.ts
@@ -7,6 +7,7 @@ export const MIN_DAY_START_HOUR = 0;
 export const MAX_DAY_START_HOUR = 23;
 
 export const DEFAULT_RESET_EDITOR_ON_EVERY_PROBLEM = false;
+export const DEFAULT_RESET_EDITOR_ON_DUE_REVIEW = false;
 export const DEFAULT_BADGE_ENABLED = true;
 export type Theme = 'light' | 'dark';
 export const DEFAULT_THEME: Theme = 'dark';

--- a/utils/content/__tests__/auto-reset.test.ts
+++ b/utils/content/__tests__/auto-reset.test.ts
@@ -146,4 +146,15 @@ describe('setupLeetcodeAutoReset', () => {
 
     expect(resetClick).not.toHaveBeenCalled();
   });
+
+  it('asks for a reset decision using the current problem', async () => {
+    dispose = setupLeetcodeAutoReset();
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(sendMessage).toHaveBeenCalledWith({
+      type: 'SHOULD_RESET_EDITOR',
+      slug: 'two-sum',
+      domain: 'leetcode.com',
+    });
+  });
 });

--- a/utils/content/auto-reset.ts
+++ b/utils/content/auto-reset.ts
@@ -1,5 +1,5 @@
 import { MessageType, sendMessage } from '@/shared/messages';
-import { getCurrentProblemSlug } from './domain';
+import { getCurrentDomain, getCurrentProblemSlug } from './domain';
 
 const RESET_CONFIRM_TIMEOUT_MS = 2000;
 const RESET_CONFIRM_POLL_MS = 50;
@@ -57,8 +57,12 @@ export function setupLeetcodeAutoReset(): () => void {
 
     isResetting = true;
     try {
-      const resetEveryProblem = await sendMessage({ type: MessageType.GET_RESET_EDITOR_ON_EVERY_PROBLEM });
-      if (!resetEveryProblem) {
+      const shouldReset = await sendMessage({
+        type: MessageType.SHOULD_RESET_EDITOR,
+        slug,
+        domain: getCurrentDomain(),
+      });
+      if (!shouldReset) {
         return;
       }
 


### PR DESCRIPTION
Stack 3/3. Depends on #120.

Adds an option to reset the editor when a card is due.

Tests: npm test, npm run compile

BEGIN_COMMIT_OVERRIDE
feat: reset editor for due cards
END_COMMIT_OVERRIDE