### PR TITLE
ci: fail on Biome warnings in CI lint step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
           echo "All versions match: $PKG_VERSION"
 
       - name: Check formatting and linting
-        run: npx biome check .
+        run: npx biome check --error-on-warnings .
 
       - name: Type check
         run: npm run compile

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,3 @@ Tests use Vitest, Happy DOM, Testing Library, and WXT's Vitest plugin. Name file
 ## Commit & Pull Request Guidelines
 
 Write concise, imperative commit subjects with a lowercase prefix, such as `fix: clean up animation timeout`. Existing prefixes include `fix`, `bugfix`, `refactor`, and `chore`. Pull requests should explain user impact, summarize implementation and testing, link issues, and include screenshots for UI changes. Do not commit generated `.output/` or `.wxt/` content.
-
-## Changelog Guidelines
-
-Record user-facing changes and notable developer-tooling changes in `CHANGELOG.md` under `Unreleased`. Do not assign them a version until a release is cut. At release time, rename the accumulated `Unreleased` section to the released version and date, then add a new empty `Unreleased` section for subsequent work.


### PR DESCRIPTION
## Summary
- Add `--error-on-warnings` to the `npx biome check .` invocation in the "Check formatting and linting" CI step so it matches the `check` script in `package.json` and actually fails on Biome warnings, not just errors.
- Remove the stale "Changelog Guidelines" section from `AGENTS.md`, since `CHANGELOG.md` no longer exists on this branch.

## Test plan
- [x] Diffed `.github/workflows/ci.yml` to confirm only the flag was added.
- [ ] CI run on this PR should exercise the updated step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RvA8K1883rW55aQZkrQZe7

---
_Generated by [Claude Code](https://claude.ai/code/session_01RvA8K1883rW55aQZkrQZe7)_