### PR TITLE
Restore 4 rationale comments removed in PR #204

### DIFF
--- a/entrypoints/background/index.ts
+++ b/entrypoints/background/index.ts
@@ -23,6 +23,7 @@ async function updateBadge() {
 }
 
 export default defineBackground(() => {
+  // Initialize async and track completion so message handlers can wait
   const readyPromise = (async () => {
     await runMigrations(migrations).catch((error) => {
       console.error('Failed to run migrations:', error);

--- a/entrypoints/content.ts
+++ b/entrypoints/content.ts
@@ -17,6 +17,7 @@ export default defineContentScript({
   matches: ['*://*.leetcode.com/*', '*://*.leetcode.cn/*'],
   runAt: 'document_idle',
   async main() {
+    // Wake up service worker so it's ready when user interacts
     try {
       await sendMessage('ping');
     } catch (error) {

--- a/services/github-sync.ts
+++ b/services/github-sync.ts
@@ -14,6 +14,7 @@ import { STORAGE_KEYS } from './storage-keys';
 
 const GIST_FILENAME = 'leetsrs-backup.json';
 
+// In-memory state for sync status (not persisted)
 let syncInProgress = false;
 let lastError: string | null = null;
 

--- a/services/import-export.ts
+++ b/services/import-export.ts
@@ -139,6 +139,7 @@ export async function prepareImportData(jsonData: string): Promise<PreparedImpor
 }
 
 export async function applyImportData(preparedData: PreparedImportData): Promise<void> {
+  // Preserve PAT before reset (it's not in export for security)
   const existingPat = await storage.getItem<string>(STORAGE_KEYS.githubPat);
 
   await resetAllData();


### PR DESCRIPTION
## Summary
- PR #204 stripped all comments from this branch, including a few that explained non-obvious behavior/rationale rather than restating code
- Restores 4 of those comments:
  - `entrypoints/background/index.ts`: why background init tracks a ready promise
  - `entrypoints/content.ts`: why the content script pings the service worker
  - `services/github-sync.ts`: why sync status is kept in-memory only (not persisted)
  - `services/import-export.ts`: why the PAT is preserved separately from export (security)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TgmnhQ7bhCmK7hkafZ8fMN

---
_Generated by [Claude Code](https://claude.ai/code/session_01TgmnhQ7bhCmK7hkafZ8fMN)_