### PR TITLE
refactor: replace deprecated selectedKey usage

### DIFF
--- a/entrypoints/popup/components/BottomNav.tsx
+++ b/entrypoints/popup/components/BottomNav.tsx
@@ -1,4 +1,4 @@
-import { Tab, TabList, Tabs } from 'react-aria-components';
+import { ToggleButton, ToggleButtonGroup } from 'react-aria-components';
 import { FaChartSimple, FaCode, FaGear, FaHouseChimney } from 'react-icons/fa6';
 import { useReviewQueueQuery } from '@/hooks/queries/cards';
 import { useI18n } from '../contexts/I18nContext';
@@ -24,36 +24,39 @@ export function BottomNav({ activeView, onNavigate }: BottomNavProps) {
 
   return (
     <nav className="fixed bottom-0 left-0 right-0 h-14 border-t flex justify-around items-center z-[1000] bg-secondary border-current">
-      <Tabs
-        selectedKey={activeView}
-        onSelectionChange={(key) => onNavigate(key as ViewId)}
+      <ToggleButtonGroup
+        selectionMode="single"
+        disallowEmptySelection
+        selectedKeys={[activeView]}
+        onSelectionChange={(keys) => {
+          const selectedView = [...keys][0];
+          if (selectedView) onNavigate(selectedView as ViewId);
+        }}
         className="flex justify-around items-center w-full h-full"
       >
-        <TabList className="flex justify-around items-center w-full h-full">
-          {navItems.map((item) => (
-            <Tab
-              key={item.id}
-              id={item.id}
-              className={({ isSelected }) =>
-                `flex flex-col items-center gap-1 bg-transparent border-none cursor-pointer p-2 transition-colors duration-200 hover:text-primary ${
-                  isSelected ? 'text-accent' : 'text-secondary'
-                }`
-              }
-              aria-label={item.label}
-            >
-              <div className="relative">
-                <item.Icon className="text-lg" />
-                {item.id === 'home' && dueCount > 0 && (
-                  <span className="absolute -top-1 -right-2 bg-red-500 text-white text-[9px] min-w-[14px] h-3.5 rounded-full flex items-center justify-center px-0.5">
-                    {dueCount > 99 ? '99+' : dueCount}
-                  </span>
-                )}
-              </div>
-              <span className="text-[11px]">{item.label}</span>
-            </Tab>
-          ))}
-        </TabList>
-      </Tabs>
+        {navItems.map((item) => (
+          <ToggleButton
+            key={item.id}
+            id={item.id}
+            className={({ isSelected }) =>
+              `flex flex-col items-center gap-1 bg-transparent border-none cursor-pointer p-2 transition-colors duration-200 hover:text-primary ${
+                isSelected ? 'text-accent' : 'text-secondary'
+              }`
+            }
+            aria-label={item.label}
+          >
+            <div className="relative">
+              <item.Icon className="text-lg" />
+              {item.id === 'home' && dueCount > 0 && (
+                <span className="absolute -top-1 -right-2 bg-red-500 text-white text-[9px] min-w-[14px] h-3.5 rounded-full flex items-center justify-center px-0.5">
+                  {dueCount > 99 ? '99+' : dueCount}
+                </span>
+              )}
+            </div>
+            <span className="text-[11px]">{item.label}</span>
+          </ToggleButton>
+        ))}
+      </ToggleButtonGroup>
     </nav>
   );
 }

--- a/entrypoints/popup/components/BottomNav.tsx
+++ b/entrypoints/popup/components/BottomNav.tsx
@@ -38,6 +38,9 @@ export function BottomNav({ activeView, onNavigate }: BottomNavProps) {
           <ToggleButton
             key={item.id}
             id={item.id}
+            onFocus={() => {
+              if (item.id !== activeView) onNavigate(item.id);
+            }}
             className={({ isSelected }) =>
               `flex flex-col items-center gap-1 bg-transparent border-none cursor-pointer p-2 transition-colors duration-200 hover:text-primary ${
                 isSelected ? 'text-accent' : 'text-secondary'

--- a/entrypoints/popup/components/__tests__/BottomNav.test.tsx
+++ b/entrypoints/popup/components/__tests__/BottomNav.test.tsx
@@ -18,4 +18,19 @@ describe('BottomNav', () => {
 
     expect(onNavigate).toHaveBeenCalledWith('settings');
   });
+
+  it('navigates when arrow keys move focus', () => {
+    const onNavigate = vi.fn();
+    const { wrapper, queryClient } = createTestWrapper();
+    queryClient.setQueryData(cardQueryKeys.reviewQueue, []);
+    render(<BottomNav activeView="home" onNavigate={onNavigate} />, { wrapper });
+    const home = screen.getByRole('radio', { name: 'Home' });
+    const cards = screen.getByRole('radio', { name: 'Cards' });
+    home.focus();
+
+    fireEvent.keyDown(home, { key: 'ArrowRight' });
+
+    expect(cards).toHaveFocus();
+    expect(onNavigate).toHaveBeenCalledWith('card');
+  });
 });

--- a/entrypoints/popup/components/__tests__/BottomNav.test.tsx
+++ b/entrypoints/popup/components/__tests__/BottomNav.test.tsx
@@ -1,0 +1,21 @@
+/** @vitest-environment happy-dom */
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { cardQueryKeys } from '@/hooks/queries/cards';
+import { createTestWrapper } from '@/test/utils/test-wrapper';
+import { BottomNav } from '../BottomNav';
+
+describe('BottomNav', () => {
+  it('shows the active view and navigates to the selected view', () => {
+    const onNavigate = vi.fn();
+    const { wrapper, queryClient } = createTestWrapper();
+    queryClient.setQueryData(cardQueryKeys.reviewQueue, []);
+    render(<BottomNav activeView="home" onNavigate={onNavigate} />, { wrapper });
+
+    expect(screen.getByRole('radio', { name: 'Home' })).toHaveAttribute('aria-checked', 'true');
+
+    fireEvent.click(screen.getByRole('radio', { name: 'Settings' }));
+
+    expect(onNavigate).toHaveBeenCalledWith('settings');
+  });
+});

--- a/entrypoints/popup/views/settings/__tests__/LanguageSection.test.tsx
+++ b/entrypoints/popup/views/settings/__tests__/LanguageSection.test.tsx
@@ -1,0 +1,37 @@
+/** @vitest-environment happy-dom */
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { settingsQueryKeys } from '@/hooks/queries/settings';
+import { sendMessage } from '@/shared/messages';
+import { createMessageMock } from '@/test/utils/message-mocks';
+import { buildSettings } from '@/test/utils/settings-mocks';
+import { createTestWrapper } from '@/test/utils/test-wrapper';
+import { LanguageSection } from '../LanguageSection';
+
+vi.mock('@/shared/messages', () => ({ sendMessage: vi.fn() }));
+
+describe('LanguageSection', () => {
+  const messages = createMessageMock(vi.mocked(sendMessage));
+
+  beforeEach(() => {
+    messages.reset().resolve('updateSettings', undefined);
+  });
+
+  it('shows the current language and persists a new selection', async () => {
+    const { wrapper, queryClient } = createTestWrapper();
+    queryClient.setQueryData(settingsQueryKeys.all, buildSettings({ language: 'en' }));
+    render(<LanguageSection />, { wrapper });
+
+    const languageSelect = screen.getByRole('button', { name: /Display language/ });
+    expect(languageSelect).toHaveTextContent('English');
+
+    fireEvent.click(languageSelect);
+    fireEvent.click(screen.getByRole('option', { name: 'Deutsch' }));
+
+    await waitFor(() =>
+      expect(sendMessage).toHaveBeenCalledWith('updateSettings', {
+        changes: { language: 'de' },
+      })
+    );
+  });
+});


### PR DESCRIPTION
- migrate bottom navigation to the controlled `selectedKeys` API
- cover navigation and persisted language selection behavior
- verify formatting, lint, TypeScript, and tests

Closes #160