### PR TITLE
refactor: scope card-list operations by card

### DIFF
--- a/entrypoints/popup/views/card/CardView.tsx
+++ b/entrypoints/popup/views/card/CardView.tsx
@@ -11,6 +11,7 @@ import type { Translations } from '@/shared/i18n';
 import { StreakCounter } from '../../components/StreakCounter';
 import { ViewLayout } from '../../components/ViewLayout';
 import { useI18n } from '../../contexts/I18nContext';
+import { filterAndSortCards } from './card-list';
 import { CardNotes } from './components/CardNotes';
 
 // Utility functions
@@ -215,17 +216,7 @@ export function CardView() {
   const [processingCards, setProcessingCards] = useState<Set<string>>(new Set());
   const [filterText, setFilterText] = useState('');
 
-  const filteredCards = cards.filter((card) => {
-    if (!filterText) return true;
-    const searchLower = filterText.toLowerCase();
-    return card.name.toLowerCase().includes(searchLower) || card.leetcodeId.includes(filterText);
-  });
-
-  const sortedCards = [...filteredCards].sort((a, b) => {
-    const aId = parseInt(a.leetcodeId, 10);
-    const bId = parseInt(b.leetcodeId, 10);
-    return aId - bId;
-  });
+  const sortedCards = filterAndSortCards(cards, filterText);
 
   const toggleCard = (cardId: string) => {
     setExpandedCards((prev) => {

--- a/entrypoints/popup/views/card/CardView.tsx
+++ b/entrypoints/popup/views/card/CardView.tsx
@@ -1,219 +1,17 @@
 import { useState } from 'react';
 import { Button, Input, Label, TextField } from 'react-aria-components';
-import { FaArrowUpRightFromSquare, FaCirclePause, FaMagnifyingGlass, FaPlay, FaTrash, FaXmark } from 'react-icons/fa6';
-import { State as FsrsState } from 'ts-fsrs';
-import { getLeetcodeProblemUrl } from '@/entrypoints/popup/leetcode';
-import { bounceButton } from '@/entrypoints/popup/styles';
-import { useCardsQuery, usePauseCardMutation, useRemoveCardMutation } from '@/hooks/queries/cards';
-import { useTimedConfirmation } from '@/hooks/useTimedConfirmation';
-import type { Card } from '@/shared/cards';
-import type { Translations } from '@/shared/i18n';
+import { FaMagnifyingGlass, FaXmark } from 'react-icons/fa6';
+import { useCardsQuery } from '@/hooks/queries/cards';
 import { StreakCounter } from '../../components/StreakCounter';
 import { ViewLayout } from '../../components/ViewLayout';
 import { useI18n } from '../../contexts/I18nContext';
 import { filterAndSortCards } from './card-list';
-import { CardNotes } from './components/CardNotes';
-
-// Utility functions
-const getStateLabel = (state: FsrsState, t: Translations) => {
-  switch (state) {
-    case FsrsState.New:
-      return t.states.new;
-    case FsrsState.Learning:
-      return t.states.learning;
-    case FsrsState.Review:
-      return t.states.review;
-    case FsrsState.Relearning:
-      return t.states.relearning;
-    default:
-      return t.states.unknown;
-  }
-};
-
-const formatDate = (date: Date) => {
-  return new Date(date).toLocaleDateString('en-US', {
-    month: 'short',
-    day: 'numeric',
-    year: 'numeric',
-  });
-};
-
-const getDifficultyColor = (difficulty: string) => {
-  switch (difficulty) {
-    case 'Easy':
-      return 'text-green-500';
-    case 'Medium':
-      return 'text-yellow-500';
-    case 'Hard':
-      return 'text-red-500';
-    default:
-      return 'text-secondary';
-  }
-};
-
-// Sub-components
-interface CardHeaderProps {
-  card: Card;
-  isExpanded: boolean;
-  t: Translations;
-}
-
-function CardHeader({ card, isExpanded, t }: CardHeaderProps) {
-  return (
-    <>
-      <div className="flex items-center gap-2">
-        {card.paused && <FaCirclePause className="text-warning text-base" title={t.cardsView.cardPausedTitle} />}
-        <span className="text-xs text-secondary">{t.format.leetcodeId(card.leetcodeId)}</span>
-        <span className={`text-sm ${card.paused ? 'opacity-60' : ''}`}>{card.name}</span>
-      </div>
-      <div className="flex items-center gap-2">
-        <span className={`text-xs ${getDifficultyColor(card.difficulty)}`}>{card.difficulty}</span>
-        <span className={`text-xs text-secondary transition-transform duration-200 ${isExpanded ? 'rotate-90' : ''}`}>
-          ▶
-        </span>
-      </div>
-    </>
-  );
-}
-
-interface StatRowProps {
-  label: string;
-  value: string | number;
-}
-
-function StatRow({ label, value }: StatRowProps) {
-  return (
-    <div className="flex justify-between">
-      <span className="text-secondary">{label}:</span>
-      <span>{value}</span>
-    </div>
-  );
-}
-
-interface CardStatsProps {
-  card: Card;
-  cardId: string;
-  onPauseToggle: () => void;
-  onDelete: () => void;
-  isPauseProcessing: boolean;
-  isDeleteProcessing: boolean;
-  t: Translations;
-}
-
-function CardStats({
-  card,
-  cardId,
-  onPauseToggle,
-  onDelete,
-  isPauseProcessing,
-  isDeleteProcessing,
-  t,
-}: CardStatsProps) {
-  const { isConfirming, startOrConfirm } = useTimedConfirmation();
-
-  return (
-    <div className="px-4 pb-3 border-t border-current">
-      <div className="mt-3 grid grid-cols-2 gap-x-4 gap-y-1.5 text-xs">
-        <StatRow label={t.cardStats.state} value={getStateLabel(card.fsrs.state, t)} />
-        <StatRow label={t.cardStats.reviews} value={card.fsrs.reps} />
-        <StatRow label={t.cardStats.stability} value={t.format.stabilityDays(card.fsrs.stability.toFixed(1))} />
-        <StatRow label={t.cardStats.lapses} value={card.fsrs.lapses} />
-        <StatRow label={t.cardStats.difficulty} value={card.fsrs.difficulty.toFixed(2)} />
-        <StatRow label={t.cardStats.due} value={formatDate(card.fsrs.due)} />
-        {card.fsrs.last_review && <StatRow label={t.cardStats.last} value={formatDate(card.fsrs.last_review)} />}
-        <StatRow label={t.cardStats.added} value={formatDate(card.createdAt)} />
-      </div>
-
-      <div className="mt-3 pt-3 border-t border-current flex gap-2">
-        <Button
-          className={`flex-1 flex items-center justify-center gap-1.5 px-3 py-1.5 rounded text-xs bg-tertiary text-primary hover:bg-quaternary transition-colors ${bounceButton} disabled:opacity-50`}
-          onPress={onPauseToggle}
-          isDisabled={isPauseProcessing}
-        >
-          {card.paused ? <FaPlay className="text-sm" /> : <FaCirclePause className="text-sm" />}
-          <span>{card.paused ? t.actions.resume : t.actions.pause}</span>
-        </Button>
-
-        <Button
-          className={`flex-1 flex items-center justify-center gap-1.5 px-3 py-1.5 rounded text-xs ${
-            isConfirming ? 'bg-ultra-danger' : 'bg-danger'
-          } text-white hover:opacity-90 transition-colors ${bounceButton} disabled:opacity-50`}
-          onPress={() => startOrConfirm(onDelete)}
-          isDisabled={isDeleteProcessing}
-        >
-          <FaTrash className="text-sm" />
-          <span>{isConfirming ? t.actions.confirm : t.actions.delete}</span>
-        </Button>
-      </div>
-
-      <CardNotes cardId={cardId} />
-    </div>
-  );
-}
-
-interface CardItemProps {
-  card: Card;
-  isExpanded: boolean;
-  onToggle: () => void;
-  onPauseToggle: () => void;
-  onDelete: () => void;
-  isPauseProcessing: boolean;
-  isDeleteProcessing: boolean;
-  t: Translations;
-}
-
-function CardItem({
-  card,
-  isExpanded,
-  onToggle,
-  onPauseToggle,
-  onDelete,
-  isPauseProcessing,
-  isDeleteProcessing,
-  t,
-}: CardItemProps) {
-  return (
-    <div className="bg-secondary rounded-lg border border-current overflow-hidden">
-      <div className="flex items-center hover:bg-tertiary transition-colors">
-        <Button
-          className="flex-1 flex items-center justify-between p-3 text-left"
-          onPress={onToggle}
-          aria-expanded={isExpanded}
-        >
-          <CardHeader card={card} isExpanded={isExpanded} t={t} />
-        </Button>
-        <a
-          href={getLeetcodeProblemUrl(card)}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="self-stretch flex items-center px-3 text-secondary hover:text-primary transition-colors"
-          aria-label={`Open ${card.name} on LeetCode`}
-        >
-          <FaArrowUpRightFromSquare className="text-sm" />
-        </a>
-      </div>
-      {isExpanded && (
-        <CardStats
-          card={card}
-          cardId={card.id}
-          onPauseToggle={onPauseToggle}
-          onDelete={onDelete}
-          isPauseProcessing={isPauseProcessing}
-          isDeleteProcessing={isDeleteProcessing}
-          t={t}
-        />
-      )}
-    </div>
-  );
-}
+import { CardListItem } from './components/CardListItem';
 
 export function CardView() {
   const t = useI18n();
   const { data: cards = [], isLoading } = useCardsQuery();
-  const pauseCardMutation = usePauseCardMutation();
-  const removeCardMutation = useRemoveCardMutation();
   const [expandedCards, setExpandedCards] = useState<Set<string>>(new Set());
-  const [processingCards, setProcessingCards] = useState<Set<string>>(new Set());
   const [filterText, setFilterText] = useState('');
 
   const sortedCards = filterAndSortCards(cards, filterText);
@@ -230,40 +28,12 @@ export function CardView() {
     });
   };
 
-  const handlePauseToggle = async (card: Card) => {
-    setProcessingCards((prev) => new Set(prev).add(card.id));
-    try {
-      await pauseCardMutation.mutateAsync({ slug: card.slug, paused: !card.paused });
-    } catch (error) {
-      console.error('Failed to toggle pause status:', error);
-    } finally {
-      setProcessingCards((prev) => {
-        const newSet = new Set(prev);
-        newSet.delete(card.id);
-        return newSet;
-      });
-    }
-  };
-
-  const handleDelete = async (card: Card) => {
-    setProcessingCards((prev) => new Set(prev).add(card.id));
-    try {
-      await removeCardMutation.mutateAsync(card.slug);
-      // Remove from expanded cards if it was expanded
-      setExpandedCards((prev) => {
-        const newSet = new Set(prev);
-        newSet.delete(card.id);
-        return newSet;
-      });
-    } catch (error) {
-      console.error('Failed to delete card:', error);
-    } finally {
-      setProcessingCards((prev) => {
-        const newSet = new Set(prev);
-        newSet.delete(card.id);
-        return newSet;
-      });
-    }
+  const removeExpandedCard = (cardId: string) => {
+    setExpandedCards((prev) => {
+      const newSet = new Set(prev);
+      newSet.delete(cardId);
+      return newSet;
+    });
   };
 
   return (
@@ -300,16 +70,12 @@ export function CardView() {
         ) : (
           <div className="space-y-2">
             {sortedCards.map((card) => (
-              <CardItem
+              <CardListItem
                 key={card.id}
                 card={card}
                 isExpanded={expandedCards.has(card.id)}
                 onToggle={() => toggleCard(card.id)}
-                onPauseToggle={() => handlePauseToggle(card)}
-                onDelete={() => handleDelete(card)}
-                isPauseProcessing={processingCards.has(card.id) && pauseCardMutation.isPending}
-                isDeleteProcessing={processingCards.has(card.id) && removeCardMutation.isPending}
-                t={t}
+                onDeleted={() => removeExpandedCard(card.id)}
               />
             ))}
           </div>

--- a/entrypoints/popup/views/card/__tests__/CardView.test.tsx
+++ b/entrypoints/popup/views/card/__tests__/CardView.test.tsx
@@ -3,9 +3,9 @@
  */
 
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { act, fireEvent, render, screen, within } from '@testing-library/react';
+import { fireEvent, render, screen, within } from '@testing-library/react';
 import { State } from 'ts-fsrs';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { cardQueryKeys } from '@/hooks/queries/cards';
 import type { Card } from '@/shared/cards';
 import { sendMessage } from '@/shared/messages';
@@ -32,12 +32,8 @@ describe('CardView', () => {
   };
 
   beforeEach(() => {
-    messages.reset().resolve('setPauseStatus', createMockCard(State.New)).resolve('removeCard', undefined);
+    messages.reset();
     queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
-  });
-
-  afterEach(() => {
-    vi.useRealTimers();
   });
 
   it('should render loading state', () => {
@@ -397,192 +393,6 @@ describe('CardView', () => {
       expect(screen.getByText('Loading cards...')).toBeInTheDocument();
       view.unmount();
       pending.resolve([]);
-    });
-  });
-
-  describe('card actions', () => {
-    it('should call pause mutation when pause button is clicked', async () => {
-      const card = createMockCard(State.New, {
-        name: 'Test Problem',
-        slug: 'test-problem',
-        paused: false,
-      });
-
-      seedCards([card]);
-
-      renderWithQueryClient(<CardView />);
-
-      // Expand the card to show buttons
-      const cardButton = screen.getByRole('button', { name: /Test Problem/i });
-      fireEvent.click(cardButton);
-
-      // Click the pause button
-      const pauseButton = screen.getByRole('button', { name: /Pause/i });
-      fireEvent.click(pauseButton);
-
-      // Assert that mutateAsync was called with correct arguments
-      await vi.waitFor(() =>
-        expect(sendMessage).toHaveBeenCalledWith('setPauseStatus', { slug: 'test-problem', paused: true })
-      );
-    });
-
-    it('should call unpause mutation when resume button is clicked', async () => {
-      const card = createMockCard(State.New, {
-        name: 'Test Problem',
-        slug: 'test-problem',
-        paused: true,
-      });
-
-      seedCards([card]);
-
-      renderWithQueryClient(<CardView />);
-
-      // Expand the card to show buttons
-      const cardButton = screen.getByRole('button', { name: /Test Problem/i });
-      fireEvent.click(cardButton);
-
-      // Click the resume button
-      const resumeButton = screen.getByRole('button', { name: /Resume/i });
-      fireEvent.click(resumeButton);
-
-      // Assert that mutateAsync was called with correct arguments
-      await vi.waitFor(() =>
-        expect(sendMessage).toHaveBeenCalledWith('setPauseStatus', { slug: 'test-problem', paused: false })
-      );
-    });
-
-    it('should call delete mutation after confirmation', async () => {
-      const card = createMockCard(State.New, {
-        name: 'Test Problem',
-        slug: 'test-problem',
-      });
-
-      seedCards([card]);
-
-      renderWithQueryClient(<CardView />);
-
-      // Expand the card to show buttons
-      const cardButton = screen.getByRole('button', { name: /Test Problem/i });
-      fireEvent.click(cardButton);
-
-      // First click on delete button
-      const deleteButton = screen.getByRole('button', { name: /Delete/i });
-      fireEvent.click(deleteButton);
-
-      // Button should now show "Confirm?"
-      expect(screen.getByRole('button', { name: /Confirm\?/i })).toBeInTheDocument();
-
-      // Second click to confirm
-      fireEvent.click(screen.getByRole('button', { name: /Confirm\?/i }));
-
-      // Assert that mutateAsync was called with the slug
-      await vi.waitFor(() => expect(sendMessage).toHaveBeenCalledWith('removeCard', { slug: 'test-problem' }));
-    });
-
-    it('should expire delete confirmation after 3000ms', () => {
-      vi.useFakeTimers();
-      const card = createMockCard(State.New, {
-        name: 'Test Problem',
-        slug: 'test-problem',
-      });
-
-      seedCards([card]);
-
-      renderWithQueryClient(<CardView />);
-      fireEvent.click(screen.getByRole('button', { name: /Test Problem/i }));
-      fireEvent.click(screen.getByRole('button', { name: /^Delete$/i }));
-
-      expect(screen.getByRole('button', { name: /Confirm\?/i })).toBeInTheDocument();
-
-      act(() => {
-        vi.advanceTimersByTime(3000);
-      });
-
-      expect(screen.getByRole('button', { name: /^Delete$/i })).toBeInTheDocument();
-      expect(sendMessage).not.toHaveBeenCalledWith('removeCard', expect.anything());
-    });
-
-    it('should keep delete confirmation independent between cards', () => {
-      const cards = [
-        createMockCard(State.New, { name: 'Problem 1', slug: 'problem-1', leetcodeId: '1' }),
-        createMockCard(State.New, { name: 'Problem 2', slug: 'problem-2', leetcodeId: '2' }),
-      ];
-
-      seedCards(cards);
-
-      renderWithQueryClient(<CardView />);
-      fireEvent.click(screen.getByRole('button', { name: /Problem 1/i }));
-      fireEvent.click(screen.getByRole('button', { name: /Problem 2/i }));
-
-      const deleteButtons = screen.getAllByRole('button', { name: /^Delete$/i });
-      fireEvent.click(deleteButtons[0]);
-
-      expect(screen.getAllByRole('button', { name: /Confirm\?/i })).toHaveLength(1);
-      expect(screen.getAllByRole('button', { name: /^Delete$/i })).toHaveLength(1);
-      expect(sendMessage).not.toHaveBeenCalledWith('removeCard', expect.anything());
-    });
-
-    it('should handle errors from mutations gracefully', async () => {
-      const card = createMockCard(State.New, {
-        name: 'Test Problem',
-        slug: 'test-problem',
-      });
-
-      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-
-      seedCards([card]);
-
-      // Mock the mutation to reject
-      messages.handle('setPauseStatus', () => Promise.reject(new Error('Network error')));
-
-      renderWithQueryClient(<CardView />);
-
-      // Expand the card
-      const cardButton = screen.getByRole('button', { name: /Test Problem/i });
-      fireEvent.click(cardButton);
-
-      // Click the pause button
-      const pauseButton = screen.getByRole('button', { name: /Pause/i });
-      fireEvent.click(pauseButton);
-
-      // Wait for the promise to reject
-      await vi.waitFor(() => {
-        expect(consoleErrorSpy).toHaveBeenCalledWith('Failed to toggle pause status:', expect.any(Error));
-      });
-
-      // Button should be enabled again after error
-      expect(pauseButton).not.toBeDisabled();
-
-      consoleErrorSpy.mockRestore();
-    });
-
-    it('should handle multiple cards with independent actions', async () => {
-      const cards = [
-        createMockCard(State.New, { name: 'Problem 1', slug: 'problem-1', leetcodeId: '1' }),
-        createMockCard(State.New, { name: 'Problem 2', slug: 'problem-2', leetcodeId: '2' }),
-      ];
-
-      seedCards(cards);
-
-      renderWithQueryClient(<CardView />);
-
-      // Expand both cards
-      const cardButtons = screen.getAllByRole('button');
-      fireEvent.click(cardButtons[0]); // First card
-      fireEvent.click(cardButtons[1]); // Second card
-
-      // Get pause buttons (should be 2)
-      const pauseButtons = screen.getAllByRole('button', { name: /Pause/i });
-      expect(pauseButtons).toHaveLength(2);
-
-      // Click pause on first card
-      fireEvent.click(pauseButtons[0]);
-
-      // Should only call mutation for first card
-      await vi.waitFor(() => {
-        expect(sendMessage).toHaveBeenCalledWith('setPauseStatus', { slug: 'problem-1', paused: true });
-        expect(vi.mocked(sendMessage).mock.calls.filter(([type]) => type === 'setPauseStatus')).toHaveLength(1);
-      });
     });
   });
 });

--- a/entrypoints/popup/views/card/__tests__/card-list.test.ts
+++ b/entrypoints/popup/views/card/__tests__/card-list.test.ts
@@ -1,0 +1,74 @@
+import { State } from 'ts-fsrs';
+import { describe, expect, it } from 'vitest';
+import type { Card } from '@/shared/cards';
+import { createMockCard } from '@/test/utils/card-mocks';
+import { filterAndSortCards } from '../card-list';
+
+const createCard = (id: string, leetcodeId: string, name = id): Card =>
+  createMockCard(State.New, { id, leetcodeId, name });
+
+const getIds = (cards: Card[]) => cards.map((card) => card.id);
+
+describe('filterAndSortCards', () => {
+  it('does not mutate the input', () => {
+    const cards = [createCard('second', '2'), createCard('first', '1')];
+
+    filterAndSortCards(cards, '');
+
+    expect(getIds(cards)).toEqual(['second', 'first']);
+  });
+
+  it.each([
+    {
+      description: 'returns every card for an empty filter',
+      cards: [createCard('second', '2'), createCard('first', '1')],
+      filterText: '',
+      expectedIds: ['first', 'second'],
+    },
+    {
+      description: 'filters names case-insensitively',
+      cards: [createCard('match', '2', 'Add TWO Numbers'), createCard('other', '1', 'Two Sum')],
+      filterText: 'two numbers',
+      expectedIds: ['match'],
+    },
+    {
+      description: 'filters by an ID substring',
+      cards: [createCard('first', '123'), createCard('match', '456'), createCard('last', '789')],
+      filterText: '45',
+      expectedIds: ['match'],
+    },
+  ])('$description', ({ cards, filterText, expectedIds }) => {
+    expect(getIds(filterAndSortCards(cards, filterText))).toEqual(expectedIds);
+  });
+
+  it.each([
+    {
+      description: 'sorts fully numeric IDs numerically without number precision limits',
+      cards: [
+        createCard('large', '9007199254740993'),
+        createCard('hundred', '100'),
+        createCard('two', '2'),
+        createCard('safe-limit', '9007199254740992'),
+      ],
+      expectedIds: ['two', 'hundred', 'safe-limit', 'large'],
+    },
+    {
+      description: 'orders equal numeric IDs by their original text and then card ID',
+      cards: [createCard('b', '1'), createCard('c', '01'), createCard('a', '1'), createCard('d', '001')],
+      expectedIds: ['d', 'c', 'a', 'b'],
+    },
+    {
+      description: 'places nonnumeric IDs after numeric IDs in deterministic lexical order',
+      cards: [
+        createCard('x-second', 'x'),
+        createCard('contest', 'contest-2'),
+        createCard('numeric', '10'),
+        createCard('x-first', 'x'),
+        createCard('alpha', 'A'),
+      ],
+      expectedIds: ['numeric', 'alpha', 'contest', 'x-first', 'x-second'],
+    },
+  ])('$description', ({ cards, expectedIds }) => {
+    expect(getIds(filterAndSortCards(cards, ''))).toEqual(expectedIds);
+  });
+});

--- a/entrypoints/popup/views/card/card-list.ts
+++ b/entrypoints/popup/views/card/card-list.ts
@@ -1,0 +1,34 @@
+import type { Card } from '@/shared/cards';
+
+const numericLeetcodeIdPattern = /^\d+$/;
+
+const compareText = (a: string, b: string) => {
+  if (a < b) return -1;
+  if (a > b) return 1;
+  return 0;
+};
+
+const compareCardsByLeetcodeId = (a: Card, b: Card) => {
+  const aIsNumeric = numericLeetcodeIdPattern.test(a.leetcodeId);
+  const bIsNumeric = numericLeetcodeIdPattern.test(b.leetcodeId);
+
+  if (aIsNumeric && bIsNumeric) {
+    const numericOrder = BigInt(a.leetcodeId) - BigInt(b.leetcodeId);
+    if (numericOrder !== 0n) return numericOrder < 0n ? -1 : 1;
+  } else if (aIsNumeric !== bIsNumeric) {
+    // Numeric IDs sort first; nonnumeric IDs use lexical ordering below.
+    return aIsNumeric ? -1 : 1;
+  }
+
+  return compareText(a.leetcodeId, b.leetcodeId) || compareText(a.id, b.id);
+};
+
+export const filterAndSortCards = (cards: readonly Card[], filterText: string) => {
+  const searchLower = filterText.toLowerCase();
+
+  return cards
+    .filter(
+      (card) => !filterText || card.name.toLowerCase().includes(searchLower) || card.leetcodeId.includes(filterText)
+    )
+    .sort(compareCardsByLeetcodeId);
+};

--- a/entrypoints/popup/views/card/components/CardListItem.tsx
+++ b/entrypoints/popup/views/card/components/CardListItem.tsx
@@ -1,0 +1,165 @@
+import { Button } from 'react-aria-components';
+import { FaArrowUpRightFromSquare, FaCirclePause, FaPlay, FaTrash } from 'react-icons/fa6';
+import { State as FsrsState } from 'ts-fsrs';
+import { getLeetcodeProblemUrl } from '@/entrypoints/popup/leetcode';
+import { bounceButton } from '@/entrypoints/popup/styles';
+import { usePauseCardMutation, useRemoveCardMutation } from '@/hooks/queries/cards';
+import { useTimedConfirmation } from '@/hooks/useTimedConfirmation';
+import type { Card } from '@/shared/cards';
+import type { Translations } from '@/shared/i18n';
+import { useI18n } from '../../../contexts/I18nContext';
+import { CardNotes } from './CardNotes';
+
+const getStateLabel = (state: FsrsState, t: Translations) => {
+  switch (state) {
+    case FsrsState.New:
+      return t.states.new;
+    case FsrsState.Learning:
+      return t.states.learning;
+    case FsrsState.Review:
+      return t.states.review;
+    case FsrsState.Relearning:
+      return t.states.relearning;
+    default:
+      return t.states.unknown;
+  }
+};
+
+const formatDate = (date: Date) =>
+  new Date(date).toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  });
+
+const getDifficultyColor = (difficulty: string) => {
+  switch (difficulty) {
+    case 'Easy':
+      return 'text-green-500';
+    case 'Medium':
+      return 'text-yellow-500';
+    case 'Hard':
+      return 'text-red-500';
+    default:
+      return 'text-secondary';
+  }
+};
+
+interface StatRowProps {
+  label: string;
+  value: string | number;
+}
+
+function StatRow({ label, value }: StatRowProps) {
+  return (
+    <div className="flex justify-between">
+      <span className="text-secondary">{label}:</span>
+      <span>{value}</span>
+    </div>
+  );
+}
+
+interface CardListItemProps {
+  card: Card;
+  isExpanded: boolean;
+  onToggle: () => void;
+  onDeleted: () => void;
+}
+
+export function CardListItem({ card, isExpanded, onToggle, onDeleted }: CardListItemProps) {
+  const t = useI18n();
+  const pauseCardMutation = usePauseCardMutation();
+  const removeCardMutation = useRemoveCardMutation();
+  const { isConfirming, startOrConfirm } = useTimedConfirmation();
+
+  const handlePauseToggle = async () => {
+    try {
+      await pauseCardMutation.mutateAsync({ slug: card.slug, paused: !card.paused });
+    } catch (error) {
+      console.error('Failed to toggle pause status:', error);
+    }
+  };
+
+  const handleDelete = async () => {
+    try {
+      await removeCardMutation.mutateAsync(card.slug);
+      onDeleted();
+    } catch (error) {
+      console.error('Failed to delete card:', error);
+    }
+  };
+
+  return (
+    <div className="bg-secondary rounded-lg border border-current overflow-hidden">
+      <div className="flex items-center hover:bg-tertiary transition-colors">
+        <Button
+          className="flex-1 flex items-center justify-between p-3 text-left"
+          onPress={onToggle}
+          aria-expanded={isExpanded}
+        >
+          <div className="flex items-center gap-2">
+            {card.paused && <FaCirclePause className="text-warning text-base" title={t.cardsView.cardPausedTitle} />}
+            <span className="text-xs text-secondary">{t.format.leetcodeId(card.leetcodeId)}</span>
+            <span className={`text-sm ${card.paused ? 'opacity-60' : ''}`}>{card.name}</span>
+          </div>
+          <div className="flex items-center gap-2">
+            <span className={`text-xs ${getDifficultyColor(card.difficulty)}`}>{card.difficulty}</span>
+            <span
+              className={`text-xs text-secondary transition-transform duration-200 ${isExpanded ? 'rotate-90' : ''}`}
+            >
+              ▶
+            </span>
+          </div>
+        </Button>
+        <a
+          href={getLeetcodeProblemUrl(card)}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="self-stretch flex items-center px-3 text-secondary hover:text-primary transition-colors"
+          aria-label={`Open ${card.name} on LeetCode`}
+        >
+          <FaArrowUpRightFromSquare className="text-sm" />
+        </a>
+      </div>
+
+      {isExpanded && (
+        <div className="px-4 pb-3 border-t border-current">
+          <div className="mt-3 grid grid-cols-2 gap-x-4 gap-y-1.5 text-xs">
+            <StatRow label={t.cardStats.state} value={getStateLabel(card.fsrs.state, t)} />
+            <StatRow label={t.cardStats.reviews} value={card.fsrs.reps} />
+            <StatRow label={t.cardStats.stability} value={t.format.stabilityDays(card.fsrs.stability.toFixed(1))} />
+            <StatRow label={t.cardStats.lapses} value={card.fsrs.lapses} />
+            <StatRow label={t.cardStats.difficulty} value={card.fsrs.difficulty.toFixed(2)} />
+            <StatRow label={t.cardStats.due} value={formatDate(card.fsrs.due)} />
+            {card.fsrs.last_review && <StatRow label={t.cardStats.last} value={formatDate(card.fsrs.last_review)} />}
+            <StatRow label={t.cardStats.added} value={formatDate(card.createdAt)} />
+          </div>
+
+          <div className="mt-3 pt-3 border-t border-current flex gap-2">
+            <Button
+              className={`flex-1 flex items-center justify-center gap-1.5 px-3 py-1.5 rounded text-xs bg-tertiary text-primary hover:bg-quaternary transition-colors ${bounceButton} disabled:opacity-50`}
+              onPress={handlePauseToggle}
+              isDisabled={pauseCardMutation.isPending}
+            >
+              {card.paused ? <FaPlay className="text-sm" /> : <FaCirclePause className="text-sm" />}
+              <span>{card.paused ? t.actions.resume : t.actions.pause}</span>
+            </Button>
+
+            <Button
+              className={`flex-1 flex items-center justify-center gap-1.5 px-3 py-1.5 rounded text-xs ${
+                isConfirming ? 'bg-ultra-danger' : 'bg-danger'
+              } text-white hover:opacity-90 transition-colors ${bounceButton} disabled:opacity-50`}
+              onPress={() => startOrConfirm(handleDelete)}
+              isDisabled={removeCardMutation.isPending}
+            >
+              <FaTrash className="text-sm" />
+              <span>{isConfirming ? t.actions.confirm : t.actions.delete}</span>
+            </Button>
+          </div>
+
+          <CardNotes cardId={card.id} />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/entrypoints/popup/views/card/components/__tests__/CardListItem.test.tsx
+++ b/entrypoints/popup/views/card/components/__tests__/CardListItem.test.tsx
@@ -1,0 +1,151 @@
+/**
+ * @vitest-environment happy-dom
+ */
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { State } from 'ts-fsrs';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Card } from '@/shared/cards';
+import { sendMessage } from '@/shared/messages';
+import { createMockCard } from '@/test/utils/card-mocks';
+import { createDeferred } from '@/test/utils/deferred';
+import { createMessageMock } from '@/test/utils/message-mocks';
+import { CardListItem } from '../CardListItem';
+
+vi.mock('@/shared/messages', () => ({ sendMessage: vi.fn() }));
+vi.mock('../CardNotes', () => ({ CardNotes: () => null }));
+
+const messages = createMessageMock(vi.mocked(sendMessage));
+let queryClient: QueryClient;
+
+const renderItem = (card: Card, onDeleted = vi.fn()) => {
+  render(
+    <QueryClientProvider client={queryClient}>
+      <CardListItem card={card} isExpanded onToggle={vi.fn()} onDeleted={onDeleted} />
+    </QueryClientProvider>
+  );
+  return onDeleted;
+};
+
+describe('CardListItem', () => {
+  beforeEach(() => {
+    messages.reset().resolve('setPauseStatus', createMockCard(State.New)).resolve('removeCard', undefined);
+    queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it.each([
+    { paused: false, action: 'Pause', nextPaused: true },
+    { paused: true, action: 'Resume', nextPaused: false },
+  ])('sends the $action mutation for its card', async ({ paused, action, nextPaused }) => {
+    const card = createMockCard(State.New, { slug: 'test-problem', paused });
+    renderItem(card);
+
+    fireEvent.click(screen.getByRole('button', { name: action }));
+
+    await vi.waitFor(() =>
+      expect(sendMessage).toHaveBeenCalledWith('setPauseStatus', { slug: 'test-problem', paused: nextPaused })
+    );
+  });
+
+  it('deletes only after confirmation and reports successful deletion', async () => {
+    const onDeleted = renderItem(createMockCard(State.New, { slug: 'test-problem' }));
+
+    fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
+    expect(screen.getByRole('button', { name: 'Confirm?' })).toBeInTheDocument();
+    expect(sendMessage).not.toHaveBeenCalledWith('removeCard', expect.anything());
+
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm?' }));
+
+    await vi.waitFor(() => {
+      expect(sendMessage).toHaveBeenCalledWith('removeCard', { slug: 'test-problem' });
+      expect(onDeleted).toHaveBeenCalledOnce();
+    });
+  });
+
+  it('expires delete confirmation', () => {
+    vi.useFakeTimers();
+    renderItem(createMockCard(State.New));
+
+    fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
+    expect(screen.getByRole('button', { name: 'Confirm?' })).toBeInTheDocument();
+
+    act(() => vi.advanceTimersByTime(3000));
+
+    expect(screen.getByRole('button', { name: 'Delete' })).toBeInTheDocument();
+    expect(sendMessage).not.toHaveBeenCalledWith('removeCard', expect.anything());
+  });
+
+  it('restores its pause action after a failure', async () => {
+    const error = new Error('Pause failed');
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    messages.handle('setPauseStatus', () => Promise.reject(error));
+    renderItem(createMockCard(State.New));
+
+    const pauseButton = screen.getByRole('button', { name: 'Pause' });
+    fireEvent.click(pauseButton);
+
+    await vi.waitFor(() => {
+      expect(consoleError).toHaveBeenCalledWith('Failed to toggle pause status:', error);
+      expect(pauseButton).not.toBeDisabled();
+    });
+  });
+
+  it('restores delete confirmation after a failure without reporting deletion', async () => {
+    const error = new Error('Delete failed');
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    messages.handle('removeCard', () => Promise.reject(error));
+    const onDeleted = renderItem(createMockCard(State.New));
+
+    fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm?' }));
+
+    await vi.waitFor(() => {
+      expect(consoleError).toHaveBeenCalledWith('Failed to delete card:', error);
+      expect(screen.getByRole('button', { name: 'Delete' })).not.toBeDisabled();
+    });
+    expect(onDeleted).not.toHaveBeenCalled();
+  });
+
+  it('keeps overlapping operations on different cards independent', async () => {
+    const pauseResult = createDeferred<Card>();
+    const deleteResult = createDeferred<void>();
+    messages.handle('setPauseStatus', () => pauseResult.promise).handle('removeCard', () => deleteResult.promise);
+    const cards = [
+      createMockCard(State.New, { id: 'first', name: 'First', slug: 'first' }),
+      createMockCard(State.New, { id: 'second', name: 'Second', slug: 'second' }),
+    ];
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        {cards.map((card) => (
+          <CardListItem key={card.id} card={card} isExpanded onToggle={vi.fn()} onDeleted={vi.fn()} />
+        ))}
+      </QueryClientProvider>
+    );
+
+    const pauseButtons = screen.getAllByRole('button', { name: 'Pause' });
+    const deleteButtons = screen.getAllByRole('button', { name: 'Delete' });
+    fireEvent.click(pauseButtons[0]);
+    fireEvent.click(deleteButtons[1]);
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm?' }));
+
+    await vi.waitFor(() => {
+      expect(pauseButtons[0]).toBeDisabled();
+      expect(pauseButtons[1]).not.toBeDisabled();
+      expect(deleteButtons[0]).not.toBeDisabled();
+      expect(deleteButtons[1]).toBeDisabled();
+    });
+
+    await act(async () => {
+      pauseResult.resolve(cards[0]);
+      deleteResult.resolve();
+      await Promise.all([pauseResult.promise, deleteResult.promise]);
+    });
+  });
+});

--- a/todo.md
+++ b/todo.md
@@ -1,7 +1,7 @@
 # Scope card-list mutations and presentation logic (#153)
 
 - [x] Extract pure card-list filtering and ordering logic from `entrypoints/popup/views/card/CardView.tsx` into a nearby utility. Preserve case-insensitive name matching and ID substring matching, sort fully numeric IDs numerically, place nonnumeric IDs in a documented deterministic fallback order, and add a stable tie-breaker.
-- [ ] Add focused utility tests for empty and case-insensitive filters, ID matches, numeric ordering, leading-zero/equal numeric IDs, mixed numeric and nonnumeric IDs, and deterministic ordering among nonnumeric IDs.
+- [x] Add focused utility tests for empty and case-insensitive filters, ID matches, numeric ordering, leading-zero/equal numeric IDs, mixed numeric and nonnumeric IDs, and deterministic ordering among nonnumeric IDs.
 - [ ] Extract an entity-scoped card-list item container under `entrypoints/popup/views/card/components/`. Move pause/resume and delete mutations, pending/error ownership, timed delete confirmation, card details, and item presentation into it while keeping each card's operations independent.
 - [ ] Keep `CardView` responsible only for loading/empty states, filter input, invoking the pure filter/order utility, and the list-level expanded-card set. Have the item notify `CardView` after successful deletion so removed cards are also removed from expansion state.
 - [ ] Preserve existing behavior and accessibility: multiple cards may remain expanded, disclosure buttons retain `aria-expanded`, problem links retain their accessible labels and safe new-tab attributes, action buttons disable only for their own pending operation, and failed operations become usable again with item-specific error handling.

--- a/todo.md
+++ b/todo.md
@@ -1,9 +1,0 @@
-# Scope card-list mutations and presentation logic (#153)
-
-- [x] Extract pure card-list filtering and ordering logic from `entrypoints/popup/views/card/CardView.tsx` into a nearby utility. Preserve case-insensitive name matching and ID substring matching, sort fully numeric IDs numerically, place nonnumeric IDs in a documented deterministic fallback order, and add a stable tie-breaker.
-- [x] Add focused utility tests for empty and case-insensitive filters, ID matches, numeric ordering, leading-zero/equal numeric IDs, mixed numeric and nonnumeric IDs, and deterministic ordering among nonnumeric IDs.
-- [ ] Extract an entity-scoped card-list item container under `entrypoints/popup/views/card/components/`. Move pause/resume and delete mutations, pending/error ownership, timed delete confirmation, card details, and item presentation into it while keeping each card's operations independent.
-- [ ] Keep `CardView` responsible only for loading/empty states, filter input, invoking the pure filter/order utility, and the list-level expanded-card set. Have the item notify `CardView` after successful deletion so removed cards are also removed from expansion state.
-- [ ] Preserve existing behavior and accessibility: multiple cards may remain expanded, disclosure buttons retain `aria-expanded`, problem links retain their accessible labels and safe new-tab attributes, action buttons disable only for their own pending operation, and failed operations become usable again with item-specific error handling.
-- [ ] Refocus `CardView` tests on list orchestration and rendering, and add item-container tests covering pause/resume, two-step delete confirmation and expiry, delete cleanup, failures, and simultaneous operations on different cards (including different operation types) without shared pending or error state.
-- [ ] Run the focused card-view/item/utility tests, then `npm run check`.

--- a/todo.md
+++ b/todo.md
@@ -1,0 +1,9 @@
+# Scope card-list mutations and presentation logic (#153)
+
+- [x] Extract pure card-list filtering and ordering logic from `entrypoints/popup/views/card/CardView.tsx` into a nearby utility. Preserve case-insensitive name matching and ID substring matching, sort fully numeric IDs numerically, place nonnumeric IDs in a documented deterministic fallback order, and add a stable tie-breaker.
+- [ ] Add focused utility tests for empty and case-insensitive filters, ID matches, numeric ordering, leading-zero/equal numeric IDs, mixed numeric and nonnumeric IDs, and deterministic ordering among nonnumeric IDs.
+- [ ] Extract an entity-scoped card-list item container under `entrypoints/popup/views/card/components/`. Move pause/resume and delete mutations, pending/error ownership, timed delete confirmation, card details, and item presentation into it while keeping each card's operations independent.
+- [ ] Keep `CardView` responsible only for loading/empty states, filter input, invoking the pure filter/order utility, and the list-level expanded-card set. Have the item notify `CardView` after successful deletion so removed cards are also removed from expansion state.
+- [ ] Preserve existing behavior and accessibility: multiple cards may remain expanded, disclosure buttons retain `aria-expanded`, problem links retain their accessible labels and safe new-tab attributes, action buttons disable only for their own pending operation, and failed operations become usable again with item-specific error handling.
+- [ ] Refocus `CardView` tests on list orchestration and rendering, and add item-container tests covering pause/resume, two-step delete confirmation and expiry, delete cleanup, failures, and simultaneous operations on different cards (including different operation types) without shared pending or error state.
+- [ ] Run the focused card-view/item/utility tests, then `npm run check`.


### PR DESCRIPTION
- move card actions, pending states, confirmation, and details into an entity-scoped item
- extract tested card filtering and deterministic ID ordering
- cover independent concurrent card operations

Closes #153