### PR TITLE
refactor: isolate background registry policy types

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,7 @@ Tests use Vitest, Happy DOM, Testing Library, and WXT's Vitest plugin. Name file
 
 ## Architecture Invariants
 
-- Extend `ExtensionMessageMap` in `shared/messages.ts` and register the corresponding typed `onMessage` handler in `entrypoints/background/index.ts`.
+- Extend `ExtensionMessageMap` in `shared/messages.ts` and add the corresponding typed handler in `entrypoints/background/messaging.ts`. Keep background registry policy types in `entrypoints/background/registry-types.ts`; `shared/messages.ts` owns the public contract and transport exports.
 - Keep `StoredCard` and card codecs in `infrastructure/storage/card-codec.ts` (snapshot contracts may import the type). Learning workflows use `infrastructure/storage/cards.ts`; preserve loaded records and decode only requested cards.
 - Keep card/stat/note storage access in `infrastructure/storage/`; services retain validation, clock/settings reads, and multi-entity write order. Stored records and note keys stay inside persistence except explicit snapshot contracts.
 - Route schema changes through a new, sequential migration in `infrastructure/storage/migrations.ts`.

--- a/entrypoints/background/__tests__/messaging.test.ts
+++ b/entrypoints/background/__tests__/messaging.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
-import type { BackgroundMessageRegistry } from '@/shared/messages';
 import { createDeferred } from '@/test/utils/deferred';
 import { createBackgroundMessageExecutor } from '../messaging';
+import type { BackgroundMessageRegistry } from '../registry-types';
 
 describe('background message executor', () => {
   it('waits for readiness and lets reads bypass queued writes', async () => {

--- a/entrypoints/background/messaging.ts
+++ b/entrypoints/background/messaging.ts
@@ -21,13 +21,8 @@ import { exportData, importData, resetAllData } from '@/services/import-export';
 import { deleteNote, getNote, saveNote } from '@/services/notes';
 import { getSettings, updateSettings } from '@/services/settings';
 import { getCardStateStats, getLastNDaysStats, getNextNDaysStats, getTodayStats } from '@/services/stats';
-import {
-  type BackgroundMessageRegistry,
-  type MessageData,
-  type MessageName,
-  type MessageResult,
-  onMessage,
-} from '@/shared/messages';
+import { type MessageData, type MessageName, type MessageResult, onMessage } from '@/shared/messages';
+import type { BackgroundMessageRegistry } from './registry-types';
 
 export const messages = {
   ping: { kind: 'read', handler: () => 'PONG' as const },

--- a/entrypoints/background/registry-types.ts
+++ b/entrypoints/background/registry-types.ts
@@ -1,0 +1,17 @@
+import type { MaybePromise } from '@webext-core/messaging';
+import type { MessageData, MessageName, MessageResult } from '@/shared/messages';
+
+type BackgroundMessage<Name extends MessageName> = {
+  handler: (data: MessageData<Name>) => MaybePromise<MessageResult<Name>>;
+} & (
+  | { kind: 'read' }
+  | {
+      kind: 'write';
+      syncTrackingOwner: 'executor' | 'handler' | 'none';
+      refreshBadge: boolean;
+    }
+);
+
+export type BackgroundMessageRegistry = {
+  [Name in MessageName]: BackgroundMessage<Name>;
+};

--- a/shared/messages.ts
+++ b/shared/messages.ts
@@ -1,9 +1,4 @@
-import {
-  defineExtensionMessaging,
-  type GetDataType,
-  type GetReturnType,
-  type MaybePromise,
-} from '@webext-core/messaging';
+import { defineExtensionMessaging, type GetDataType, type GetReturnType } from '@webext-core/messaging';
 import type { State as FsrsState } from 'ts-fsrs';
 import type { Card, LeetcodeDomain, ProblemDescriptor, RateCardInput } from '@/domain/cards';
 import type { Note } from '@/domain/notes';
@@ -51,20 +46,5 @@ export interface ExtensionMessageMap {
 export type MessageName = keyof ExtensionMessageMap;
 export type MessageData<Name extends MessageName> = GetDataType<ExtensionMessageMap[Name]>;
 export type MessageResult<Name extends MessageName> = GetReturnType<ExtensionMessageMap[Name]>;
-
-type BackgroundMessage<Name extends MessageName> = {
-  handler: (data: MessageData<Name>) => MaybePromise<MessageResult<Name>>;
-} & (
-  | { kind: 'read' }
-  | {
-      kind: 'write';
-      syncTrackingOwner: 'executor' | 'handler' | 'none';
-      refreshBadge: boolean;
-    }
-);
-
-export type BackgroundMessageRegistry = {
-  [Name in MessageName]: BackgroundMessage<Name>;
-};
 
 export const { onMessage, sendMessage } = defineExtensionMessaging<ExtensionMessageMap>();


### PR DESCRIPTION
- Move background registry policy types beside the executor, keeping public message contracts and transport exports in `shared/messages.ts`.
- Preserve exhaustive handler typing and runtime behavior; update test imports and repository guidance.

Closes #246