### PR TITLE
refactor: show China banner on leetcode.cn only

### DIFF
--- a/entrypoints/popup/components/LeetcodeCnBanner.tsx
+++ b/entrypoints/popup/components/LeetcodeCnBanner.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState } from 'react';
 import { FaXmark } from 'react-icons/fa6';
 import { browser } from 'wxt/browser';
+import { isLeetcodeCnUrl } from '@/shared/leetcode';
 import { useI18n } from '../contexts/I18nContext';
 
 const LEETCODE_CN_ORIGIN = '*://*.leetcode.cn/*';
@@ -22,6 +23,7 @@ export function LeetcodeCnBanner() {
 
   const check = useCallback(async () => {
     if (activeTabUrl === undefined) return;
+    if (!isLeetcodeCnUrl(activeTabUrl)) return;
     if (localStorage.getItem(DISMISS_KEY)) return;
     const granted = await browser.permissions.contains({ origins: [LEETCODE_CN_ORIGIN] });
     if (!granted) setVisible(true);

--- a/entrypoints/popup/components/LeetcodeCnBanner.tsx
+++ b/entrypoints/popup/components/LeetcodeCnBanner.tsx
@@ -9,12 +9,23 @@ export const DISMISS_KEY = 'leetsrs:leetcodeCnBannerDismissed';
 export function LeetcodeCnBanner() {
   const t = useI18n();
   const [visible, setVisible] = useState(false);
+  const [activeTabUrl, setActiveTabUrl] = useState<string | null>();
+
+  useEffect(() => {
+    const loadActiveTabUrl = async () => {
+      const [activeTab] = await browser.tabs.query({ active: true, currentWindow: true });
+      setActiveTabUrl(activeTab?.url ?? null);
+    };
+
+    loadActiveTabUrl();
+  }, []);
 
   const check = useCallback(async () => {
+    if (activeTabUrl === undefined) return;
     if (localStorage.getItem(DISMISS_KEY)) return;
     const granted = await browser.permissions.contains({ origins: [LEETCODE_CN_ORIGIN] });
     if (!granted) setVisible(true);
-  }, []);
+  }, [activeTabUrl]);
 
   useEffect(() => {
     check();

--- a/entrypoints/popup/components/__tests__/LeetcodeCnBanner.test.tsx
+++ b/entrypoints/popup/components/__tests__/LeetcodeCnBanner.test.tsx
@@ -8,6 +8,8 @@ import { DISMISS_KEY, LeetcodeCnBanner } from '../LeetcodeCnBanner';
 
 const mockContains = vi.fn<() => Promise<boolean>>();
 const mockRequest = vi.fn<() => Promise<boolean>>();
+type QueriedTabs = Parameters<Parameters<typeof browser.tabs.query>[1]>[0];
+const mockQuery = vi.fn<() => Promise<QueriedTabs>>();
 
 // Mock localStorage since WXT test env doesn't provide one
 const store: Record<string, string> = {};
@@ -37,8 +39,11 @@ beforeEach(() => {
   mockLocalStorage.clear();
   browser.permissions.contains = mockContains;
   browser.permissions.request = mockRequest;
+  browser.tabs.query = mockQuery as typeof browser.tabs.query;
   mockContains.mockReset();
   mockRequest.mockReset();
+  mockQuery.mockReset();
+  mockQuery.mockResolvedValue([{ url: 'https://leetcode.cn/problems/two-sum/' } as QueriedTabs[number]]);
 });
 
 afterEach(() => {

--- a/entrypoints/popup/components/__tests__/LeetcodeCnBanner.test.tsx
+++ b/entrypoints/popup/components/__tests__/LeetcodeCnBanner.test.tsx
@@ -10,6 +10,7 @@ const mockContains = vi.fn<() => Promise<boolean>>();
 const mockRequest = vi.fn<() => Promise<boolean>>();
 type QueriedTabs = Parameters<Parameters<typeof browser.tabs.query>[1]>[0];
 const mockQuery = vi.fn<() => Promise<QueriedTabs>>();
+const tabWithUrl = (url?: string) => ({ url }) as QueriedTabs[number];
 
 // Mock localStorage since WXT test env doesn't provide one
 const store: Record<string, string> = {};
@@ -43,7 +44,7 @@ beforeEach(() => {
   mockContains.mockReset();
   mockRequest.mockReset();
   mockQuery.mockReset();
-  mockQuery.mockResolvedValue([{ url: 'https://leetcode.cn/problems/two-sum/' } as QueriedTabs[number]]);
+  mockQuery.mockResolvedValue([tabWithUrl('https://leetcode.cn/problems/two-sum/')]);
 });
 
 afterEach(() => {
@@ -55,6 +56,25 @@ afterEach(() => {
 });
 
 describe('LeetcodeCnBanner', () => {
+  it.each([
+    { context: 'a leetcode.com tab', tabs: [tabWithUrl('https://leetcode.com/problems/two-sum/')] },
+    { context: 'an unrelated tab', tabs: [tabWithUrl('https://example.com/')] },
+    { context: 'a tab without a URL', tabs: [tabWithUrl()] },
+    { context: 'an invalid tab URL', tabs: [tabWithUrl('not-a-url')] },
+    { context: 'no active tab', tabs: [] },
+  ])('is hidden for $context', async ({ tabs }) => {
+    mockQuery.mockResolvedValue(tabs);
+
+    await act(async () => {
+      render(<LeetcodeCnBanner />);
+    });
+
+    expect(mockQuery).toHaveBeenCalledWith({ active: true, currentWindow: true });
+    expect(mockContains).not.toHaveBeenCalled();
+    expect(mockRequest).not.toHaveBeenCalled();
+    expect(screen.queryByText(/leetcode\.cn/i)).not.toBeInTheDocument();
+  });
+
   it('is hidden when permission is already granted', async () => {
     mockContains.mockResolvedValue(true);
 
@@ -85,6 +105,7 @@ describe('LeetcodeCnBanner', () => {
 
     expect(screen.getByText(/leetcode\.cn/i)).toBeInTheDocument();
     expect(screen.getByText('Enable')).toBeInTheDocument();
+    expect(mockRequest).not.toHaveBeenCalled();
   });
 
   it('requests permission and hides on success when Enable clicked', async () => {

--- a/shared/__tests__/leetcode.test.ts
+++ b/shared/__tests__/leetcode.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { getLeetcodeProblemUrl } from '@/shared/leetcode';
+import { getLeetcodeProblemUrl, isLeetcodeCnUrl } from '@/shared/leetcode';
 
 describe('getLeetcodeProblemUrl', () => {
   it.each([
@@ -7,5 +7,19 @@ describe('getLeetcodeProblemUrl', () => {
     ['leetcode.cn', 'add-two-numbers', 'https://leetcode.cn/problems/add-two-numbers/description/'],
   ] as const)('builds a problem URL for %s', (domain, slug, expected) => {
     expect(getLeetcodeProblemUrl({ domain, slug })).toBe(expected);
+  });
+});
+
+describe('isLeetcodeCnUrl', () => {
+  it.each([
+    { url: 'https://leetcode.cn/problems/two-sum/', expected: true },
+    { url: 'https://www.leetcode.cn/problemset/', expected: true },
+    { url: null, expected: false },
+    { url: '', expected: false },
+    { url: 'not-a-url', expected: false },
+    { url: 'https://leetcode.com/', expected: false },
+    { url: 'https://leetcode.cn.example.com/', expected: false },
+  ])('returns $expected for $url', ({ url, expected }) => {
+    expect(isLeetcodeCnUrl(url)).toBe(expected);
   });
 });

--- a/shared/leetcode.ts
+++ b/shared/leetcode.ts
@@ -8,3 +8,14 @@ interface LeetcodeProblemLink {
 export function getLeetcodeProblemUrl({ domain, slug }: LeetcodeProblemLink): string {
   return `https://${domain}/problems/${slug}/description/`;
 }
+
+export function isLeetcodeCnUrl(url: string | null): boolean {
+  if (!url) return false;
+
+  try {
+    const hostname = new URL(url).hostname;
+    return hostname === 'leetcode.cn' || hostname.endsWith('.leetcode.cn');
+  } catch {
+    return false;
+  }
+}

--- a/todo.md
+++ b/todo.md
@@ -2,7 +2,7 @@
 
 - [x] Add `activeTab` to the extension manifest permissions.
 - [x] Query the active tab when the LeetCode China banner initializes.
-- [ ] Show the banner only on `leetcode.cn` when host permission is missing and the banner has not been dismissed.
+- [x] Show the banner only on `leetcode.cn` when host permission is missing and the banner has not been dismissed.
 - [ ] Keep the optional host-permission request behind the existing Enable button.
 - [ ] Update tests for China tabs, other tabs, unavailable tab URLs, existing permission, dismissal, and user-triggered permission requests.
 - [ ] Run formatting checks, tests, and TypeScript compilation.

--- a/todo.md
+++ b/todo.md
@@ -1,0 +1,8 @@
+# Issue #157
+
+- [x] Add `activeTab` to the extension manifest permissions.
+- [x] Query the active tab when the LeetCode China banner initializes.
+- [ ] Show the banner only on `leetcode.cn` when host permission is missing and the banner has not been dismissed.
+- [ ] Keep the optional host-permission request behind the existing Enable button.
+- [ ] Update tests for China tabs, other tabs, unavailable tab URLs, existing permission, dismissal, and user-triggered permission requests.
+- [ ] Run formatting checks, tests, and TypeScript compilation.

--- a/todo.md
+++ b/todo.md
@@ -1,8 +1,0 @@
-# Issue #157
-
-- [x] Add `activeTab` to the extension manifest permissions.
-- [x] Query the active tab when the LeetCode China banner initializes.
-- [x] Show the banner only on `leetcode.cn` when host permission is missing and the banner has not been dismissed.
-- [ ] Keep the optional host-permission request behind the existing Enable button.
-- [ ] Update tests for China tabs, other tabs, unavailable tab URLs, existing permission, dismissal, and user-triggered permission requests.
-- [ ] Run formatting checks, tests, and TypeScript compilation.

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -12,7 +12,7 @@ export default defineConfig({
     name: '__MSG_extName__',
     description: '__MSG_extDescription__',
     default_locale: 'en',
-    permissions: ['storage', 'alarms'],
+    permissions: ['storage', 'alarms', 'activeTab'],
     host_permissions: ['*://*.leetcode.com/*'],
     optional_host_permissions: ['*://*.leetcode.cn/*'],
   },


### PR DESCRIPTION
- detect whether the popup was opened from a leetcode.cn tab
- show the China permission banner only when needed
- cover active-tab, domain, permission, and dismissal states

Closes #157