### PR TITLE
test: remove redundant implementation-detail tests

### DIFF
--- a/entrypoints/popup/views/home/__tests__/ReviewQueue.test.tsx
+++ b/entrypoints/popup/views/home/__tests__/ReviewQueue.test.tsx
@@ -5,7 +5,7 @@
 import type { QueryClient } from '@tanstack/react-query';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { Rating, State } from 'ts-fsrs';
-import { afterEach, beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
+import { beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
 import { cardQueryKeys } from '@/hooks/queries/cards';
 import { settingsQueryKeys } from '@/hooks/queries/settings';
 import type { Card } from '@/shared/cards';
@@ -15,20 +15,6 @@ import { createMessageMock } from '@/test/utils/message-mocks';
 import { buildSettings } from '@/test/utils/settings-mocks';
 import { createTestWrapper } from '@/test/utils/test-wrapper';
 import { ReviewQueue } from '../ReviewQueue';
-
-// Mock localStorage to disable animations in tests
-const originalLocalStorage = window.localStorage;
-const mockLocalStorage = {
-  getItem: (key: string) => {
-    if (key === 'animationsEnabled') return 'false';
-    return null;
-  },
-  setItem: vi.fn(),
-  removeItem: vi.fn(),
-  clear: vi.fn(),
-  length: 0,
-  key: () => null,
-};
 
 vi.mock('@/shared/messages', () => ({ sendMessage: vi.fn() }));
 
@@ -122,13 +108,6 @@ describe('ReviewQueue', () => {
   const seedQueue = (cards: Card[]) => queryClient.setQueryData(cardQueryKeys.reviewQueue, cards);
 
   beforeEach(() => {
-    // Set up localStorage mock
-    Object.defineProperty(window, 'localStorage', {
-      value: mockLocalStorage,
-      writable: true,
-      configurable: true,
-    });
-
     messages
       .reset()
       .handle('rateCard', mockMutateAsync)
@@ -146,20 +125,7 @@ describe('ReviewQueue', () => {
     mockMutateAsync.mockResolvedValue({ card: mockCards[0], shouldRequeue: false });
   });
 
-  afterEach(() => {
-    Object.defineProperty(window, 'localStorage', {
-      value: originalLocalStorage,
-      writable: true,
-      configurable: true,
-    });
-  });
-
   describe('Empty Queue', () => {
-    it('should have animations disabled in tests', () => {
-      // Verify that localStorage mock returns false for animationsEnabled
-      expect(window.localStorage.getItem('animationsEnabled')).toBe('false');
-    });
-
     it('should show empty state when no cards to review', async () => {
       seedQueue([]);
 

--- a/hooks/queries/__tests__/cards.test.tsx
+++ b/hooks/queries/__tests__/cards.test.tsx
@@ -140,17 +140,20 @@ describe('usePauseCardMutation', () => {
     vi.clearAllMocks();
   });
 
-  it('should call sendMessage with correct parameters when pausing a card', async () => {
+  it.each([
+    ['pausing', 'two-sum', true],
+    ['unpausing', 'three-sum', false],
+  ] as const)('sends the correct message when %s a card', async (_action, slug, paused) => {
     const mockCard: Card = {
       id: 'test-id',
-      slug: 'two-sum',
+      slug,
       name: 'Two Sum',
       leetcodeId: '1',
       difficulty: 'Easy',
       domain: 'leetcode.com',
       createdAt: new Date(),
       fsrs: createEmptyCard(),
-      paused: true,
+      paused,
     };
 
     vi.mocked(sendMessage).mockResolvedValue(mockCard);
@@ -159,78 +162,14 @@ describe('usePauseCardMutation', () => {
       wrapper: createTestWrapper().wrapper,
     });
 
-    result.current.mutate({ slug: 'two-sum', paused: true });
+    result.current.mutate({ slug, paused });
 
     await waitFor(() => {
       expect(sendMessage).toHaveBeenCalledWith('setPauseStatus', {
-        slug: 'two-sum',
-        paused: true,
+        slug,
+        paused,
       });
     });
-  });
-
-  it('should call sendMessage with correct parameters when unpausing a card', async () => {
-    const mockCard: Card = {
-      id: 'test-id',
-      slug: 'three-sum',
-      name: 'Three Sum',
-      leetcodeId: '15',
-      difficulty: 'Medium',
-      domain: 'leetcode.com',
-      createdAt: new Date(),
-      fsrs: createEmptyCard(),
-      paused: false,
-    };
-
-    vi.mocked(sendMessage).mockResolvedValue(mockCard);
-
-    const { result } = renderHook(() => usePauseCardMutation(), {
-      wrapper: createTestWrapper().wrapper,
-    });
-
-    result.current.mutate({ slug: 'three-sum', paused: false });
-
-    await waitFor(() => {
-      expect(sendMessage).toHaveBeenCalledWith('setPauseStatus', {
-        slug: 'three-sum',
-        paused: false,
-      });
-    });
-  });
-
-  it('should invalidate card queries on successful pause', async () => {
-    const mockCard: Card = {
-      id: 'test-id',
-      slug: 'test-problem',
-      name: 'Test Problem',
-      leetcodeId: '999',
-      difficulty: 'Hard',
-      domain: 'leetcode.com',
-      createdAt: new Date(),
-      fsrs: createEmptyCard(),
-      paused: true,
-    };
-
-    const { wrapper, queryClient } = createTestWrapper();
-    const invalidateQueriesSpy = vi.spyOn(queryClient, 'invalidateQueries');
-
-    vi.mocked(sendMessage).mockResolvedValue(mockCard);
-
-    const { result } = renderHook(() => usePauseCardMutation(), {
-      wrapper,
-    });
-
-    result.current.mutate({ slug: 'test-problem', paused: true });
-
-    await waitFor(() => {
-      expect(result.current.isSuccess).toBe(true);
-    });
-
-    expect(invalidateQueriesSpy).toHaveBeenCalledWith({
-      queryKey: cardQueryKeys.all,
-    });
-
-    invalidateQueriesSpy.mockRestore();
   });
 
   it('should handle mutation error properly', async () => {

--- a/hooks/queries/__tests__/notes.test.tsx
+++ b/hooks/queries/__tests__/notes.test.tsx
@@ -17,10 +17,11 @@ describe('useSaveNoteMutation', () => {
     vi.clearAllMocks();
   });
 
-  it('should call sendMessage with correct parameters when mutate is called', async () => {
-    const cardId = 'test-card-123';
-    const noteText = 'This is my solution using two pointers approach';
-
+  it.each([
+    ['ordinary text', 'test-card-123', 'This is my solution using two pointers approach'],
+    ['empty text', 'test-card-456', ''],
+    ['maximum length text', 'test-card-789', 'a'.repeat(500)],
+  ])('sends %s unchanged', async (_case, cardId, noteText) => {
     vi.mocked(sendMessage).mockResolvedValue(undefined);
 
     const { result } = renderHook(() => useSaveNoteMutation(cardId), {
@@ -31,47 +32,7 @@ describe('useSaveNoteMutation', () => {
 
     await waitFor(() => {
       expect(sendMessage).toHaveBeenCalledWith('saveNote', {
-        cardId: 'test-card-123',
-        text: 'This is my solution using two pointers approach',
-      });
-    });
-  });
-
-  it('should handle empty note text', async () => {
-    const cardId = 'test-card-456';
-    const noteText = '';
-
-    vi.mocked(sendMessage).mockResolvedValue(undefined);
-
-    const { result } = renderHook(() => useSaveNoteMutation(cardId), {
-      wrapper: createTestWrapper().wrapper,
-    });
-
-    result.current.mutate(noteText);
-
-    await waitFor(() => {
-      expect(sendMessage).toHaveBeenCalledWith('saveNote', {
-        cardId: 'test-card-456',
-        text: '',
-      });
-    });
-  });
-
-  it('should handle maximum length note text', async () => {
-    const cardId = 'test-card-789';
-    const noteText = 'a'.repeat(500);
-
-    vi.mocked(sendMessage).mockResolvedValue(undefined);
-
-    const { result } = renderHook(() => useSaveNoteMutation(cardId), {
-      wrapper: createTestWrapper().wrapper,
-    });
-
-    result.current.mutate(noteText);
-
-    await waitFor(() => {
-      expect(sendMessage).toHaveBeenCalledWith('saveNote', {
-        cardId: 'test-card-789',
+        cardId,
         text: noteText,
       });
     });


### PR DESCRIPTION
- remove ReviewQueue test scaffolding that only verified its own mock
- table-drive equivalent pause and note mutation cases
- remove duplicate pause invalidation coverage

Closes #179

Tests: `npm test`, `npm run compile`