### PR TITLE
ci: skip Claude reviews for Dependabot

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -10,7 +10,9 @@ on:
 
 jobs:
   claude-review:
-    if: ${{ !startsWith(github.event.pull_request.head.ref, 'release-please--branches--') }}
+    if: >-
+      github.event.pull_request.user.login != 'dependabot[bot]' &&
+      !startsWith(github.event.pull_request.head.ref, 'release-please--branches--')
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
- skip Claude code review jobs for Dependabot-authored pull requests
- keep existing release PR exclusion