### PR TITLE
refactor: consolidate query invalidation

### DIFF
--- a/hooks/queries/__tests__/cards.test.tsx
+++ b/hooks/queries/__tests__/cards.test.tsx
@@ -112,21 +112,18 @@ describe('card mutation invalidation', () => {
       );
     };
 
-    await expectInvalidations(
-      () => result.current.add.mutateAsync(problem),
-      [cardQueryKeys.all, statsQueryKeys.cardState, statsQueryKeys.nextNDays.all]
-    );
+    await expectInvalidations(() => result.current.add.mutateAsync(problem), [cardQueryKeys.all, statsQueryKeys.all]);
     await expectInvalidations(
       () => result.current.remove.mutateAsync(problem.slug),
-      [cardQueryKeys.all, statsQueryKeys.cardState, statsQueryKeys.nextNDays.all]
+      [cardQueryKeys.all, statsQueryKeys.all]
     );
     await expectInvalidations(
       () => result.current.delay.mutateAsync({ slug: problem.slug, days: 1 }),
-      [cardQueryKeys.all, statsQueryKeys.nextNDays.all]
+      [cardQueryKeys.all, statsQueryKeys.all]
     );
     await expectInvalidations(
       () => result.current.pause.mutateAsync({ slug: problem.slug, paused: true }),
-      [cardQueryKeys.all, statsQueryKeys.nextNDays.all]
+      [cardQueryKeys.all, statsQueryKeys.all]
     );
     await expectInvalidations(
       () => result.current.rate.mutateAsync({ ...problem, rating: Rating.Good }),

--- a/hooks/queries/__tests__/settings.test.tsx
+++ b/hooks/queries/__tests__/settings.test.tsx
@@ -25,12 +25,6 @@ it('invalidates only the queries affected by each settings change', async () => 
   };
 
   await expectInvalidations({ theme: 'dark' }, [settingsQueryKeys.all]);
-  await expectInvalidations({ maxNewCardsPerDay: 10 }, [settingsQueryKeys.all, cardQueryKeys.reviewQueue]);
-  await expectInvalidations({ dayStartHour: 4 }, [
-    settingsQueryKeys.all,
-    cardQueryKeys.reviewQueue,
-    statsQueryKeys.today,
-    statsQueryKeys.lastNDays.all,
-    statsQueryKeys.nextNDays.all,
-  ]);
+  await expectInvalidations({ maxNewCardsPerDay: 10 }, [settingsQueryKeys.all, cardQueryKeys.all]);
+  await expectInvalidations({ dayStartHour: 4 }, [settingsQueryKeys.all, cardQueryKeys.all, statsQueryKeys.all]);
 });

--- a/hooks/queries/cards.ts
+++ b/hooks/queries/cards.ts
@@ -1,4 +1,4 @@
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { type QueryClient, useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import type { Card, ProblemDescriptor, RateCardInput } from '@/shared/cards';
 import { sendMessage } from '@/shared/messages';
 import { statsQueryKeys } from './stats';
@@ -7,6 +7,11 @@ export const cardQueryKeys = {
   all: ['cards'] as const,
   reviewQueue: ['cards', 'reviewQueue'] as const,
 };
+
+function invalidateCardData(queryClient: QueryClient) {
+  queryClient.invalidateQueries({ queryKey: cardQueryKeys.all });
+  queryClient.invalidateQueries({ queryKey: statsQueryKeys.all });
+}
 
 export function useCardsQuery() {
   return useQuery({
@@ -32,11 +37,7 @@ export function useAddCardMutation() {
 
   return useMutation({
     mutationFn: (problem: ProblemDescriptor) => sendMessage('addCard', { problem }),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: cardQueryKeys.all });
-      queryClient.invalidateQueries({ queryKey: statsQueryKeys.cardState });
-      queryClient.invalidateQueries({ queryKey: statsQueryKeys.nextNDays.all });
-    },
+    onSuccess: () => invalidateCardData(queryClient),
   });
 }
 
@@ -45,11 +46,7 @@ export function useRemoveCardMutation() {
 
   return useMutation({
     mutationFn: (slug: string) => sendMessage('removeCard', { slug }),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: cardQueryKeys.all });
-      queryClient.invalidateQueries({ queryKey: statsQueryKeys.cardState });
-      queryClient.invalidateQueries({ queryKey: statsQueryKeys.nextNDays.all });
-    },
+    onSuccess: () => invalidateCardData(queryClient),
   });
 }
 
@@ -58,10 +55,7 @@ export function useRateCardMutation() {
 
   return useMutation<{ card: Card; shouldRequeue: boolean }, Error, RateCardInput>({
     mutationFn: (input) => sendMessage('rateCard', { input }),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: cardQueryKeys.all });
-      queryClient.invalidateQueries({ queryKey: statsQueryKeys.all });
-    },
+    onSuccess: () => invalidateCardData(queryClient),
   });
 }
 
@@ -77,10 +71,7 @@ export function useDelayCardMutation() {
     }
   >({
     mutationFn: ({ slug, days }) => sendMessage('delayCard', { slug, days }),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: cardQueryKeys.all });
-      queryClient.invalidateQueries({ queryKey: statsQueryKeys.nextNDays.all });
-    },
+    onSuccess: () => invalidateCardData(queryClient),
   });
 }
 
@@ -96,9 +87,6 @@ export function usePauseCardMutation() {
     }
   >({
     mutationFn: ({ slug, paused }) => sendMessage('setPauseStatus', { slug, paused }),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: cardQueryKeys.all });
-      queryClient.invalidateQueries({ queryKey: statsQueryKeys.nextNDays.all });
-    },
+    onSuccess: () => invalidateCardData(queryClient),
   });
 }

--- a/hooks/queries/settings.ts
+++ b/hooks/queries/settings.ts
@@ -24,13 +24,11 @@ export function useUpdateSettingsMutation() {
       queryClient.invalidateQueries({ queryKey: settingsQueryKeys.all });
 
       if ('maxNewCardsPerDay' in changes || 'dayStartHour' in changes) {
-        queryClient.invalidateQueries({ queryKey: cardQueryKeys.reviewQueue });
+        queryClient.invalidateQueries({ queryKey: cardQueryKeys.all });
       }
 
       if ('dayStartHour' in changes) {
-        queryClient.invalidateQueries({ queryKey: statsQueryKeys.today });
-        queryClient.invalidateQueries({ queryKey: statsQueryKeys.lastNDays.all });
-        queryClient.invalidateQueries({ queryKey: statsQueryKeys.nextNDays.all });
+        queryClient.invalidateQueries({ queryKey: statsQueryKeys.all });
       }
     },
   });


### PR DESCRIPTION
- invalidate card and statistics query namespaces after card mutations
- invalidate namespace roots for scheduling-related settings changes
- simplify invalidation coverage

Closes #178

Tests: `npm test`, `npm run compile`