### PR TITLE
refactor: migrate extension messaging

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,7 @@ Tests use Vitest, Happy DOM, Testing Library, and WXT's Vitest plugin. Name file
 
 ## Architecture Invariants
 
-- Extend the typed message bus in `shared/messages.ts`: update `MessageType`, `MessageRequest`, `MessageResponseMap`, and the exhaustive handler in `entrypoints/background.ts`.
+- Extend `ExtensionProtocolMap` in `shared/messages.ts` and register the corresponding typed `onMessage` handler in `entrypoints/background.ts`.
 - Persist cards as `StoredCard`; serialize and deserialize at the storage boundary.
 - Route schema changes through a new, sequential migration in `services/migrations.ts`.
 - Use `formatLocalDate` and `isDueByDate` with `dayStartHour` for review-day comparisons; do not compare raw timestamps.

--- a/TODO.md
+++ b/TODO.md
@@ -2,7 +2,7 @@
 
 - [x] Add `@webext-core/messaging` as a runtime dependency.
 - [x] Replace the custom extension message types with an idiomatic protocol map.
-- [ ] Register extension message handlers with `onMessage` in the background.
+- [x] Register extension message handlers with `onMessage` in the background.
 - [ ] Migrate popup and content-script callers to the new `sendMessage` API.
 - [ ] Update messaging tests and add coverage for both protocol maps.
 - [ ] Update the messaging architecture invariant in `AGENTS.md`.

--- a/TODO.md
+++ b/TODO.md
@@ -1,9 +1,0 @@
-# Messaging migration
-
-- [x] Add `@webext-core/messaging` as a runtime dependency.
-- [x] Replace the custom extension message types with an idiomatic protocol map.
-- [x] Register extension message handlers with `onMessage` in the background.
-- [x] Migrate popup and content-script callers to the new `sendMessage` API.
-- [x] Update messaging tests and cover payload and no-payload messages.
-- [ ] Update the messaging architecture invariant in `AGENTS.md`.
-- [ ] Run formatting, lint, type-checking, tests, and a production build.

--- a/TODO.md
+++ b/TODO.md
@@ -3,7 +3,7 @@
 - [x] Add `@webext-core/messaging` as a runtime dependency.
 - [x] Replace the custom extension message types with an idiomatic protocol map.
 - [x] Register extension message handlers with `onMessage` in the background.
-- [ ] Migrate popup and content-script callers to the new `sendMessage` API.
-- [ ] Update messaging tests and add coverage for both protocol maps.
+- [x] Migrate popup and content-script callers to the new `sendMessage` API.
+- [x] Update messaging tests and cover payload and no-payload messages.
 - [ ] Update the messaging architecture invariant in `AGENTS.md`.
 - [ ] Run formatting, lint, type-checking, tests, and a production build.

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,9 @@
+# Messaging migration
+
+- [x] Add `@webext-core/messaging` as a runtime dependency.
+- [x] Replace the custom extension message types with an idiomatic protocol map.
+- [ ] Register extension message handlers with `onMessage` in the background.
+- [ ] Migrate popup and content-script callers to the new `sendMessage` API.
+- [ ] Update messaging tests and add coverage for both protocol maps.
+- [ ] Update the messaging architecture invariant in `AGENTS.md`.
+- [ ] Run formatting, lint, type-checking, tests, and a production build.

--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -41,7 +41,7 @@ import {
   setTheme,
 } from '@/services/settings';
 import { getCardStateStats, getLastNDaysStats, getNextNDaysStats, getTodayStats } from '@/services/stats';
-import { type MessageRequest, MessageType } from '@/shared/messages';
+import { onMessage } from '@/shared/messages';
 
 const SYNC_ALARM_NAME = 'gist-sync';
 const SYNC_INTERVAL_MINUTES = 1;
@@ -95,171 +95,62 @@ export default defineBackground(() => {
     }
   });
 
-  async function handleMessage(request: MessageRequest) {
-    // Wait for initialization before handling any messages
+  const handleRequest = async <T>(handler: () => T | Promise<T>): Promise<T> => {
     await readyPromise;
+    return handler();
+  };
 
-    const handleDataUpdate = async <T>(handler: () => Promise<T>): Promise<T> => {
+  const handleDataUpdate = async <T>(handler: () => Promise<T>): Promise<T> => {
+    return handleRequest(async () => {
       const result = await handler();
       await markDataUpdated();
       await updateBadge();
       return result;
-    };
+    });
+  };
 
-    switch (request.type) {
-      case MessageType.PING:
-        return 'PONG' as const;
-
-      case MessageType.ADD_CARD: {
-        return handleDataUpdate(() => addCard(request.problem));
-      }
-
-      case MessageType.GET_ALL_CARDS:
-        return await getAllCards();
-
-      case MessageType.REMOVE_CARD: {
-        return handleDataUpdate(() => removeCard(request.slug));
-      }
-
-      case MessageType.DELAY_CARD: {
-        return handleDataUpdate(() => delayCard(request.slug, request.days));
-      }
-
-      case MessageType.SET_PAUSE_STATUS: {
-        return handleDataUpdate(() => setPauseStatus(request.slug, request.paused));
-      }
-
-      case MessageType.RATE_CARD: {
-        return handleDataUpdate(() => rateCard(request.input));
-      }
-
-      case MessageType.GET_REVIEW_QUEUE:
-        return await getReviewQueue();
-
-      case MessageType.GET_TODAY_STATS:
-        return await getTodayStats();
-
-      case MessageType.GET_NOTE:
-        return await getNote(request.cardId);
-
-      case MessageType.SAVE_NOTE: {
-        return handleDataUpdate(() => saveNote(request.cardId, request.text));
-      }
-
-      case MessageType.DELETE_NOTE: {
-        return handleDataUpdate(() => deleteNote(request.cardId));
-      }
-
-      case MessageType.GET_MAX_NEW_CARDS_PER_DAY:
-        return await getMaxNewCardsPerDay();
-
-      case MessageType.SET_MAX_NEW_CARDS_PER_DAY: {
-        return handleDataUpdate(() => setMaxNewCardsPerDay(request.value));
-      }
-
-      case MessageType.GET_DAY_START_HOUR:
-        return await getDayStartHour();
-
-      case MessageType.SET_DAY_START_HOUR: {
-        return handleDataUpdate(() => setDayStartHour(request.value));
-      }
-
-      case MessageType.GET_ANIMATIONS_ENABLED:
-        return await getAnimationsEnabled();
-
-      case MessageType.SET_ANIMATIONS_ENABLED: {
-        return handleDataUpdate(() => setAnimationsEnabled(request.value));
-      }
-
-      case MessageType.GET_THEME:
-        return await getTheme();
-
-      case MessageType.SET_THEME: {
-        return handleDataUpdate(() => setTheme(request.value));
-      }
-
-      case MessageType.GET_RESET_EDITOR_ON_EVERY_PROBLEM:
-        return await getResetEditorOnEveryProblem();
-
-      case MessageType.SET_RESET_EDITOR_ON_EVERY_PROBLEM: {
-        return handleDataUpdate(() => setResetEditorOnEveryProblem(request.value));
-      }
-
-      case MessageType.GET_RESET_EDITOR_ON_DUE_REVIEW:
-        return await getResetEditorOnDueReview();
-
-      case MessageType.SET_RESET_EDITOR_ON_DUE_REVIEW:
-        return handleDataUpdate(() => setResetEditorOnDueReview(request.value));
-
-      case MessageType.SHOULD_RESET_EDITOR:
-        return await shouldResetEditor(request.slug, request.domain);
-
-      case MessageType.GET_BADGE_ENABLED:
-        return await getBadgeEnabled();
-
-      case MessageType.SET_BADGE_ENABLED: {
-        return handleDataUpdate(() => setBadgeEnabled(request.value));
-      }
-
-      case MessageType.GET_LANGUAGE:
-        return await getLanguage();
-
-      case MessageType.SET_LANGUAGE:
-        return handleDataUpdate(() => setLanguage(request.value));
-
-      case MessageType.GET_CARD_STATE_STATS:
-        return await getCardStateStats();
-
-      case MessageType.GET_LAST_N_DAYS_STATS:
-        return await getLastNDaysStats(request.days);
-
-      case MessageType.GET_NEXT_N_DAYS_STATS:
-        return await getNextNDaysStats(request.days);
-
-      case MessageType.EXPORT_DATA:
-        return await exportData();
-
-      case MessageType.IMPORT_DATA:
-        return await importData(request.jsonData);
-
-      case MessageType.RESET_ALL_DATA:
-        return await resetAllData();
-
-      // GitHub Gist Sync
-      case MessageType.GET_GIST_SYNC_CONFIG:
-        return await getGistSyncConfig();
-
-      case MessageType.SET_GIST_SYNC_CONFIG:
-        return await setGistSyncConfig(request.config);
-
-      case MessageType.GET_GIST_SYNC_STATUS:
-        return await getGistSyncStatus();
-
-      case MessageType.TRIGGER_GIST_SYNC:
-        return await triggerGistSync();
-
-      case MessageType.CREATE_NEW_GIST:
-        return await createNewGist();
-
-      case MessageType.VALIDATE_PAT:
-        return await validatePat(request.pat);
-
-      case MessageType.VALIDATE_GIST_ID:
-        return await validateGistId(request.gistId, request.pat);
-
-      default: {
-        // Exhaustive check - compile error if a message type is not handled
-        const _: never = request;
-        throw new Error(`Unknown message type: ${(request as { type?: string }).type}`);
-      }
-    }
-  }
-
-  // Message handler for popup communication
-  browser.runtime.onMessage.addListener((request: MessageRequest, _sender, sendResponse) => {
-    handleMessage(request).then(sendResponse);
-
-    // Return true to indicate we'll send a response asynchronously
-    return true;
-  });
+  onMessage('ping', () => handleRequest(() => 'PONG' as const));
+  onMessage('addCard', ({ data }) => handleDataUpdate(() => addCard(data.problem)));
+  onMessage('getAllCards', () => handleRequest(getAllCards));
+  onMessage('removeCard', ({ data }) => handleDataUpdate(() => removeCard(data.slug)));
+  onMessage('delayCard', ({ data }) => handleDataUpdate(() => delayCard(data.slug, data.days)));
+  onMessage('setPauseStatus', ({ data }) => handleDataUpdate(() => setPauseStatus(data.slug, data.paused)));
+  onMessage('rateCard', ({ data }) => handleDataUpdate(() => rateCard(data.input)));
+  onMessage('getReviewQueue', () => handleRequest(getReviewQueue));
+  onMessage('getTodayStats', () => handleRequest(getTodayStats));
+  onMessage('getNote', ({ data }) => handleRequest(() => getNote(data.cardId)));
+  onMessage('saveNote', ({ data }) => handleDataUpdate(() => saveNote(data.cardId, data.text)));
+  onMessage('deleteNote', ({ data }) => handleDataUpdate(() => deleteNote(data.cardId)));
+  onMessage('getMaxNewCardsPerDay', () => handleRequest(getMaxNewCardsPerDay));
+  onMessage('setMaxNewCardsPerDay', ({ data }) => handleDataUpdate(() => setMaxNewCardsPerDay(data.value)));
+  onMessage('getDayStartHour', () => handleRequest(getDayStartHour));
+  onMessage('setDayStartHour', ({ data }) => handleDataUpdate(() => setDayStartHour(data.value)));
+  onMessage('getAnimationsEnabled', () => handleRequest(getAnimationsEnabled));
+  onMessage('setAnimationsEnabled', ({ data }) => handleDataUpdate(() => setAnimationsEnabled(data.value)));
+  onMessage('getTheme', () => handleRequest(getTheme));
+  onMessage('setTheme', ({ data }) => handleDataUpdate(() => setTheme(data.value)));
+  onMessage('getResetEditorOnEveryProblem', () => handleRequest(getResetEditorOnEveryProblem));
+  onMessage('setResetEditorOnEveryProblem', ({ data }) =>
+    handleDataUpdate(() => setResetEditorOnEveryProblem(data.value))
+  );
+  onMessage('getResetEditorOnDueReview', () => handleRequest(getResetEditorOnDueReview));
+  onMessage('setResetEditorOnDueReview', ({ data }) => handleDataUpdate(() => setResetEditorOnDueReview(data.value)));
+  onMessage('shouldResetEditor', ({ data }) => handleRequest(() => shouldResetEditor(data.slug, data.domain)));
+  onMessage('getBadgeEnabled', () => handleRequest(getBadgeEnabled));
+  onMessage('setBadgeEnabled', ({ data }) => handleDataUpdate(() => setBadgeEnabled(data.value)));
+  onMessage('getLanguage', () => handleRequest(getLanguage));
+  onMessage('setLanguage', ({ data }) => handleDataUpdate(() => setLanguage(data.value)));
+  onMessage('getCardStateStats', () => handleRequest(getCardStateStats));
+  onMessage('getLastNDaysStats', ({ data }) => handleRequest(() => getLastNDaysStats(data.days)));
+  onMessage('getNextNDaysStats', ({ data }) => handleRequest(() => getNextNDaysStats(data.days)));
+  onMessage('exportData', () => handleRequest(exportData));
+  onMessage('importData', ({ data }) => handleRequest(() => importData(data.jsonData)));
+  onMessage('resetAllData', () => handleRequest(resetAllData));
+  onMessage('getGistSyncConfig', () => handleRequest(getGistSyncConfig));
+  onMessage('setGistSyncConfig', ({ data }) => handleRequest(() => setGistSyncConfig(data.config)));
+  onMessage('getGistSyncStatus', () => handleRequest(getGistSyncStatus));
+  onMessage('triggerGistSync', () => handleRequest(triggerGistSync));
+  onMessage('createNewGist', () => handleRequest(createNewGist));
+  onMessage('validatePat', ({ data }) => handleRequest(() => validatePat(data.pat)));
+  onMessage('validateGistId', ({ data }) => handleRequest(() => validateGistId(data.gistId, data.pat)));
 });

--- a/entrypoints/content.ts
+++ b/entrypoints/content.ts
@@ -1,7 +1,7 @@
 import type { Grade } from 'ts-fsrs';
 import { getServiceTranslations } from '@/services/i18n';
 import type { ProblemDescriptor } from '@/shared/cards';
-import { MessageType, sendMessage } from '@/shared/messages';
+import { sendMessage } from '@/shared/messages';
 import type { ProblemData } from '@/shared/problem-data';
 import {
   createLeetSrsButton,
@@ -18,7 +18,7 @@ export default defineContentScript({
   async main() {
     // Wake up service worker so it's ready when user interacts
     try {
-      await sendMessage({ type: MessageType.PING });
+      await sendMessage('ping');
     } catch (error) {
       console.error('Failed to ping service worker:', error);
     }
@@ -76,8 +76,7 @@ function setupLeetSrsButton() {
       buttonWrapper,
       async (rating, label) => {
         await withProblemData(async (problem) => {
-          const result = await sendMessage({
-            type: MessageType.RATE_CARD,
+          const result = await sendMessage('rateCard', {
             input: { ...problem, rating: rating as Grade },
           });
           console.log(`${label} - Card rated:`, result);
@@ -86,10 +85,7 @@ function setupLeetSrsButton() {
       },
       async () => {
         await withProblemData(async (problem) => {
-          const result = await sendMessage({
-            type: MessageType.ADD_CARD,
-            problem,
-          });
+          const result = await sendMessage('addCard', { problem });
           console.log('Add without rating - Card added:', result);
           return result;
         });

--- a/hooks/__tests__/useBackgroundQueries.test.tsx
+++ b/hooks/__tests__/useBackgroundQueries.test.tsx
@@ -6,45 +6,38 @@ import { renderHook, waitFor } from '@testing-library/react';
 import { createEmptyCard, type Grade, Rating } from 'ts-fsrs';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { Card } from '@/shared/cards';
-import { MessageType, sendMessage } from '@/shared/messages';
+import { sendMessage } from '@/shared/messages';
 import { createTestWrapper, createWrapper } from '@/test/utils/test-wrapper';
 import {
   queryKeys,
+  useCardsQuery,
   useDeleteNoteMutation,
   usePauseCardMutation,
   useRateCardMutation,
   useSaveNoteMutation,
 } from '../useBackgroundQueries';
 
-// Mock the sendMessage function
 vi.mock('@/shared/messages', () => ({
-  sendMessage: vi.fn((message) => {
-    // Return appropriate default values for animations queries
-    if (message.type === 'GET_ANIMATIONS_ENABLED') {
-      return Promise.resolve(false);
-    }
-    return Promise.resolve(undefined);
-  }),
-  MessageType: {
-    RATE_CARD: 'RATE_CARD',
-    SAVE_NOTE: 'SAVE_NOTE',
-    DELETE_NOTE: 'DELETE_NOTE',
-    SET_PAUSE_STATUS: 'SET_PAUSE_STATUS',
-    GET_ANIMATIONS_ENABLED: 'GET_ANIMATIONS_ENABLED',
-    SET_ANIMATIONS_ENABLED: 'SET_ANIMATIONS_ENABLED',
-  },
+  sendMessage: vi.fn(() => Promise.resolve(undefined)),
 }));
+
+describe('useCardsQuery', () => {
+  it('sends a message without a payload', async () => {
+    vi.mocked(sendMessage).mockResolvedValue([]);
+
+    const { result } = renderHook(() => useCardsQuery(), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(sendMessage).toHaveBeenCalledWith('getAllCards');
+  });
+});
 
 describe('useRateCardMutation', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    // Ensure sendMessage returns appropriate values after clearing
-    vi.mocked(sendMessage).mockImplementation((message) => {
-      if (message.type === 'GET_ANIMATIONS_ENABLED') {
-        return Promise.resolve(false);
-      }
-      return Promise.resolve(undefined);
-    });
+    vi.mocked(sendMessage).mockResolvedValue(undefined);
   });
 
   it('should call sendMessage with correct parameters when mutate is called', async () => {
@@ -78,8 +71,7 @@ describe('useRateCardMutation', () => {
     result.current.mutate(mockCard);
 
     await waitFor(() => {
-      expect(sendMessage).toHaveBeenCalledWith({
-        type: MessageType.RATE_CARD,
+      expect(sendMessage).toHaveBeenCalledWith('rateCard', {
         input: {
           slug: 'two-sum',
           name: 'Two Sum',
@@ -111,8 +103,7 @@ describe('useSaveNoteMutation', () => {
     result.current.mutate(noteText);
 
     await waitFor(() => {
-      expect(sendMessage).toHaveBeenCalledWith({
-        type: MessageType.SAVE_NOTE,
+      expect(sendMessage).toHaveBeenCalledWith('saveNote', {
         cardId: 'test-card-123',
         text: 'This is my solution using two pointers approach',
       });
@@ -132,8 +123,7 @@ describe('useSaveNoteMutation', () => {
     result.current.mutate(noteText);
 
     await waitFor(() => {
-      expect(sendMessage).toHaveBeenCalledWith({
-        type: MessageType.SAVE_NOTE,
+      expect(sendMessage).toHaveBeenCalledWith('saveNote', {
         cardId: 'test-card-456',
         text: '',
       });
@@ -153,8 +143,7 @@ describe('useSaveNoteMutation', () => {
     result.current.mutate(noteText);
 
     await waitFor(() => {
-      expect(sendMessage).toHaveBeenCalledWith({
-        type: MessageType.SAVE_NOTE,
+      expect(sendMessage).toHaveBeenCalledWith('saveNote', {
         cardId: 'test-card-789',
         text: noteText,
       });
@@ -210,8 +199,7 @@ describe('useDeleteNoteMutation', () => {
     result.current.mutate();
 
     await waitFor(() => {
-      expect(sendMessage).toHaveBeenCalledWith({
-        type: MessageType.DELETE_NOTE,
+      expect(sendMessage).toHaveBeenCalledWith('deleteNote', {
         cardId: 'test-card-123',
       });
     });
@@ -275,8 +263,7 @@ describe('usePauseCardMutation', () => {
     result.current.mutate({ slug: 'two-sum', paused: true });
 
     await waitFor(() => {
-      expect(sendMessage).toHaveBeenCalledWith({
-        type: MessageType.SET_PAUSE_STATUS,
+      expect(sendMessage).toHaveBeenCalledWith('setPauseStatus', {
         slug: 'two-sum',
         paused: true,
       });
@@ -305,8 +292,7 @@ describe('usePauseCardMutation', () => {
     result.current.mutate({ slug: 'three-sum', paused: false });
 
     await waitFor(() => {
-      expect(sendMessage).toHaveBeenCalledWith({
-        type: MessageType.SET_PAUSE_STATUS,
+      expect(sendMessage).toHaveBeenCalledWith('setPauseStatus', {
         slug: 'three-sum',
         paused: false,
       });

--- a/hooks/useBackgroundQueries.ts
+++ b/hooks/useBackgroundQueries.ts
@@ -1,7 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import type { Card, ProblemDescriptor, RateCardInput } from '@/shared/cards';
 import type { GistSyncConfig } from '@/shared/gist-sync';
-import { MessageType, sendMessage } from '@/shared/messages';
+import { sendMessage } from '@/shared/messages';
 import type { Language, Theme } from '@/shared/settings';
 
 // Query Keys with hierarchical structure
@@ -48,7 +48,7 @@ export const queryKeys = {
 export function useCardsQuery() {
   return useQuery({
     queryKey: queryKeys.cards.all,
-    queryFn: () => sendMessage({ type: MessageType.GET_ALL_CARDS }),
+    queryFn: () => sendMessage('getAllCards'),
   });
 }
 
@@ -56,7 +56,7 @@ export function useReviewQueueQuery(options?: { enabled?: boolean; refetchOnWind
   const { enabled = true, refetchOnWindowFocus = false } = options || {};
   return useQuery({
     queryKey: queryKeys.cards.reviewQueue,
-    queryFn: () => sendMessage({ type: MessageType.GET_REVIEW_QUEUE }),
+    queryFn: () => sendMessage('getReviewQueue'),
     enabled,
     staleTime: 0,
     gcTime: 0,
@@ -67,35 +67,35 @@ export function useReviewQueueQuery(options?: { enabled?: boolean; refetchOnWind
 export function useTodayStatsQuery() {
   return useQuery({
     queryKey: queryKeys.stats.today,
-    queryFn: () => sendMessage({ type: MessageType.GET_TODAY_STATS }),
+    queryFn: () => sendMessage('getTodayStats'),
   });
 }
 
 export function useCardStateStatsQuery() {
   return useQuery({
     queryKey: queryKeys.stats.cardState,
-    queryFn: () => sendMessage({ type: MessageType.GET_CARD_STATE_STATS }),
+    queryFn: () => sendMessage('getCardStateStats'),
   });
 }
 
 export function useLastNDaysStatsQuery(days: number) {
   return useQuery({
     queryKey: queryKeys.stats.lastNDays(days),
-    queryFn: () => sendMessage({ type: MessageType.GET_LAST_N_DAYS_STATS, days }),
+    queryFn: () => sendMessage('getLastNDaysStats', { days }),
   });
 }
 
 export function useNextNDaysStatsQuery(days: number) {
   return useQuery({
     queryKey: queryKeys.stats.nextNDays(days),
-    queryFn: () => sendMessage({ type: MessageType.GET_NEXT_N_DAYS_STATS, days }),
+    queryFn: () => sendMessage('getNextNDaysStats', { days }),
   });
 }
 
 export function useNoteQuery(cardId: string) {
   return useQuery({
     queryKey: queryKeys.notes.detail(cardId),
-    queryFn: () => sendMessage({ type: MessageType.GET_NOTE, cardId }),
+    queryFn: () => sendMessage('getNote', { cardId }),
     staleTime: 1000 * 60 * 5, // 5 minutes
   });
 }
@@ -105,7 +105,7 @@ export function useAddCardMutation() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: (problem: ProblemDescriptor) => sendMessage({ type: MessageType.ADD_CARD, problem }),
+    mutationFn: (problem: ProblemDescriptor) => sendMessage('addCard', { problem }),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: queryKeys.cards.all });
       queryClient.invalidateQueries({ queryKey: queryKeys.stats.all });
@@ -117,7 +117,7 @@ export function useRemoveCardMutation() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: (slug: string) => sendMessage({ type: MessageType.REMOVE_CARD, slug }),
+    mutationFn: (slug: string) => sendMessage('removeCard', { slug }),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: queryKeys.cards.all });
       queryClient.invalidateQueries({ queryKey: queryKeys.stats.all });
@@ -129,7 +129,7 @@ export function useRateCardMutation() {
   const queryClient = useQueryClient();
 
   return useMutation<{ card: Card; shouldRequeue: boolean }, Error, RateCardInput>({
-    mutationFn: (input) => sendMessage({ type: MessageType.RATE_CARD, input }),
+    mutationFn: (input) => sendMessage('rateCard', { input }),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: queryKeys.cards.all });
       queryClient.invalidateQueries({ queryKey: queryKeys.stats.all });
@@ -141,7 +141,7 @@ export function useSaveNoteMutation(cardId: string) {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: (text: string) => sendMessage({ type: MessageType.SAVE_NOTE, cardId, text }),
+    mutationFn: (text: string) => sendMessage('saveNote', { cardId, text }),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: queryKeys.notes.detail(cardId) });
     },
@@ -152,7 +152,7 @@ export function useDeleteNoteMutation(cardId: string) {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: () => sendMessage({ type: MessageType.DELETE_NOTE, cardId }),
+    mutationFn: () => sendMessage('deleteNote', { cardId }),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: queryKeys.notes.detail(cardId) });
     },
@@ -170,7 +170,7 @@ export function useDelayCardMutation() {
       days: number;
     }
   >({
-    mutationFn: ({ slug, days }) => sendMessage({ type: MessageType.DELAY_CARD, slug, days }),
+    mutationFn: ({ slug, days }) => sendMessage('delayCard', { slug, days }),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: queryKeys.cards.all });
     },
@@ -188,7 +188,7 @@ export function usePauseCardMutation() {
       paused: boolean;
     }
   >({
-    mutationFn: ({ slug, paused }) => sendMessage({ type: MessageType.SET_PAUSE_STATUS, slug, paused }),
+    mutationFn: ({ slug, paused }) => sendMessage('setPauseStatus', { slug, paused }),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: queryKeys.cards.all });
     },
@@ -198,7 +198,7 @@ export function usePauseCardMutation() {
 export function useMaxNewCardsPerDayQuery() {
   return useQuery({
     queryKey: queryKeys.settings.maxNewCardsPerDay,
-    queryFn: () => sendMessage({ type: MessageType.GET_MAX_NEW_CARDS_PER_DAY }),
+    queryFn: () => sendMessage('getMaxNewCardsPerDay'),
   });
 }
 
@@ -206,7 +206,7 @@ export function useSetMaxNewCardsPerDayMutation() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: (value: number) => sendMessage({ type: MessageType.SET_MAX_NEW_CARDS_PER_DAY, value }),
+    mutationFn: (value: number) => sendMessage('setMaxNewCardsPerDay', { value }),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: queryKeys.settings.maxNewCardsPerDay });
       queryClient.invalidateQueries({ queryKey: queryKeys.cards.reviewQueue });
@@ -217,7 +217,7 @@ export function useSetMaxNewCardsPerDayMutation() {
 export function useDayStartHourQuery() {
   return useQuery({
     queryKey: queryKeys.settings.dayStartHour,
-    queryFn: () => sendMessage({ type: MessageType.GET_DAY_START_HOUR }),
+    queryFn: () => sendMessage('getDayStartHour'),
   });
 }
 
@@ -225,7 +225,7 @@ export function useSetDayStartHourMutation() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: (value: number) => sendMessage({ type: MessageType.SET_DAY_START_HOUR, value }),
+    mutationFn: (value: number) => sendMessage('setDayStartHour', { value }),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: queryKeys.settings.dayStartHour });
       queryClient.invalidateQueries({ queryKey: queryKeys.cards.reviewQueue });
@@ -237,7 +237,7 @@ export function useSetDayStartHourMutation() {
 export function useAnimationsEnabledQuery() {
   return useQuery({
     queryKey: queryKeys.settings.animationsEnabled,
-    queryFn: () => sendMessage({ type: MessageType.GET_ANIMATIONS_ENABLED }),
+    queryFn: () => sendMessage('getAnimationsEnabled'),
   });
 }
 
@@ -245,7 +245,7 @@ export function useSetAnimationsEnabledMutation() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: (value: boolean) => sendMessage({ type: MessageType.SET_ANIMATIONS_ENABLED, value }),
+    mutationFn: (value: boolean) => sendMessage('setAnimationsEnabled', { value }),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: queryKeys.settings.animationsEnabled });
     },
@@ -255,7 +255,7 @@ export function useSetAnimationsEnabledMutation() {
 export function useThemeQuery() {
   return useQuery({
     queryKey: queryKeys.settings.theme,
-    queryFn: () => sendMessage({ type: MessageType.GET_THEME }),
+    queryFn: () => sendMessage('getTheme'),
   });
 }
 
@@ -263,7 +263,7 @@ export function useSetThemeMutation() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: (value: Theme) => sendMessage({ type: MessageType.SET_THEME, value }),
+    mutationFn: (value: Theme) => sendMessage('setTheme', { value }),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: queryKeys.settings.theme });
     },
@@ -273,7 +273,7 @@ export function useSetThemeMutation() {
 export function useResetEditorOnEveryProblemQuery() {
   return useQuery({
     queryKey: queryKeys.settings.resetEditorOnEveryProblem,
-    queryFn: () => sendMessage({ type: MessageType.GET_RESET_EDITOR_ON_EVERY_PROBLEM }),
+    queryFn: () => sendMessage('getResetEditorOnEveryProblem'),
   });
 }
 
@@ -281,7 +281,7 @@ export function useSetResetEditorOnEveryProblemMutation() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: (value: boolean) => sendMessage({ type: MessageType.SET_RESET_EDITOR_ON_EVERY_PROBLEM, value }),
+    mutationFn: (value: boolean) => sendMessage('setResetEditorOnEveryProblem', { value }),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: queryKeys.settings.resetEditorOnEveryProblem });
     },
@@ -291,7 +291,7 @@ export function useSetResetEditorOnEveryProblemMutation() {
 export function useResetEditorOnDueReviewQuery() {
   return useQuery({
     queryKey: queryKeys.settings.resetEditorOnDueReview,
-    queryFn: () => sendMessage({ type: MessageType.GET_RESET_EDITOR_ON_DUE_REVIEW }),
+    queryFn: () => sendMessage('getResetEditorOnDueReview'),
   });
 }
 
@@ -299,7 +299,7 @@ export function useSetResetEditorOnDueReviewMutation() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: (value: boolean) => sendMessage({ type: MessageType.SET_RESET_EDITOR_ON_DUE_REVIEW, value }),
+    mutationFn: (value: boolean) => sendMessage('setResetEditorOnDueReview', { value }),
     onSuccess: () => queryClient.invalidateQueries({ queryKey: queryKeys.settings.resetEditorOnDueReview }),
   });
 }
@@ -307,7 +307,7 @@ export function useSetResetEditorOnDueReviewMutation() {
 export function useBadgeEnabledQuery() {
   return useQuery({
     queryKey: queryKeys.settings.badgeEnabled,
-    queryFn: () => sendMessage({ type: MessageType.GET_BADGE_ENABLED }),
+    queryFn: () => sendMessage('getBadgeEnabled'),
   });
 }
 
@@ -315,7 +315,7 @@ export function useSetBadgeEnabledMutation() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: (value: boolean) => sendMessage({ type: MessageType.SET_BADGE_ENABLED, value }),
+    mutationFn: (value: boolean) => sendMessage('setBadgeEnabled', { value }),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: queryKeys.settings.badgeEnabled });
     },
@@ -325,7 +325,7 @@ export function useSetBadgeEnabledMutation() {
 export function useLanguageQuery() {
   return useQuery({
     queryKey: queryKeys.settings.language,
-    queryFn: () => sendMessage({ type: MessageType.GET_LANGUAGE }),
+    queryFn: () => sendMessage('getLanguage'),
   });
 }
 
@@ -333,7 +333,7 @@ export function useSetLanguageMutation() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: (value: Language) => sendMessage({ type: MessageType.SET_LANGUAGE, value }),
+    mutationFn: (value: Language) => sendMessage('setLanguage', { value }),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: queryKeys.settings.language });
     },
@@ -343,7 +343,7 @@ export function useSetLanguageMutation() {
 // Import/Export mutations
 export function useExportDataMutation() {
   return useMutation({
-    mutationFn: () => sendMessage({ type: MessageType.EXPORT_DATA }),
+    mutationFn: () => sendMessage('exportData'),
   });
 }
 
@@ -351,7 +351,7 @@ export function useImportDataMutation() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: (jsonData: string) => sendMessage({ type: MessageType.IMPORT_DATA, jsonData }),
+    mutationFn: (jsonData: string) => sendMessage('importData', { jsonData }),
     onSuccess: () => {
       queryClient.invalidateQueries();
     },
@@ -362,7 +362,7 @@ export function useResetAllDataMutation() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: () => sendMessage({ type: MessageType.RESET_ALL_DATA }),
+    mutationFn: () => sendMessage('resetAllData'),
     onSuccess: () => {
       queryClient.invalidateQueries();
     },
@@ -373,14 +373,14 @@ export function useResetAllDataMutation() {
 export function useGistSyncConfigQuery() {
   return useQuery({
     queryKey: queryKeys.gistSync.config,
-    queryFn: () => sendMessage({ type: MessageType.GET_GIST_SYNC_CONFIG }),
+    queryFn: () => sendMessage('getGistSyncConfig'),
   });
 }
 
 export function useGistSyncStatusQuery() {
   return useQuery({
     queryKey: queryKeys.gistSync.status,
-    queryFn: () => sendMessage({ type: MessageType.GET_GIST_SYNC_STATUS }),
+    queryFn: () => sendMessage('getGistSyncStatus'),
     refetchInterval: 15000,
   });
 }
@@ -389,7 +389,7 @@ export function useSetGistSyncConfigMutation() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: (config: Partial<GistSyncConfig>) => sendMessage({ type: MessageType.SET_GIST_SYNC_CONFIG, config }),
+    mutationFn: (config: Partial<GistSyncConfig>) => sendMessage('setGistSyncConfig', { config }),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: queryKeys.gistSync.config });
     },
@@ -400,7 +400,7 @@ export function useTriggerGistSyncMutation() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: () => sendMessage({ type: MessageType.TRIGGER_GIST_SYNC }),
+    mutationFn: () => sendMessage('triggerGistSync'),
     onSuccess: () => {
       queryClient.invalidateQueries();
     },
@@ -411,7 +411,7 @@ export function useCreateNewGistMutation() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: () => sendMessage({ type: MessageType.CREATE_NEW_GIST }),
+    mutationFn: () => sendMessage('createNewGist'),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: queryKeys.gistSync.all });
     },
@@ -420,13 +420,12 @@ export function useCreateNewGistMutation() {
 
 export function useValidatePatMutation() {
   return useMutation({
-    mutationFn: (pat: string) => sendMessage({ type: MessageType.VALIDATE_PAT, pat }),
+    mutationFn: (pat: string) => sendMessage('validatePat', { pat }),
   });
 }
 
 export function useValidateGistIdMutation() {
   return useMutation({
-    mutationFn: ({ gistId, pat }: { gistId: string; pat: string }) =>
-      sendMessage({ type: MessageType.VALIDATE_GIST_ID, gistId, pat }),
+    mutationFn: ({ gistId, pat }: { gistId: string; pat: string }) => sendMessage('validateGistId', { gistId, pat }),
   });
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@tailwindcss/vite": "^4.1.11",
         "@tanstack/react-query": "^5.84.1",
         "@tanstack/react-query-devtools": "^5.84.1",
+        "@webext-core/messaging": "^4.0.0",
         "chart.js": "^4.5.0",
         "octokit": "^5.0.5",
         "react": "^19.1.0",
@@ -157,6 +158,12 @@
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
       }
+    },
+    "node_modules/@aklinker1/zero-serialize-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@aklinker1/zero-serialize-error/-/zero-serialize-error-1.0.2.tgz",
+      "integrity": "sha512-hGVkgFqb8Zs80JJ7MOSCGQXH2SyWfwnJwOl8Qpp1lUdkp5T7GTf8QrAMib42Hnzx6HtnNYdmNaSSg4MQy+MDRQ==",
+      "license": "MIT"
     },
     "node_modules/@aklinker1/zero-zip": {
       "version": "1.0.1",
@@ -2459,6 +2466,26 @@
       "license": "MIT",
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/@webext-core/messaging": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@webext-core/messaging/-/messaging-4.0.0.tgz",
+      "integrity": "sha512-1GWLsiWeIRJ/LpSlI87jU3e4KCDhyTadQEwyhMlLSwXOt5/ui2xkVcE96/clxjxqp/FcUBA00c5iT5I3crjlTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@aklinker1/zero-serialize-error": "^1.0.2"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "peerDependencies": {
+        "@types/chrome": "*"
+      },
+      "peerDependenciesMeta": {
+        "@types/chrome": {
+          "optional": true
+        }
       }
     },
     "node_modules/@wxt-dev/browser": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@tailwindcss/vite": "^4.1.11",
     "@tanstack/react-query": "^5.84.1",
     "@tanstack/react-query-devtools": "^5.84.1",
+    "@webext-core/messaging": "^4.0.0",
     "chart.js": "^4.5.0",
     "octokit": "^5.0.5",
     "react": "^19.1.0",

--- a/shared/messages.ts
+++ b/shared/messages.ts
@@ -1,5 +1,5 @@
+import { defineExtensionMessaging } from '@webext-core/messaging';
 import type { State as FsrsState } from 'ts-fsrs';
-import { browser } from 'wxt/browser';
 import type { DailyStats, UpcomingReviewStats } from '@/services/stats';
 import type { Card, LeetcodeDomain, ProblemDescriptor, RateCardInput } from '@/shared/cards';
 import type {
@@ -12,149 +12,49 @@ import type {
 import type { Note } from '@/shared/notes';
 import type { Language, Theme } from '@/shared/settings';
 
-// Message type constants
-export const MessageType = {
-  PING: 'PING',
-  ADD_CARD: 'ADD_CARD',
-  GET_ALL_CARDS: 'GET_ALL_CARDS',
-  REMOVE_CARD: 'REMOVE_CARD',
-  DELAY_CARD: 'DELAY_CARD',
-  SET_PAUSE_STATUS: 'SET_PAUSE_STATUS',
-  RATE_CARD: 'RATE_CARD',
-  GET_REVIEW_QUEUE: 'GET_REVIEW_QUEUE',
-  GET_TODAY_STATS: 'GET_TODAY_STATS',
-  GET_NOTE: 'GET_NOTE',
-  SAVE_NOTE: 'SAVE_NOTE',
-  DELETE_NOTE: 'DELETE_NOTE',
-  GET_MAX_NEW_CARDS_PER_DAY: 'GET_MAX_NEW_CARDS_PER_DAY',
-  SET_MAX_NEW_CARDS_PER_DAY: 'SET_MAX_NEW_CARDS_PER_DAY',
-  GET_DAY_START_HOUR: 'GET_DAY_START_HOUR',
-  SET_DAY_START_HOUR: 'SET_DAY_START_HOUR',
-  GET_ANIMATIONS_ENABLED: 'GET_ANIMATIONS_ENABLED',
-  SET_ANIMATIONS_ENABLED: 'SET_ANIMATIONS_ENABLED',
-  GET_THEME: 'GET_THEME',
-  SET_THEME: 'SET_THEME',
-  GET_RESET_EDITOR_ON_EVERY_PROBLEM: 'GET_RESET_EDITOR_ON_EVERY_PROBLEM',
-  SET_RESET_EDITOR_ON_EVERY_PROBLEM: 'SET_RESET_EDITOR_ON_EVERY_PROBLEM',
-  GET_RESET_EDITOR_ON_DUE_REVIEW: 'GET_RESET_EDITOR_ON_DUE_REVIEW',
-  SET_RESET_EDITOR_ON_DUE_REVIEW: 'SET_RESET_EDITOR_ON_DUE_REVIEW',
-  SHOULD_RESET_EDITOR: 'SHOULD_RESET_EDITOR',
-  GET_BADGE_ENABLED: 'GET_BADGE_ENABLED',
-  SET_BADGE_ENABLED: 'SET_BADGE_ENABLED',
-  GET_LANGUAGE: 'GET_LANGUAGE',
-  SET_LANGUAGE: 'SET_LANGUAGE',
-  GET_CARD_STATE_STATS: 'GET_CARD_STATE_STATS',
-  GET_LAST_N_DAYS_STATS: 'GET_LAST_N_DAYS_STATS',
-  GET_NEXT_N_DAYS_STATS: 'GET_NEXT_N_DAYS_STATS',
-  EXPORT_DATA: 'EXPORT_DATA',
-  IMPORT_DATA: 'IMPORT_DATA',
-  RESET_ALL_DATA: 'RESET_ALL_DATA',
-  // GitHub Gist Sync
-  GET_GIST_SYNC_CONFIG: 'GET_GIST_SYNC_CONFIG',
-  SET_GIST_SYNC_CONFIG: 'SET_GIST_SYNC_CONFIG',
-  GET_GIST_SYNC_STATUS: 'GET_GIST_SYNC_STATUS',
-  TRIGGER_GIST_SYNC: 'TRIGGER_GIST_SYNC',
-  CREATE_NEW_GIST: 'CREATE_NEW_GIST',
-  VALIDATE_PAT: 'VALIDATE_PAT',
-  VALIDATE_GIST_ID: 'VALIDATE_GIST_ID',
-} as const;
-
-// Message request types as discriminated union
-export type MessageRequest =
-  | { type: typeof MessageType.PING }
-  | { type: typeof MessageType.ADD_CARD; problem: ProblemDescriptor }
-  | { type: typeof MessageType.GET_ALL_CARDS }
-  | { type: typeof MessageType.REMOVE_CARD; slug: string }
-  | { type: typeof MessageType.DELAY_CARD; slug: string; days: number }
-  | { type: typeof MessageType.SET_PAUSE_STATUS; slug: string; paused: boolean }
-  | { type: typeof MessageType.RATE_CARD; input: RateCardInput }
-  | { type: typeof MessageType.GET_REVIEW_QUEUE }
-  | { type: typeof MessageType.GET_TODAY_STATS }
-  | { type: typeof MessageType.GET_NOTE; cardId: string }
-  | { type: typeof MessageType.SAVE_NOTE; cardId: string; text: string }
-  | { type: typeof MessageType.DELETE_NOTE; cardId: string }
-  | { type: typeof MessageType.GET_MAX_NEW_CARDS_PER_DAY }
-  | { type: typeof MessageType.SET_MAX_NEW_CARDS_PER_DAY; value: number }
-  | { type: typeof MessageType.GET_DAY_START_HOUR }
-  | { type: typeof MessageType.SET_DAY_START_HOUR; value: number }
-  | { type: typeof MessageType.GET_ANIMATIONS_ENABLED }
-  | { type: typeof MessageType.SET_ANIMATIONS_ENABLED; value: boolean }
-  | { type: typeof MessageType.GET_THEME }
-  | { type: typeof MessageType.SET_THEME; value: Theme }
-  | { type: typeof MessageType.GET_RESET_EDITOR_ON_EVERY_PROBLEM }
-  | { type: typeof MessageType.SET_RESET_EDITOR_ON_EVERY_PROBLEM; value: boolean }
-  | { type: typeof MessageType.GET_RESET_EDITOR_ON_DUE_REVIEW }
-  | { type: typeof MessageType.SET_RESET_EDITOR_ON_DUE_REVIEW; value: boolean }
-  | { type: typeof MessageType.SHOULD_RESET_EDITOR; slug: string; domain: LeetcodeDomain }
-  | { type: typeof MessageType.GET_BADGE_ENABLED }
-  | { type: typeof MessageType.SET_BADGE_ENABLED; value: boolean }
-  | { type: typeof MessageType.GET_LANGUAGE }
-  | { type: typeof MessageType.SET_LANGUAGE; value: Language }
-  | { type: typeof MessageType.GET_CARD_STATE_STATS }
-  | { type: typeof MessageType.GET_LAST_N_DAYS_STATS; days: number }
-  | { type: typeof MessageType.GET_NEXT_N_DAYS_STATS; days: number }
-  | { type: typeof MessageType.EXPORT_DATA }
-  | { type: typeof MessageType.IMPORT_DATA; jsonData: string }
-  | { type: typeof MessageType.RESET_ALL_DATA }
-  // GitHub Gist Sync
-  | { type: typeof MessageType.GET_GIST_SYNC_CONFIG }
-  | { type: typeof MessageType.SET_GIST_SYNC_CONFIG; config: Partial<GistSyncConfig> }
-  | { type: typeof MessageType.GET_GIST_SYNC_STATUS }
-  | { type: typeof MessageType.TRIGGER_GIST_SYNC }
-  | { type: typeof MessageType.CREATE_NEW_GIST }
-  | { type: typeof MessageType.VALIDATE_PAT; pat: string }
-  | { type: typeof MessageType.VALIDATE_GIST_ID; gistId: string; pat: string };
-
-// Type mapping for request to response
-export type MessageResponseMap = {
-  [MessageType.PING]: 'PONG';
-  [MessageType.ADD_CARD]: Card;
-  [MessageType.GET_ALL_CARDS]: Card[];
-  [MessageType.REMOVE_CARD]: undefined;
-  [MessageType.DELAY_CARD]: Card;
-  [MessageType.SET_PAUSE_STATUS]: Card;
-  [MessageType.RATE_CARD]: { card: Card; shouldRequeue: boolean };
-  [MessageType.GET_REVIEW_QUEUE]: Card[];
-  [MessageType.GET_TODAY_STATS]: DailyStats | null;
-  [MessageType.GET_NOTE]: Note | null;
-  [MessageType.SAVE_NOTE]: undefined;
-  [MessageType.DELETE_NOTE]: undefined;
-  [MessageType.GET_MAX_NEW_CARDS_PER_DAY]: number;
-  [MessageType.SET_MAX_NEW_CARDS_PER_DAY]: undefined;
-  [MessageType.GET_DAY_START_HOUR]: number;
-  [MessageType.SET_DAY_START_HOUR]: undefined;
-  [MessageType.GET_ANIMATIONS_ENABLED]: boolean;
-  [MessageType.SET_ANIMATIONS_ENABLED]: undefined;
-  [MessageType.GET_THEME]: Theme;
-  [MessageType.SET_THEME]: undefined;
-  [MessageType.GET_RESET_EDITOR_ON_EVERY_PROBLEM]: boolean;
-  [MessageType.SET_RESET_EDITOR_ON_EVERY_PROBLEM]: undefined;
-  [MessageType.GET_RESET_EDITOR_ON_DUE_REVIEW]: boolean;
-  [MessageType.SET_RESET_EDITOR_ON_DUE_REVIEW]: undefined;
-  [MessageType.SHOULD_RESET_EDITOR]: boolean;
-  [MessageType.GET_BADGE_ENABLED]: boolean;
-  [MessageType.SET_BADGE_ENABLED]: undefined;
-  [MessageType.GET_LANGUAGE]: Language;
-  [MessageType.SET_LANGUAGE]: undefined;
-  [MessageType.GET_CARD_STATE_STATS]: Record<FsrsState, number>;
-  [MessageType.GET_LAST_N_DAYS_STATS]: DailyStats[];
-  [MessageType.GET_NEXT_N_DAYS_STATS]: UpcomingReviewStats[];
-  [MessageType.EXPORT_DATA]: string;
-  [MessageType.IMPORT_DATA]: undefined;
-  [MessageType.RESET_ALL_DATA]: undefined;
-  // GitHub Gist Sync
-  [MessageType.GET_GIST_SYNC_CONFIG]: GistSyncConfig;
-  [MessageType.SET_GIST_SYNC_CONFIG]: undefined;
-  [MessageType.GET_GIST_SYNC_STATUS]: GistSyncStatus;
-  [MessageType.TRIGGER_GIST_SYNC]: SyncResult;
-  [MessageType.CREATE_NEW_GIST]: { gistId: string };
-  [MessageType.VALIDATE_PAT]: PatValidationResult;
-  [MessageType.VALIDATE_GIST_ID]: GistValidationResult;
-};
-
-/**
- * Type-safe wrapper for sending messages to the background script
- */
-export async function sendMessage<T extends MessageRequest>(message: T): Promise<MessageResponseMap[T['type']]> {
-  return browser.runtime.sendMessage(message);
+export interface ExtensionProtocolMap {
+  ping(): 'PONG';
+  addCard(data: { problem: ProblemDescriptor }): Card;
+  getAllCards(): Card[];
+  removeCard(data: { slug: string }): void;
+  delayCard(data: { slug: string; days: number }): Card;
+  setPauseStatus(data: { slug: string; paused: boolean }): Card;
+  rateCard(data: { input: RateCardInput }): { card: Card; shouldRequeue: boolean };
+  getReviewQueue(): Card[];
+  getTodayStats(): DailyStats | null;
+  getNote(data: { cardId: string }): Note | null;
+  saveNote(data: { cardId: string; text: string }): void;
+  deleteNote(data: { cardId: string }): void;
+  getMaxNewCardsPerDay(): number;
+  setMaxNewCardsPerDay(data: { value: number }): void;
+  getDayStartHour(): number;
+  setDayStartHour(data: { value: number }): void;
+  getAnimationsEnabled(): boolean;
+  setAnimationsEnabled(data: { value: boolean }): void;
+  getTheme(): Theme;
+  setTheme(data: { value: Theme }): void;
+  getResetEditorOnEveryProblem(): boolean;
+  setResetEditorOnEveryProblem(data: { value: boolean }): void;
+  getResetEditorOnDueReview(): boolean;
+  setResetEditorOnDueReview(data: { value: boolean }): void;
+  shouldResetEditor(data: { slug: string; domain: LeetcodeDomain }): boolean;
+  getBadgeEnabled(): boolean;
+  setBadgeEnabled(data: { value: boolean }): void;
+  getLanguage(): Language;
+  setLanguage(data: { value: Language }): void;
+  getCardStateStats(): Record<FsrsState, number>;
+  getLastNDaysStats(data: { days: number }): DailyStats[];
+  getNextNDaysStats(data: { days: number }): UpcomingReviewStats[];
+  exportData(): string;
+  importData(data: { jsonData: string }): void;
+  resetAllData(): void;
+  getGistSyncConfig(): GistSyncConfig;
+  setGistSyncConfig(data: { config: Partial<GistSyncConfig> }): void;
+  getGistSyncStatus(): GistSyncStatus;
+  triggerGistSync(): SyncResult;
+  createNewGist(): { gistId: string };
+  validatePat(data: { pat: string }): PatValidationResult;
+  validateGistId(data: { gistId: string; pat: string }): GistValidationResult;
 }
+
+export const { onMessage, sendMessage } = defineExtensionMessaging<ExtensionProtocolMap>();

--- a/utils/content/__tests__/auto-reset.test.ts
+++ b/utils/content/__tests__/auto-reset.test.ts
@@ -152,8 +152,7 @@ describe('setupLeetcodeAutoReset', () => {
     dispose = setupLeetcodeAutoReset();
     await vi.advanceTimersByTimeAsync(0);
 
-    expect(sendMessage).toHaveBeenCalledWith({
-      type: 'SHOULD_RESET_EDITOR',
+    expect(sendMessage).toHaveBeenCalledWith('shouldResetEditor', {
       slug: 'two-sum',
       domain: 'leetcode.com',
     });

--- a/utils/content/auto-reset.ts
+++ b/utils/content/auto-reset.ts
@@ -1,4 +1,4 @@
-import { MessageType, sendMessage } from '@/shared/messages';
+import { sendMessage } from '@/shared/messages';
 import { getCurrentDomain, getCurrentProblemSlug } from './domain';
 
 const RESET_CONFIRM_TIMEOUT_MS = 2000;
@@ -57,8 +57,7 @@ export function setupLeetcodeAutoReset(): () => void {
 
     isResetting = true;
     try {
-      const shouldReset = await sendMessage({
-        type: MessageType.SHOULD_RESET_EDITOR,
+      const shouldReset = await sendMessage('shouldResetEditor', {
         slug,
         domain: getCurrentDomain(),
       });


### PR DESCRIPTION
Closes #136.

Replaces the custom typed message bus with `@webext-core/messaging` across the background, popup, and content script. Preserves typed request/response behavior and updates the messaging tests and repository guidance.

Tests: `npm run check`, `npm run build`