### PR TITLE
chore: ignore experiments directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ web-ext.config.ts
 devex/
 
 docs/plans
+experiments/


### PR DESCRIPTION
Ignore the local experiments directory so experimental files are not included in version control.

Tests: not run (gitignore-only change)