### PR TITLE
build: exclude query devtools from production

### DIFF
--- a/entrypoints/popup/main.tsx
+++ b/entrypoints/popup/main.tsx
@@ -37,7 +37,7 @@ ReactDOM.createRoot(root).render(
             <App />
           </I18nProvider>
         </Suspense>
-        <ReactQueryDevtools initialIsOpen={false} />
+        {import.meta.env.DEV && <ReactQueryDevtools initialIsOpen={false} />}
       </QueryClientProvider>
     </ErrorBoundary>
   </React.StrictMode>

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
       "dependencies": {
         "@tailwindcss/vite": "^4.1.11",
         "@tanstack/react-query": "^5.84.1",
-        "@tanstack/react-query-devtools": "^5.84.1",
         "@webext-core/messaging": "^4.0.0",
         "chart.js": "^4.5.0",
         "octokit": "^5.0.5",
@@ -26,6 +25,7 @@
       },
       "devDependencies": {
         "@biomejs/biome": "^2.5.11",
+        "@tanstack/react-query-devtools": "^5.84.1",
         "@testing-library/dom": "^10.4.1",
         "@testing-library/jest-dom": "^7.0.0",
         "@testing-library/react": "^16.3.0",
@@ -2049,6 +2049,7 @@
       "version": "5.101.4",
       "resolved": "https://registry.npmjs.org/@tanstack/query-devtools/-/query-devtools-5.101.4.tgz",
       "integrity": "sha512-z5IPHnDX3aUWeTWlRKLyooBQekaCAw4xRpZqPQ390RiWTDBcTynjpPT221BArw0u2+pnQMdGvPQI9YNNubBcmA==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -2075,6 +2076,7 @@
       "version": "5.101.4",
       "resolved": "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-5.101.4.tgz",
       "integrity": "sha512-VeK2gtmfj7kvRBjtxS7TKxt/6qKhn8VzabY4UiYMr7NV9CddjSRYRgeYyld+NpjAkgMV9dd+2Qdr8ah5I03NeA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@tanstack/query-devtools": "5.101.4"

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
   "dependencies": {
     "@tailwindcss/vite": "^4.1.11",
     "@tanstack/react-query": "^5.84.1",
-    "@tanstack/react-query-devtools": "^5.84.1",
     "@webext-core/messaging": "^4.0.0",
     "chart.js": "^4.5.0",
     "octokit": "^5.0.5",
@@ -41,6 +40,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "^2.5.11",
+    "@tanstack/react-query-devtools": "^5.84.1",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^7.0.0",
     "@testing-library/react": "^16.3.0",


### PR DESCRIPTION
- render React Query Devtools only during development
- move the devtools package to development dependencies
- keep the production popup bundle free of devtools code

Closes #176

Tests: `npm test`, `npm run compile`, `npm run build`