### PR TITLE
fix: correct Release Please configuration

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Create release PR or GitHub release
-        uses: googleapis/release-please-action@v4
+        uses: googleapis/release-please-action@v5
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -17,5 +17,6 @@ jobs:
       - name: Create release PR or GitHub release
         uses: googleapis/release-please-action@v5
         with:
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "include-component-in-tag": false,
   "release-type": "node",
   "packages": {
     ".": {


### PR DESCRIPTION
## Summary

- use the Node 24-based Release Please v5 action
- recognize existing tags such as v0.5.0 without a component prefix
- authenticate with RELEASE_PLEASE_TOKEN so generated release PRs trigger CI

## Testing

- Biome check
- JSON and workflow YAML validation

BEGIN_COMMIT_OVERRIDE
chore: correct Release Please configuration
END_COMMIT_OVERRIDE