### PR TITLE
ci: skip Claude reviews on release PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   claude-review:
+    if: ${{ !startsWith(github.event.pull_request.head.ref, 'release-please--branches--') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary

Skip the Claude review job for Release Please branches so automated release PRs do not receive Claude comments or consume review runs.

## Testing

- workflow YAML validation
- Biome check