### PR TITLE
ci: enforce Markdown formatting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,9 @@ jobs:
       - name: Check formatting and linting
         run: npx biome check --error-on-warnings .
 
+      - name: Check Markdown formatting
+        run: npm run format:markdown:check
+
       - name: Type check
         run: npm run compile
 

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,6 @@
+.wxt/
+.output/
+dist/
+coverage/
+experiments/
+CHANGELOG.md

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,3 +1,3 @@
 {
-  "recommendations": ["biomejs.biome", "bradlc.vscode-tailwindcss"]
+  "recommendations": ["biomejs.biome", "bradlc.vscode-tailwindcss", "esbenp.prettier-vscode"]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -20,6 +20,9 @@
   "[jsonc]": {
     "editor.defaultFormatter": "biomejs.biome"
   },
+  "[markdown]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
   "[css]": {
     "editor.defaultFormatter": "biomejs.biome"
   }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,9 +14,12 @@ Use Node.js 24+ and install dependencies with `npm install`.
 - `npm test` runs the Vitest suite once.
 - `npm run compile` performs TypeScript checking without emitting files.
 - `npm run lint` and `npm run format:check` check style.
+- `npm run format:markdown` formats all Markdown files with Prettier, respecting `.prettierignore`.
 - `npm run check` checks formatting, lints, type-checks, and tests.
 
 ## Coding Style & Naming Conventions
+
+After writing or editing any Markdown file, always run `npm run format:markdown` across the repository, including formatting fixes in files you did not edit.
 
 Use TypeScript/TSX, ES modules, two-space indentation, single quotes, and semicolons; Biome enforces these rules. Avoid `any`; prefix intentionally unused names with `_`. Use PascalCase for components (`ReviewQueue.tsx`), `use` plus camelCase for hooks (`useNoteEditor.ts`), and kebab-case for utilities and services (`github-sync.ts`). Keep domain logic out of UI components.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "@vitest/ui": "^4.1.11",
         "@wxt-dev/module-react": "^1.1.3",
         "happy-dom": "^20.12.2",
+        "prettier": "^3.9.6",
         "typescript": "^7.0.2",
         "vite": "^8.2.2",
         "vitest": "^4.1.10",
@@ -7118,6 +7119,22 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.9.6",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.6.tgz",
+      "integrity": "sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/pretty-format": {

--- a/package.json
+++ b/package.json
@@ -17,11 +17,13 @@
     "lint": "biome lint .",
     "lint:fix": "biome lint --write .",
     "format": "biome format --write .",
+    "format:markdown": "prettier --write \"**/*.md\"",
+    "format:markdown:check": "prettier --check \"**/*.md\"",
     "format:check": "biome format .",
     "test": "vitest --run",
     "test:ui": "vitest --ui",
     "test:verbose": "vitest --run --reporter=verbose",
-    "check": "biome check --error-on-warnings . && npm run compile && npm test",
+    "check": "biome check --error-on-warnings . && npm run format:markdown:check && npm run compile && npm test",
     "postinstall": "wxt prepare"
   },
   "dependencies": {
@@ -51,6 +53,7 @@
     "@vitest/ui": "^4.1.11",
     "@wxt-dev/module-react": "^1.1.3",
     "happy-dom": "^20.12.2",
+    "prettier": "^3.9.6",
     "typescript": "^7.0.2",
     "vite": "^8.2.2",
     "vitest": "^4.1.10",


### PR DESCRIPTION
- Add Prettier Markdown formatting, VS Code integration, and agent instructions to format all Markdown after edits.
- Check Markdown formatting in CI and local checks, excluding generated files and the release changelog.
