### PR TITLE
test: remove implementation-prescribing and redundant coverage

### DIFF
--- a/domain/__tests__/review.test.ts
+++ b/domain/__tests__/review.test.ts
@@ -1,267 +1,29 @@
-import { createEmptyCard, State as FsrsState, State } from 'ts-fsrs';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { State } from 'ts-fsrs';
+import { describe, expect, it } from 'vitest';
 import type { Card } from '@/domain/cards';
 import { createMockCard } from '@/test/utils/card-mocks';
 import { buildReviewQueue, calculateDelayedDueDate, isDueByDate } from '../review';
 
 describe('isDueByDate', () => {
-  beforeEach(() => {
-    vi.useFakeTimers();
-    // Set a specific local time for testing
-    vi.setSystemTime(new Date('2024-01-15T14:30:00')); // 2:30 PM local time
+  it.each([
+    ['2024-01-14T10:00:00', true],
+    ['2024-01-15T00:00:00', true],
+    ['2024-01-15T08:00:00', true],
+    ['2024-01-15T23:59:59.999', true],
+    ['2024-01-16T00:00:00', false],
+    ['2024-01-20T10:00:00', false],
+  ])('checks due date %s against the local calendar day', (due, expected) => {
+    const card = dueCard('card', due, State.Review);
+    expect(isDueByDate(card, new Date('2024-01-15T14:30:00'))).toBe(expected);
   });
 
-  afterEach(() => {
-    vi.useRealTimers();
-  });
-
-  it('should return true for new cards with due date today', () => {
-    const newCard: Card = {
-      id: 'test-id',
-      slug: 'test-problem',
-      name: 'Test Problem',
-      leetcodeId: '1',
-      difficulty: 'Easy',
-      createdAt: new Date(),
-      fsrs: createEmptyCard(), // createEmptyCard sets due date to now
-      paused: false,
-      domain: 'leetcode.com',
-    };
-
-    expect(isDueByDate(newCard, new Date())).toBe(true);
-  });
-
-  it('should return true for cards due today (earlier time)', () => {
-    const now = new Date();
-    const dueToday = new Date(now.getFullYear(), now.getMonth(), now.getDate(), 8, 0, 0); // 8 AM today
-
-    const card: Card = {
-      id: 'test-id',
-      slug: 'test-problem',
-      name: 'Test Problem',
-      leetcodeId: '1',
-      difficulty: 'Easy',
-      createdAt: new Date('2024-01-10'),
-      fsrs: {
-        ...createEmptyCard(),
-        state: FsrsState.Learning,
-        due: dueToday,
-      },
-      paused: false,
-      domain: 'leetcode.com',
-    };
-
-    expect(isDueByDate(card, new Date())).toBe(true);
-  });
-
-  it('should return true for cards due today (later time)', () => {
-    const now = new Date();
-    const dueToday = new Date(now.getFullYear(), now.getMonth(), now.getDate(), 23, 59, 59); // 11:59 PM today
-
-    const card: Card = {
-      id: 'test-id',
-      slug: 'test-problem',
-      name: 'Test Problem',
-      leetcodeId: '1',
-      difficulty: 'Easy',
-      createdAt: new Date('2024-01-10'),
-      fsrs: {
-        ...createEmptyCard(),
-        state: FsrsState.Review,
-        due: dueToday,
-      },
-      paused: false,
-      domain: 'leetcode.com',
-    };
-
-    expect(isDueByDate(card, new Date())).toBe(true);
-  });
-
-  it('should return true for cards due in the past', () => {
-    const now = new Date();
-    const yesterday = new Date(now.getFullYear(), now.getMonth(), now.getDate() - 1, 10, 0, 0);
-
-    const card: Card = {
-      id: 'test-id',
-      slug: 'test-problem',
-      name: 'Test Problem',
-      leetcodeId: '1',
-      difficulty: 'Easy',
-      createdAt: new Date('2024-01-10'),
-      fsrs: {
-        ...createEmptyCard(),
-        state: FsrsState.Review,
-        due: yesterday,
-      },
-      paused: false,
-      domain: 'leetcode.com',
-    };
-
-    expect(isDueByDate(card, new Date())).toBe(true);
-  });
-
-  it('should return false for cards due tomorrow', () => {
-    const now = new Date();
-    const tomorrow = new Date(now.getFullYear(), now.getMonth(), now.getDate() + 1, 0, 0, 1); // 12:00:01 AM tomorrow
-
-    const card: Card = {
-      id: 'test-id',
-      slug: 'test-problem',
-      name: 'Test Problem',
-      leetcodeId: '1',
-      difficulty: 'Easy',
-      createdAt: new Date('2024-01-10'),
-      fsrs: {
-        ...createEmptyCard(),
-        state: FsrsState.Review,
-        due: tomorrow,
-      },
-      paused: false,
-      domain: 'leetcode.com',
-    };
-
-    expect(isDueByDate(card, new Date())).toBe(false);
-  });
-
-  it('should return false for cards due in the future', () => {
-    const now = new Date();
-    const futureDate = new Date(now.getFullYear(), now.getMonth(), now.getDate() + 5, 10, 0, 0); // 5 days from now
-
-    const card: Card = {
-      id: 'test-id',
-      slug: 'test-problem',
-      name: 'Test Problem',
-      leetcodeId: '1',
-      difficulty: 'Easy',
-      createdAt: new Date('2024-01-10'),
-      fsrs: {
-        ...createEmptyCard(),
-        state: FsrsState.Review,
-        due: futureDate,
-      },
-      paused: false,
-      domain: 'leetcode.com',
-    };
-
-    expect(isDueByDate(card, new Date())).toBe(false);
-  });
-
-  it('should handle cards due at exactly midnight today', () => {
-    const now = new Date();
-    const midnightToday = new Date(now.getFullYear(), now.getMonth(), now.getDate(), 0, 0, 0);
-
-    const card: Card = {
-      id: 'test-id',
-      slug: 'test-problem',
-      name: 'Test Problem',
-      leetcodeId: '1',
-      difficulty: 'Easy',
-      createdAt: new Date('2024-01-10'),
-      fsrs: {
-        ...createEmptyCard(),
-        state: FsrsState.Learning,
-        due: midnightToday,
-      },
-      paused: false,
-      domain: 'leetcode.com',
-    };
-
-    expect(isDueByDate(card, new Date())).toBe(true);
-  });
-
-  it('should handle cards due at 23:59:59 today', () => {
-    const now = new Date();
-    const endOfToday = new Date(now.getFullYear(), now.getMonth(), now.getDate(), 23, 59, 59, 999);
-
-    const card: Card = {
-      id: 'test-id',
-      slug: 'test-problem',
-      name: 'Test Problem',
-      leetcodeId: '1',
-      difficulty: 'Easy',
-      createdAt: new Date('2024-01-10'),
-      fsrs: {
-        ...createEmptyCard(),
-        state: FsrsState.Review,
-        due: endOfToday,
-      },
-      paused: false,
-      domain: 'leetcode.com',
-    };
-
-    expect(isDueByDate(card, new Date())).toBe(true);
-  });
-
-  it('should correctly handle date comparison in local timezone', () => {
-    // Test at different times of day to ensure date comparison works
-    const testTimes = [
-      new Date('2024-01-15T00:00:00'), // Midnight local
-      new Date('2024-01-15T06:00:00'), // 6 AM local
-      new Date('2024-01-15T12:00:00'), // Noon local
-      new Date('2024-01-15T18:00:00'), // 6 PM local
-      new Date('2024-01-15T23:59:59'), // End of day local
-    ];
-
-    testTimes.forEach((time) => {
-      vi.setSystemTime(time);
-
-      // Create a card due at any time today
-      const cardDueToday: Card = {
-        id: 'test-id',
-        slug: 'test-problem',
-        name: 'Test Problem',
-        leetcodeId: '1',
-        difficulty: 'Easy',
-        createdAt: new Date('2024-01-10'),
-        fsrs: {
-          ...createEmptyCard(),
-          state: FsrsState.Review,
-          due: new Date('2024-01-15T10:00:00'), // 10 AM on the same day
-        },
-        paused: false,
-        domain: 'leetcode.com',
-      };
-
-      expect(isDueByDate(cardDueToday, new Date())).toBe(true);
-    });
-  });
-
-  it('should handle timezone edge cases correctly', () => {
-    // Test that a card due today in local timezone is included
-    // even if it might be tomorrow in UTC
-    vi.setSystemTime(new Date('2024-01-15T23:00:00')); // 11 PM local time
-
-    const now = new Date();
-    const cardDueToday: Card = {
-      id: 'test-id',
-      slug: 'test-problem',
-      name: 'Test Problem',
-      leetcodeId: '1',
-      difficulty: 'Easy',
-      createdAt: new Date('2024-01-10'),
-      fsrs: {
-        ...createEmptyCard(),
-        state: FsrsState.Review,
-        // Due at noon today local time
-        due: new Date(now.getFullYear(), now.getMonth(), now.getDate(), 12, 0, 0),
-      },
-      paused: false,
-      domain: 'leetcode.com',
-    };
-
-    expect(isDueByDate(cardDueToday, new Date())).toBe(true);
-
-    // Card due tomorrow should not be included
-    const cardDueTomorrow: Card = {
-      ...cardDueToday,
-      fsrs: {
-        ...cardDueToday.fsrs,
-        due: new Date(now.getFullYear(), now.getMonth(), now.getDate() + 1, 0, 0, 1),
-      },
-    };
-
-    expect(isDueByDate(cardDueTomorrow, new Date())).toBe(false);
-  });
+  it.each([State.New, State.Learning, State.Review, State.Relearning])(
+    'includes state %s due later on the same local day',
+    (state) => {
+      const card = dueCard('card', '2024-01-15T23:59:59.999', state);
+      expect(isDueByDate(card, new Date('2024-01-15T00:00:00'))).toBe(true);
+    }
+  );
 });
 
 describe('review-day boundaries', () => {

--- a/entrypoints/popup/views/stats/__tests__/CardDistributionChart.test.tsx
+++ b/entrypoints/popup/views/stats/__tests__/CardDistributionChart.test.tsx
@@ -2,7 +2,7 @@
  * @vitest-environment happy-dom
  */
 
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import { State as FsrsState } from 'ts-fsrs';
 import { describe, expect, it, vi } from 'vitest';
 import { statsQueryKeys } from '@/entrypoints/popup/queries/stats';
@@ -14,12 +14,8 @@ import { CardDistributionChart } from '../CardDistributionChart';
 
 // Mock react-chartjs-2
 vi.mock('react-chartjs-2', () => ({
-  Doughnut: ({ data, options }: { data: unknown; options: unknown }) => (
-    <div
-      data-testid="doughnut-chart"
-      data-chart-data={JSON.stringify(data)}
-      data-chart-options={JSON.stringify(options)}
-    >
+  Doughnut: ({ data }: { data: unknown }) => (
+    <div data-testid="doughnut-chart" data-chart-data={JSON.stringify(data)}>
       Doughnut Chart
     </div>
   ),
@@ -45,59 +41,15 @@ describe('CardDistributionChart', () => {
     return render(<CardDistributionChart />, { wrapper });
   };
 
-  it('should render the card distribution section', () => {
-    renderChart();
-
-    expect(screen.getByRole('heading', { name: 'Card Distribution' })).toBeInTheDocument();
-  });
-
-  it('should render the doughnut chart', () => {
-    renderChart();
-
-    const chart = screen.getByTestId('doughnut-chart');
-    expect(chart).toBeInTheDocument();
-  });
-
   it('should pass correct data to the doughnut chart', () => {
     renderChart();
 
     const chart = screen.getByTestId('doughnut-chart');
     const chartData = JSON.parse(chart.getAttribute('data-chart-data') || '{}');
 
+    expect(screen.getByRole('heading', { name: 'Card Distribution' })).toBeInTheDocument();
     expect(chartData.labels).toEqual(['New', 'Learning', 'Review', 'Relearning']);
     expect(chartData.datasets[0].data).toEqual([5, 3, 8, 2]);
-  });
-
-  it('should render chart with correct options', () => {
-    renderChart();
-
-    const chart = screen.getByTestId('doughnut-chart');
-    const chartOptions = JSON.parse(chart.getAttribute('data-chart-options') || '{}');
-
-    expect(chartOptions.responsive).toBe(true);
-    expect(chartOptions.maintainAspectRatio).toBe(false);
-    expect(chartOptions.plugins.legend.position).toBe('top');
-  });
-
-  it('should render zeros when no stats data is available', () => {
-    const pending = createDeferred<Record<FsrsState, number>>();
-    messages.reset().resolve('getCardStateStats', pending.promise);
-    const { wrapper } = createTestWrapper();
-    const view = render(<CardDistributionChart />, { wrapper });
-
-    const chart = screen.getByTestId('doughnut-chart');
-    const chartData = JSON.parse(chart.getAttribute('data-chart-data') || '{}');
-
-    expect(chartData.datasets[0].data).toEqual([0, 0, 0, 0]);
-    view.unmount();
-    pending.resolve(mockCardStateStats);
-  });
-
-  it('should set chart container height', () => {
-    renderChart();
-
-    const chartContainer = screen.getByTestId('doughnut-chart').parentElement;
-    expect(chartContainer).toHaveStyle({ height: '200px' });
   });
 
   describe('loading state', () => {
@@ -119,10 +71,11 @@ describe('CardDistributionChart', () => {
   });
 
   describe('error state', () => {
-    it('should handle error state gracefully', () => {
+    it('should handle error state gracefully', async () => {
       messages.reset().handle('getCardStateStats', () => Promise.reject(new Error('Failed to fetch stats')));
-      const { wrapper } = createTestWrapper();
+      const { wrapper, queryClient } = createTestWrapper();
       render(<CardDistributionChart />, { wrapper });
+      await waitFor(() => expect(queryClient.getQueryState(statsQueryKeys.cardState)?.status).toBe('error'));
 
       // Chart should still render with default data
       const chart = screen.getByTestId('doughnut-chart');
@@ -146,20 +99,6 @@ describe('CardDistributionChart', () => {
       const chartData = JSON.parse(chart.getAttribute('data-chart-data') || '{}');
 
       expect(chartData.datasets[0].data).toEqual([0, 0, 0, 0]);
-    });
-
-    it('should handle large numbers', () => {
-      renderChart({
-        [FsrsState.New]: 1000,
-        [FsrsState.Learning]: 500,
-        [FsrsState.Review]: 2500,
-        [FsrsState.Relearning]: 100,
-      });
-
-      const chart = screen.getByTestId('doughnut-chart');
-      const chartData = JSON.parse(chart.getAttribute('data-chart-data') || '{}');
-
-      expect(chartData.datasets[0].data).toEqual([1000, 500, 2500, 100]);
     });
   });
 });

--- a/entrypoints/popup/views/stats/__tests__/ReviewHistoryChart.test.tsx
+++ b/entrypoints/popup/views/stats/__tests__/ReviewHistoryChart.test.tsx
@@ -18,8 +18,8 @@ import { ReviewHistoryChart } from '../ReviewHistoryChart';
 
 // Mock react-chartjs-2
 vi.mock('react-chartjs-2', () => ({
-  Bar: ({ data, options }: { data: unknown; options: unknown }) => (
-    <div data-testid="bar-chart" data-chart-data={JSON.stringify(data)} data-chart-options={JSON.stringify(options)}>
+  Bar: ({ data }: { data: unknown }) => (
+    <div data-testid="bar-chart" data-chart-data={JSON.stringify(data)}>
       Bar Chart
     </div>
   ),
@@ -74,19 +74,6 @@ describe('Bar Chart (Last 30 Days Review History)', () => {
     );
   };
 
-  it('should render the review history section', () => {
-    renderChart();
-
-    expect(screen.getByRole('heading', { name: 'Last 30 Days Review History' })).toBeInTheDocument();
-  });
-
-  it('should render the bar chart', () => {
-    renderChart();
-
-    const chart = screen.getByTestId('bar-chart');
-    expect(chart).toBeInTheDocument();
-  });
-
   it.each(['en', 'pl'] as const)('passes ordered localized datasets and correct grade counts in %s', (language) => {
     renderChart(mockLast30DaysStats, language);
     const t = translations[language];
@@ -95,6 +82,7 @@ describe('Bar Chart (Last 30 Days Review History)', () => {
     const chartData = JSON.parse(chart.getAttribute('data-chart-data') || '{}');
 
     expect(chartData.labels).toEqual(['5/15', '5/16']);
+    expect(sendMessage).toHaveBeenCalledWith('getLastNDaysStats', { days: 30 });
 
     // Check datasets
     expect(chartData.datasets).toHaveLength(4);
@@ -108,16 +96,6 @@ describe('Bar Chart (Last 30 Days Review History)', () => {
     expect(chartData.datasets[3].data).toEqual([4, 6]);
   });
 
-  it('should configure bar chart as stacked', () => {
-    renderChart();
-
-    const chart = screen.getByTestId('bar-chart');
-    const chartOptions = JSON.parse(chart.getAttribute('data-chart-options') || '{}');
-
-    expect(chartOptions.scales.x.stacked).toBe(true);
-    expect(chartOptions.scales.y.stacked).toBe(true);
-  });
-
   it('should handle empty data gracefully', () => {
     renderChart([]);
 
@@ -129,25 +107,5 @@ describe('Bar Chart (Last 30 Days Review History)', () => {
     expect(chartData.datasets[1].data).toEqual([]);
     expect(chartData.datasets[2].data).toEqual([]);
     expect(chartData.datasets[3].data).toEqual([]);
-  });
-
-  it('should request exactly 30 days of data', () => {
-    renderChart();
-
-    expect(sendMessage).toHaveBeenCalledWith('getLastNDaysStats', { days: 30 });
-  });
-
-  it('should apply correct CSS classes to review history section', () => {
-    renderChart();
-
-    const reviewSection = screen.getByRole('heading', { name: 'Last 30 Days Review History' }).parentElement;
-    expect(reviewSection).toHaveClass('mb-6', 'p-4', 'rounded-lg');
-  });
-
-  it('should set bar chart container height', () => {
-    renderChart();
-
-    const chartContainer = screen.getByTestId('bar-chart').parentElement;
-    expect(chartContainer).toHaveStyle({ height: '250px' });
   });
 });

--- a/entrypoints/popup/views/stats/__tests__/StatsView.test.tsx
+++ b/entrypoints/popup/views/stats/__tests__/StatsView.test.tsx
@@ -42,29 +42,12 @@ describe('StatsView', () => {
     return render(<StatsView />, { wrapper });
   };
 
-  it('should render the streak counter in header', () => {
+  it('renders the streak in the header and all three charts', () => {
     renderStatsView();
 
-    const headerContent = screen.getByTestId('header-content');
-    expect(headerContent).toBeInTheDocument();
-    expect(screen.getByTestId('streak-counter')).toBeInTheDocument();
-  });
-
-  it('should render all three chart components', () => {
-    renderStatsView();
-
+    expect(screen.getByTestId('header-content')).toContainElement(screen.getByTestId('streak-counter'));
     expect(screen.getByTestId('card-distribution-chart')).toBeInTheDocument();
     expect(screen.getByTestId('review-history-chart')).toBeInTheDocument();
     expect(screen.getByTestId('upcoming-reviews-chart')).toBeInTheDocument();
-  });
-
-  it('should render charts in correct order', () => {
-    renderStatsView();
-
-    const charts = screen.getAllByTestId(/chart$/);
-    expect(charts).toHaveLength(3);
-    expect(charts[0]).toHaveAttribute('data-testid', 'card-distribution-chart');
-    expect(charts[1]).toHaveAttribute('data-testid', 'review-history-chart');
-    expect(charts[2]).toHaveAttribute('data-testid', 'upcoming-reviews-chart');
   });
 });

--- a/entrypoints/popup/views/stats/__tests__/UpcomingReviewsChart.test.tsx
+++ b/entrypoints/popup/views/stats/__tests__/UpcomingReviewsChart.test.tsx
@@ -14,8 +14,8 @@ import { UpcomingReviewsChart } from '../UpcomingReviewsChart';
 
 // Mock react-chartjs-2
 vi.mock('react-chartjs-2', () => ({
-  Line: ({ data, options }: { data: unknown; options: unknown }) => (
-    <div data-testid="line-chart" data-chart-data={JSON.stringify(data)} data-chart-options={JSON.stringify(options)}>
+  Line: ({ data }: { data: unknown }) => (
+    <div data-testid="line-chart" data-chart-data={JSON.stringify(data)}>
       Line Chart
     </div>
   ),
@@ -34,7 +34,7 @@ describe('UpcomingReviewsChart', () => {
     },
     {
       date: '2024-05-16',
-      count: 3,
+      count: 0,
     },
     {
       date: '2024-05-17',
@@ -49,57 +49,20 @@ describe('UpcomingReviewsChart', () => {
     return render(<UpcomingReviewsChart />, { wrapper });
   };
 
-  it('should render the upcoming reviews section', () => {
-    renderChart();
-
-    expect(screen.getByRole('heading', { name: 'Upcoming Reviews (Next 14 Days)' })).toBeInTheDocument();
-  });
-
-  it('should render the line chart', () => {
-    renderChart();
-
-    const chart = screen.getByTestId('line-chart');
-    expect(chart).toBeInTheDocument();
-  });
-
   it('should pass correct data to the line chart', () => {
     renderChart();
 
     const chart = screen.getByTestId('line-chart');
     const chartData = JSON.parse(chart.getAttribute('data-chart-data') || '{}');
 
-    // Check labels exist and are formatted as MM/DD
-    expect(chartData.labels).toHaveLength(3);
-    expect(chartData.labels[0]).toMatch(/^\d{1,2}\/\d{1,2}$/);
-    expect(chartData.labels[1]).toMatch(/^\d{1,2}\/\d{1,2}$/);
-    expect(chartData.labels[2]).toMatch(/^\d{1,2}\/\d{1,2}$/);
+    expect(chartData.labels).toEqual(['5/15', '5/16', '5/17']);
+    expect(screen.getByRole('heading', { name: 'Upcoming Reviews (Next 14 Days)' })).toBeInTheDocument();
+    expect(sendMessage).toHaveBeenCalledWith('getNextNDaysStats', { days: 14 });
 
     // Check dataset
     expect(chartData.datasets).toHaveLength(1);
     expect(chartData.datasets[0].label).toBe('Cards Due');
-    expect(chartData.datasets[0].data).toEqual([5, 3, 8]);
-  });
-
-  it('should use correct styling for the line', () => {
-    renderChart();
-
-    const chart = screen.getByTestId('line-chart');
-    const chartData = JSON.parse(chart.getAttribute('data-chart-data') || '{}');
-
-    expect(chartData.datasets[0].tension).toBe(0.1);
-  });
-
-  it('should configure line chart options correctly', () => {
-    renderChart();
-
-    const chart = screen.getByTestId('line-chart');
-    const chartOptions = JSON.parse(chart.getAttribute('data-chart-options') || '{}');
-
-    expect(chartOptions.responsive).toBe(true);
-    expect(chartOptions.maintainAspectRatio).toBe(false);
-    expect(chartOptions.scales.y.beginAtZero).toBe(true);
-    expect(chartOptions.scales.y.ticks.stepSize).toBe(1);
-    expect(chartOptions.plugins.legend.display).toBe(false);
+    expect(chartData.datasets[0].data).toEqual([5, 0, 8]);
   });
 
   it('should handle empty data gracefully', () => {
@@ -110,26 +73,6 @@ describe('UpcomingReviewsChart', () => {
 
     expect(chartData.labels).toEqual([]);
     expect(chartData.datasets[0].data).toEqual([]);
-  });
-
-  it('should request exactly 14 days of data', () => {
-    renderChart();
-
-    expect(sendMessage).toHaveBeenCalledWith('getNextNDaysStats', { days: 14 });
-  });
-
-  it('should apply correct CSS classes to upcoming reviews section', () => {
-    renderChart();
-
-    const section = screen.getByRole('heading', { name: 'Upcoming Reviews (Next 14 Days)' }).parentElement;
-    expect(section).toHaveClass('mb-6', 'p-4', 'rounded-lg');
-  });
-
-  it('should set line chart container height', () => {
-    renderChart();
-
-    const chartContainer = screen.getByTestId('line-chart').parentElement;
-    expect(chartContainer).toHaveStyle({ height: '250px' });
   });
 
   it('should handle loading state gracefully', () => {
@@ -147,22 +90,5 @@ describe('UpcomingReviewsChart', () => {
     expect(chartData.datasets[0].data).toEqual([]);
     view.unmount();
     pending.resolve([]);
-  });
-
-  it('should handle dates with no reviews', () => {
-    const statsWithZeros: UpcomingReviewStats[] = [
-      { date: '2024-05-15', count: 5 },
-      { date: '2024-05-16', count: 0 },
-      { date: '2024-05-17', count: 3 },
-      { date: '2024-05-18', count: 0 },
-      { date: '2024-05-19', count: 7 },
-    ];
-
-    renderChart(statsWithZeros);
-
-    const chart = screen.getByTestId('line-chart');
-    const chartData = JSON.parse(chart.getAttribute('data-chart-data') || '{}');
-
-    expect(chartData.datasets[0].data).toEqual([5, 0, 3, 0, 7]);
   });
 });

--- a/services/__tests__/cards.test.ts
+++ b/services/__tests__/cards.test.ts
@@ -1688,11 +1688,6 @@ describe('getReviewQueue', () => {
     expect(queue[1].slug).toBe('card-10'); // '10' comes after '1' in string sort
   });
 
-  it('should handle empty queue gracefully', async () => {
-    const queue = await getReviewQueue();
-    expect(queue).toEqual([]);
-  });
-
   it('should handle queue with only paused cards', async () => {
     await addCard({
       slug: 'paused-1',
@@ -1792,30 +1787,5 @@ describe('getReviewQueue', () => {
     // But new2 and new4 are paused, so only new1 and new3 are available
     // So we should get: new1 (or new3) + review2 = 2 total
     expect(queue).toHaveLength(2);
-  });
-
-  it('should handle all cards being paused', async () => {
-    // Create and pause all cards
-    await addCard({
-      slug: 'paused1',
-      name: 'Paused 1',
-      leetcodeId: '3001',
-      difficulty: 'Easy',
-      domain: 'leetcode.com',
-    });
-    await addCard({
-      slug: 'paused2',
-      name: 'Paused 2',
-      leetcodeId: '3002',
-      difficulty: 'Medium',
-      domain: 'leetcode.com',
-    });
-    await setPauseStatus('paused1', true);
-    await setPauseStatus('paused2', true);
-
-    const queue = await getReviewQueue();
-
-    // Should return empty queue when all cards are paused
-    expect(queue).toEqual([]);
   });
 });

--- a/services/__tests__/gist-setup.test.ts
+++ b/services/__tests__/gist-setup.test.ts
@@ -2,17 +2,8 @@ import { Octokit } from 'octokit';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { fakeBrowser } from 'wxt/testing/fake-browser';
 import { storage } from 'wxt/utils/storage';
-import { createGitHubClient } from '@/infrastructure/github/client';
 import { STORAGE_KEYS } from '@/infrastructure/storage/storage-keys';
-import {
-  createGist,
-  createNewGist,
-  getGistDestinationConfig,
-  getGistSyncConfig,
-  setGistSyncConfig,
-  validateGist,
-  validateGistId,
-} from '../gist-setup';
+import { createNewGist, getGistSyncConfig, setGistSyncConfig, validateGistId } from '../gist-setup';
 import * as auth from '../github-auth';
 
 const { getGist, create, getAuthenticated, exportData } = vi.hoisted(() => ({
@@ -38,63 +29,26 @@ describe('gist-setup boundaries', () => {
   it.each([
     { name: 'empty storage', saved: false, expected: { pat: '', gistId: null, enabled: false } },
     { name: 'saved configuration', saved: true, expected: { pat: 'token', gistId: 'gist', enabled: true } },
-  ])('reads $name through destination and combined configuration', async ({ saved, expected }) => {
+  ])('reads $name', async ({ saved, expected }) => {
     if (saved) {
       await storage.setItem(STORAGE_KEYS.githubPat, expected.pat);
       await storage.setItem(STORAGE_KEYS.gistId, expected.gistId);
       await storage.setItem(STORAGE_KEYS.gistSyncEnabled, expected.enabled);
     }
-    const reads = vi.spyOn(storage, 'getItem');
-    expect(await getGistDestinationConfig()).toEqual({ gistId: expected.gistId, enabled: expected.enabled });
-    expect(reads.mock.calls.map(([key]) => key)).not.toContain(STORAGE_KEYS.githubPat);
     expect(await getGistSyncConfig()).toEqual(expected);
   });
 
-  it('writes credentials, destination, and enabled in order', async () => {
-    const writes = vi.spyOn(storage, 'setItem');
-    await setGistSyncConfig({ pat: ' token ', gistId: 'gist', enabled: true });
-    expect(writes.mock.calls).toEqual([
-      [STORAGE_KEYS.githubPat, ' token '],
-      [STORAGE_KEYS.gistId, 'gist'],
-      [STORAGE_KEYS.gistSyncEnabled, true],
-    ]);
+  it('persists the complete configuration without marking learning data edited', async () => {
+    const config = { pat: ' token ', gistId: 'gist', enabled: true };
+    await setGistSyncConfig(config);
+    expect(await getGistSyncConfig()).toEqual(config);
+    expect(await storage.getItem(STORAGE_KEYS.dataUpdatedAt)).toBeNull();
   });
-
-  it.each(['validate', 'create'] as const)(
-    'can %s with a supplied client without credential access',
-    async (operation) => {
-      const client = createGitHubClient('supplied');
-      const acquire = vi.spyOn(auth, 'getAuthenticatedGitHubClient');
-      const reads = vi.spyOn(storage, 'getItem');
-      getGist.mockResolvedValue({ data: { files: { 'leetsrs-backup.json': {} } } });
-      create.mockResolvedValue({ data: { id: 'created' } });
-      exportData.mockResolvedValue('{"snapshot":true}');
-
-      if (operation === 'validate') {
-        expect(await validateGist(' gist ', client)).toEqual({ valid: true });
-        expect(getGist).toHaveBeenCalledExactlyOnceWith({ gist_id: ' gist ' });
-      } else {
-        expect(await createGist(client)).toEqual({ gistId: 'created' });
-        expect(create).toHaveBeenCalledExactlyOnceWith({
-          description: expect.any(String),
-          public: false,
-          files: { 'leetsrs-backup.json': { content: '{"snapshot":true}' } },
-        });
-      }
-      expect(acquire).not.toHaveBeenCalled();
-      expect(getAuthenticated).not.toHaveBeenCalled();
-      expect(reads.mock.calls.map(([key]) => key)).not.toContain(STORAGE_KEYS.githubPat);
-    }
-  );
 
   it.each(['', ' \t\n'])('rejects blank Gist ID %j without acquiring a client or requesting a Gist', async (gistId) => {
     const acquire = vi.spyOn(auth, 'getAuthenticatedGitHubClient');
     expect(await validateGistId(gistId, 'token')).toEqual({ valid: false, error: 'Gist ID is required' });
     expect(acquire).not.toHaveBeenCalled();
-    expect(await validateGist(gistId, createGitHubClient('supplied'))).toEqual({
-      valid: false,
-      error: 'Gist ID is required',
-    });
     expect(getGist).not.toHaveBeenCalled();
   });
 
@@ -127,24 +81,21 @@ describe('gist-setup boundaries', () => {
     expect(getGist).toHaveBeenCalledTimes(stage === 'acquisition' ? 0 : 1);
   });
 
-  it('preserves configuration-read failures before creation acquires its client', async () => {
+  it('propagates configuration-read failures during creation', async () => {
     await storage.setItem(STORAGE_KEYS.githubPat, 'saved');
     const read = storage.getItem.bind(storage);
     vi.spyOn(storage, 'getItem').mockImplementation((key, options) => {
       if (key === STORAGE_KEYS.gistId) return Promise.reject(new Error('read failed'));
       return read(key, options);
     });
-    const acquire = vi.spyOn(auth, 'getAuthenticatedGitHubClient');
-
     await expect(createNewGist()).rejects.toThrow('read failed');
-    expect(acquire).not.toHaveBeenCalled();
-    expect(exportData).not.toHaveBeenCalled();
+    expect(create).not.toHaveBeenCalled();
   });
 
   it.each(['export', 'request', 'destination'] as const)(
     'stops creation persistence after a failed %s',
     async (stage) => {
-      const client = createGitHubClient('supplied');
+      await storage.setItem(STORAGE_KEYS.githubPat, 'saved');
       const failure = new Error('failed');
       exportData.mockResolvedValue('{}');
       create.mockResolvedValue({ data: { id: 'created' } });
@@ -153,7 +104,7 @@ describe('gist-setup boundaries', () => {
       if (stage === 'request') create.mockRejectedValue(failure);
       if (stage === 'destination') writes.mockRejectedValue(failure);
 
-      await expect(createGist(client)).rejects.toBe(failure);
+      await expect(createNewGist()).rejects.toBe(failure);
       expect(writes.mock.calls).toEqual(stage === 'destination' ? [[STORAGE_KEYS.gistId, 'created']] : []);
       if (stage === 'export') expect(create).not.toHaveBeenCalled();
     }
@@ -208,7 +159,6 @@ describe('gist-setup boundaries', () => {
 
   describe('creation and configuration persistence', () => {
     const now = '2024-02-01T12:00:00.000Z';
-    const later = '2024-02-01T12:00:01.000Z';
 
     beforeEach(async () => {
       vi.useFakeTimers();
@@ -247,39 +197,21 @@ describe('gist-setup boundaries', () => {
       }
     );
 
-    it('creates the client before export, resolves localization afterward, then saves ID before status', async () => {
-      await storage.setItem(STORAGE_KEYS.language, 'en');
-      exportData.mockImplementation(async () => {
-        expect(Octokit).toHaveBeenCalledExactlyOnceWith({ auth: 'ghp_test' });
-        await storage.setItem(STORAGE_KEYS.language, 'zh-CN');
-        await storage.setItem(STORAGE_KEYS.githubPat, 'replacement');
-        return '{"local":"snapshot"}';
-      });
-      create.mockImplementation(async () => {
-        expect(await storage.getItem(STORAGE_KEYS.gistId)).toBe('gist123');
-        vi.setSystemTime(new Date(later));
-        return { data: { id: 'created' } };
-      });
-      const writes = vi.spyOn(storage, 'setItem');
+    it('creates a secret localized backup and saves the destination and sync status', async () => {
+      await storage.setItem(STORAGE_KEYS.language, 'zh-CN');
+      exportData.mockResolvedValue('{"local":"snapshot"}');
+      create.mockResolvedValue({ data: { id: 'created' } });
 
       await expect(createNewGist()).resolves.toEqual({ gistId: 'created' });
 
-      expect(Octokit).toHaveBeenCalledExactlyOnceWith({ auth: 'ghp_test' });
-      expect(getAuthenticated).not.toHaveBeenCalled();
+      expect(Octokit).toHaveBeenCalledWith({ auth: 'ghp_test' });
       expect(create).toHaveBeenCalledExactlyOnceWith({
         description: 'LeetSRS 备份 - 间隔重复数据',
         public: false,
         files: { 'leetsrs-backup.json': { content: '{"local":"snapshot"}' } },
       });
-      expect(writes.mock.calls).toEqual([
-        [STORAGE_KEYS.language, 'zh-CN'],
-        [STORAGE_KEYS.githubPat, 'replacement'],
-        [STORAGE_KEYS.gistId, 'created'],
-        [STORAGE_KEYS.lastSyncTime, later],
-        [STORAGE_KEYS.lastSyncDirection, 'push'],
-      ]);
       expect(await storage.getItem(STORAGE_KEYS.gistId)).toBe('created');
-      expect(await storage.getItem(STORAGE_KEYS.lastSyncTime)).toBe(later);
+      expect(await storage.getItem(STORAGE_KEYS.lastSyncTime)).toBe(now);
       expect(await storage.getItem(STORAGE_KEYS.lastSyncDirection)).toBe('push');
     });
 

--- a/services/__tests__/github-auth.test.ts
+++ b/services/__tests__/github-auth.test.ts
@@ -3,14 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { fakeBrowser } from 'wxt/testing/fake-browser';
 import { storage } from 'wxt/utils/storage';
 import { STORAGE_KEYS } from '@/infrastructure/storage/storage-keys';
-import {
-  getAuthenticatedGitHubClient,
-  getGitHubPat,
-  hasGitHubCredentials,
-  removeGitHubPat,
-  setGitHubPat,
-  validatePat,
-} from '../github-auth';
+import { getGitHubPat, removeGitHubPat, setGitHubPat, validatePat } from '../github-auth';
 
 const { getAuthenticated, getGist } = vi.hoisted(() => ({
   getAuthenticated: vi.fn(),
@@ -46,42 +39,6 @@ describe('github-auth', () => {
     expect(Octokit).not.toHaveBeenCalled();
   });
 
-  it.each([
-    { pat: null, ready: false },
-    { pat: '', ready: false },
-    { pat: '   ', ready: true },
-    { pat: ' token ', ready: true },
-  ])('reports readiness and acquires a client for stored credential $pat', async ({ pat, ready }) => {
-    if (pat !== null) await storage.setItem(STORAGE_KEYS.githubPat, pat);
-
-    expect(await hasGitHubCredentials()).toBe(ready);
-    expect(Octokit).not.toHaveBeenCalled();
-
-    const client = await getAuthenticatedGitHubClient();
-    if (ready) {
-      expect(client).not.toBeNull();
-      expect(Octokit).toHaveBeenCalledExactlyOnceWith({ auth: pat });
-    } else {
-      expect(client).toBeNull();
-      expect(Octokit).not.toHaveBeenCalled();
-    }
-    expect(getAuthenticated).not.toHaveBeenCalled();
-  });
-
-  it.each([' supplied ', '', '   '])('uses supplied credential %j without reading or writing storage', async (pat) => {
-    await storage.setItem(STORAGE_KEYS.githubPat, 'stored');
-    const reads = vi.spyOn(storage, 'getItem');
-    const writes = vi.spyOn(storage, 'setItem');
-    const client = await getAuthenticatedGitHubClient(pat);
-    await client.getGist('gist');
-
-    expect(Octokit).toHaveBeenCalledExactlyOnceWith({ auth: pat });
-    expect(getGist).toHaveBeenCalledExactlyOnceWith({ gist_id: 'gist' });
-    expect(getAuthenticated).not.toHaveBeenCalled();
-    expect(reads).not.toHaveBeenCalled();
-    expect(writes).not.toHaveBeenCalled();
-  });
-
   it('propagates credential persistence failures', async () => {
     const failure = new Error('storage unavailable');
     vi.spyOn(storage, 'getItem').mockRejectedValue(failure);
@@ -89,8 +46,6 @@ describe('github-auth', () => {
     vi.spyOn(storage, 'removeItem').mockRejectedValue(failure);
 
     await expect(getGitHubPat()).rejects.toBe(failure);
-    await expect(hasGitHubCredentials()).rejects.toBe(failure);
-    await expect(getAuthenticatedGitHubClient()).rejects.toBe(failure);
     await expect(setGitHubPat('token')).rejects.toBe(failure);
     await expect(removeGitHubPat()).rejects.toBe(failure);
     expect(Octokit).not.toHaveBeenCalled();

--- a/services/__tests__/import-export-characterization.test.ts
+++ b/services/__tests__/import-export-characterization.test.ts
@@ -2,11 +2,9 @@ import { createEmptyCard } from 'ts-fsrs';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { fakeBrowser } from 'wxt/testing/fake-browser';
 import { storage } from 'wxt/utils/storage';
-import { SETTING_KEYS } from '@/domain/settings';
 import { createDailyStats } from '@/domain/statistics';
 import { STORAGE_KEYS } from '@/infrastructure/storage/storage-keys';
 import { buildProblem } from '@/test/utils/card-mocks';
-import { createDeferred } from '@/test/utils/deferred';
 import { exportData, importData, prepareImportData, resetAllData } from '../import-export';
 
 const now = '2026-09-06T12:00:00.000Z';
@@ -60,7 +58,7 @@ describe('backup workflow characterization', () => {
     fakeBrowser.reset();
   });
 
-  it('exports exact raw records and JSON formatting, omitting credentials and orphan notes', async () => {
+  it('exports raw records while omitting credentials and orphan notes', async () => {
     await seedExistingData();
     await storage.setItem(STORAGE_KEYS.cards, payload.data.cards);
     await storage.setItem(STORAGE_KEYS.stats, payload.data.stats);
@@ -68,203 +66,99 @@ describe('backup workflow characterization', () => {
     await storage.setItem(STORAGE_KEYS.theme, 'invalid-theme');
     await storage.setItem(STORAGE_KEYS.gistSyncEnabled, false);
     await storage.setItem(STORAGE_KEYS.lastSyncTime, 'private-sync-time');
-    const reads = vi.spyOn(storage, 'getItem');
-
-    expect(await exportData()).toBe(
-      JSON.stringify(
-        {
-          schemaVersion: 2,
-          exportDate: now,
-          dataUpdatedAt: 'old-time',
-          data: {
-            cards: payload.data.cards,
-            stats: payload.data.stats,
-            notes: payload.data.notes,
-            settings: {},
-            gistSync: { gistId: 'old-gist', enabled: false },
-          },
-        },
-        null,
-        2
-      )
-    );
-    expect(reads.mock.calls.map(([key]) => key)).not.toContain(STORAGE_KEYS.githubPat);
+    expect(JSON.parse(await exportData())).toEqual({
+      schemaVersion: 2,
+      exportDate: now,
+      dataUpdatedAt: 'old-time',
+      data: {
+        cards: payload.data.cards,
+        stats: payload.data.stats,
+        notes: payload.data.notes,
+        settings: {},
+        gistSync: { gistId: 'old-gist', enabled: false },
+      },
+    });
   });
 
-  it('samples export time only after the final schema read completes', async () => {
-    const schema = createDeferred<number>();
-    const read = storage.getItem.bind(storage);
-    vi.spyOn(storage, 'getItem').mockImplementation((key, options) =>
-      key === STORAGE_KEYS.schemaVersion ? schema.promise : read(key, options)
-    );
-    const exporting = exportData();
-    await vi.waitFor(() => expect(storage.getItem).toHaveBeenCalledWith(STORAGE_KEYS.schemaVersion));
-    vi.setSystemTime(new Date(incomingTime));
-    schema.resolve(2);
-    expect(JSON.parse(await exporting).exportDate).toBe(incomingTime);
-  });
-
-  it('rejects malformed input before schema I/O and validates records only after it succeeds', async () => {
+  it('propagates schema-read failures without changing existing data', async () => {
+    await seedExistingData();
     const failure = new Error('schema unavailable');
-    const read = vi.spyOn(storage, 'getItem').mockRejectedValue(failure);
-    await expect(prepareImportData('invalid json')).rejects.toThrow('Invalid JSON format');
-    await expect(prepareImportData('{}')).rejects.toThrow('Invalid export data structure');
-    expect(read).not.toHaveBeenCalled();
-
-    await expect(
-      prepareImportData(
-        JSON.stringify({
-          ...payload,
-          data: { ...payload.data, cards: null },
-        })
-      )
-    ).rejects.toBe(failure);
-    expect(read).toHaveBeenCalledExactlyOnceWith(STORAGE_KEYS.schemaVersion);
-  });
-
-  it('generates a missing import timestamp after the schema read, rejecting an empty timestamp', async () => {
-    const schema = createDeferred<number>();
     const read = storage.getItem.bind(storage);
     vi.spyOn(storage, 'getItem').mockImplementation((key, options) =>
-      key === STORAGE_KEYS.schemaVersion ? schema.promise : read(key, options)
+      key === STORAGE_KEYS.schemaVersion ? Promise.reject(failure) : read(key, options)
     );
-    const preparing = prepareImportData(JSON.stringify({ ...payload, dataUpdatedAt: undefined }));
-    vi.setSystemTime(new Date(incomingTime));
-    schema.resolve(2);
-    expect((await preparing).dataUpdatedAt).toBe(incomingTime);
+    const before = await fakeBrowser.storage.local.get(null);
+
+    await expect(importData(JSON.stringify(payload))).rejects.toBe(failure);
+    expect(await fakeBrowser.storage.local.get(null)).toEqual(before);
+  });
+
+  it('generates a missing import timestamp and rejects an empty timestamp', async () => {
+    expect((await prepareImportData(JSON.stringify({ ...payload, dataUpdatedAt: undefined }))).dataUpdatedAt).toBe(now);
     await expect(prepareImportData(JSON.stringify({ ...payload, dataUpdatedAt: '' }))).rejects.toThrow(
       'Invalid update timestamp'
     );
   });
 
-  it('resets before restoration and overwrites the settings timestamp with the imported timestamp', async () => {
+  it('replaces learning data and settings while preserving the local PAT and schema', async () => {
     await seedExistingData();
-    const events: string[] = [];
-    const read = storage.getItem.bind(storage);
-    vi.spyOn(storage, 'getItem').mockImplementation((key, options) => {
-      if (key === STORAGE_KEYS.githubPat) events.push(`read:${key}`);
-      return read(key, options);
-    });
-    const remove = storage.removeItem.bind(storage);
-    const write = storage.setItem.bind(storage);
-    vi.spyOn(storage, 'removeItem').mockImplementation(async (key, options) => {
-      events.push(`remove:${key}`);
-      return remove(key, options);
-    });
-    const writes = vi.spyOn(storage, 'setItem').mockImplementation(async (key, value) => {
-      events.push(`write:${key}`);
-      return write(key, value);
-    });
+    await storage.setItem(STORAGE_KEYS.theme, 'light');
+    await storage.setItem(STORAGE_KEYS.maxNewCardsPerDay, 12);
 
     await importData(JSON.stringify(payload));
 
-    expect(events).toEqual([
-      `read:${STORAGE_KEYS.githubPat}`,
-      `remove:${STORAGE_KEYS.cards}`,
-      `remove:${STORAGE_KEYS.stats}`,
-      ...SETTING_KEYS.map((key) => `remove:${STORAGE_KEYS[key]}`),
-      ...['githubPat', 'gistId', 'gistSyncEnabled', 'lastSyncTime', 'lastSyncDirection', 'dataUpdatedAt'].map(
-        (key) => `remove:${STORAGE_KEYS[key as keyof typeof STORAGE_KEYS]}`
-      ),
-      `remove:${oldNoteKey}`,
-      ...['githubPat', 'cards', 'stats'].map((key) => `write:${STORAGE_KEYS[key as keyof typeof STORAGE_KEYS]}`),
-      `write:${newNoteKey}`,
-      ...['theme', 'dataUpdatedAt', 'gistId', 'gistSyncEnabled', 'dataUpdatedAt'].map(
-        (key) => `write:${STORAGE_KEYS[key as keyof typeof STORAGE_KEYS]}`
-      ),
-    ]);
-    expect(writes.mock.calls.filter(([key]) => key === STORAGE_KEYS.dataUpdatedAt)).toEqual([
-      [STORAGE_KEYS.dataUpdatedAt, now],
-      [STORAGE_KEYS.dataUpdatedAt, incomingTime],
-    ]);
-    expect(await storage.getItem(orphanNoteKey)).toEqual({ text: 'orphan note' });
+    expect(await storage.getItem(STORAGE_KEYS.cards)).toEqual(payload.data.cards);
+    expect(await storage.getItem(STORAGE_KEYS.stats)).toEqual(payload.data.stats);
+    expect(await storage.getItem(newNoteKey)).toEqual(payload.data.notes.new);
+    expect(await storage.getItem(oldNoteKey)).toBeNull();
+    expect(await storage.getItem(STORAGE_KEYS.theme)).toBe('dark');
+    expect(await storage.getItem(STORAGE_KEYS.maxNewCardsPerDay)).toBeNull();
+    expect(await storage.getItem(STORAGE_KEYS.dataUpdatedAt)).toBe(incomingTime);
+    expect(await storage.getItem(STORAGE_KEYS.githubPat)).toBe('existing-pat');
     expect(await storage.getItem(STORAGE_KEYS.schemaVersion)).toBe(2);
   });
 
-  it('leaves existing data untouched when reading the credential fails', async () => {
-    await seedExistingData();
-    const failure = new Error('credential read failed');
-    const read = storage.getItem.bind(storage);
-    vi.spyOn(storage, 'getItem').mockImplementation((key, options) => {
-      if (key === STORAGE_KEYS.githubPat) return Promise.reject(failure);
-      return read(key, options);
-    });
-    const remove = vi.spyOn(storage, 'removeItem');
-    const write = vi.spyOn(storage, 'setItem');
-
-    await expect(importData(JSON.stringify(payload))).rejects.toBe(failure);
-
-    expect(remove).not.toHaveBeenCalled();
-    expect(write).not.toHaveBeenCalled();
-  });
-
-  it.each([
-    [STORAGE_KEYS.stats, 'existing-pat', 'old-time'],
-    [STORAGE_KEYS.githubPat, 'existing-pat', 'old-time'],
-    [oldNoteKey, null, null],
-  ] as const)('retains partial reset state when removing %s fails', async (failedKey, pat, timestamp) => {
+  it('reports a failure to remove the previous dataset', async () => {
     await seedExistingData();
     const failure = new Error('reset failed');
     const remove = storage.removeItem.bind(storage);
-    vi.spyOn(storage, 'removeItem').mockImplementation(async (key, options) => {
-      if (key === failedKey) throw failure;
-      return remove(key, options);
-    });
-    const writes = vi.spyOn(storage, 'setItem');
+    vi.spyOn(storage, 'removeItem').mockImplementation((key, options) =>
+      key === STORAGE_KEYS.cards ? Promise.reject(failure) : remove(key, options)
+    );
 
     await expect(importData(JSON.stringify(payload))).rejects.toBe(failure);
-
-    expect(writes).not.toHaveBeenCalled();
-    expect(await storage.getItem(STORAGE_KEYS.cards)).toBeNull();
-    expect(await storage.getItem(STORAGE_KEYS.githubPat)).toBe(pat);
-    expect(await storage.getItem(STORAGE_KEYS.dataUpdatedAt)).toBe(timestamp);
-    expect(await storage.getItem(oldNoteKey)).toEqual({ text: 'old note' });
   });
 
-  it.each([STORAGE_KEYS.githubPat, STORAGE_KEYS.stats, STORAGE_KEYS.gistId])(
-    'stops restoration at a failed %s write without rollback',
+  it.each([STORAGE_KEYS.cards, STORAGE_KEYS.stats, newNoteKey, STORAGE_KEYS.theme, STORAGE_KEYS.dataUpdatedAt])(
+    'reports a failed import write to %s',
     async (failedKey) => {
       await seedExistingData();
-      const failure = new Error('restore failed');
+      const failure = new Error('import write failed');
       const write = storage.setItem.bind(storage);
-      vi.spyOn(storage, 'setItem').mockImplementation(async (key, value) => {
-        if (key === failedKey) throw failure;
-        return write(key, value);
-      });
+      vi.spyOn(storage, 'setItem').mockImplementation((key, value) =>
+        key === failedKey ? Promise.reject(failure) : write(key, value)
+      );
 
       await expect(importData(JSON.stringify(payload))).rejects.toBe(failure);
-
-      expect(await storage.getItem(oldNoteKey)).toBeNull();
-      expect(await storage.getItem(STORAGE_KEYS.githubPat)).toBe(
-        failedKey === STORAGE_KEYS.githubPat ? null : 'existing-pat'
-      );
-      expect(await storage.getItem(STORAGE_KEYS.cards)).toEqual(
-        failedKey === STORAGE_KEYS.githubPat ? null : payload.data.cards
-      );
-      expect(await storage.getItem(STORAGE_KEYS.dataUpdatedAt)).toBe(failedKey === STORAGE_KEYS.gistId ? now : null);
-      expect(await storage.getItem(STORAGE_KEYS.gistSyncEnabled)).toBeNull();
     }
   );
 
-  it.each([null, '', 'existing-pat', '   '])(
-    'preserves only a truthy local PAT (%s), ignoring imported credentials',
-    async (pat) => {
-      if (pat !== null) await storage.setItem(STORAGE_KEYS.githubPat, pat);
-      await importData(
-        JSON.stringify({ ...payload, data: { ...payload.data, gistSync: { githubPat: 'untrusted-pat' } } })
-      );
-      expect(await storage.getItem(STORAGE_KEYS.githubPat)).toBe(pat || null);
-      expect(await storage.getItem(STORAGE_KEYS.gistId)).toBeNull();
-      expect(await storage.getItem(STORAGE_KEYS.gistSyncEnabled)).toBeNull();
-    }
-  );
+  it.each([null, 'existing-pat'])('ignores imported credentials when the local PAT is %s', async (pat) => {
+    if (pat !== null) await storage.setItem(STORAGE_KEYS.githubPat, pat);
+    await importData(
+      JSON.stringify({ ...payload, data: { ...payload.data, gistSync: { githubPat: 'untrusted-pat' } } })
+    );
+    expect(await storage.getItem(STORAGE_KEYS.githubPat)).toBe(pat || null);
+  });
 
-  it('standalone reset removes the PAT and sync timestamp but preserves schema and orphan notes', async () => {
+  it('standalone reset removes learning data and credentials while preserving the schema', async () => {
     await seedExistingData();
     await resetAllData();
     expect(await storage.getItem(STORAGE_KEYS.githubPat)).toBeNull();
     expect(await storage.getItem(STORAGE_KEYS.dataUpdatedAt)).toBeNull();
     expect(await storage.getItem(STORAGE_KEYS.schemaVersion)).toBe(2);
-    expect(await storage.getItem(orphanNoteKey)).toEqual({ text: 'orphan note' });
+    expect(await storage.getItem(STORAGE_KEYS.cards)).toBeNull();
+    expect(await storage.getItem(STORAGE_KEYS.stats)).toBeNull();
+    expect(await storage.getItem(oldNoteKey)).toBeNull();
   });
 });

--- a/services/__tests__/learning-persistence.test.ts
+++ b/services/__tests__/learning-persistence.test.ts
@@ -28,20 +28,13 @@ describe('learning persistence sequencing', () => {
     vi.useRealTimers();
   });
 
-  it('awaits the card write before reading stats and awaits stats before requeue settings', async () => {
+  it('awaits card and statistics persistence before resolving a rating', async () => {
     const cardWrite = createDeferred<void>();
     const statsWrite = createDeferred<void>();
     const cardStarted = createDeferred<void>();
     const statsStarted = createDeferred<void>();
-    const events: string[] = [];
-    const getItem = storage.getItem.bind(storage);
     const setItem = storage.setItem.bind(storage);
-    vi.spyOn(storage, 'getItem').mockImplementation((key, options) => {
-      events.push(`read:${key}`);
-      return getItem(key, options);
-    });
     vi.spyOn(storage, 'setItem').mockImplementation(async (key, value) => {
-      events.push(`write:${key}`);
       if (key === STORAGE_KEYS.cards) {
         cardStarted.resolve();
         await cardWrite.promise;
@@ -51,29 +44,23 @@ describe('learning persistence sequencing', () => {
       }
       await setItem(key, value);
     });
-    vi.mocked(getSettings).mockImplementation(async () => {
-      events.push('settings');
-      return buildSettings();
-    });
+    const settled = vi.fn();
+    const rating = rateCard({ ...buildProblem(), rating: Rating.Good }).then(settled);
 
-    const rating = rateCard({ ...buildProblem(), rating: Rating.Good });
     await cardStarted.promise;
-    expect(events).toEqual([`read:${STORAGE_KEYS.cards}`, `write:${STORAGE_KEYS.cards}`]);
+    expect(settled).not.toHaveBeenCalled();
+    expect(await storage.getItem(STORAGE_KEYS.stats)).toBeNull();
     cardWrite.resolve();
     await statsStarted.promise;
-    expect(events).toEqual([
-      `read:${STORAGE_KEYS.cards}`,
-      `write:${STORAGE_KEYS.cards}`,
-      `read:${STORAGE_KEYS.stats}`,
-      'settings',
-      'settings',
-      `write:${STORAGE_KEYS.stats}`,
-    ]);
+    expect(settled).not.toHaveBeenCalled();
+    expect(await getAllCards()).toHaveLength(1);
     statsWrite.resolve();
     await rating;
-    expect(events.at(-1)).toBe('settings');
-    expect(getSettings).toHaveBeenCalledTimes(3);
-    expect(await getItem(STORAGE_KEYS.dataUpdatedAt)).toBeNull();
+
+    expect(await storage.getItem(STORAGE_KEYS.stats)).toMatchObject({
+      '2024-03-15': { totalReviews: 1, newCards: 1 },
+    });
+    expect(await storage.getItem(STORAGE_KEYS.dataUpdatedAt)).toBeNull();
   });
 
   it.each([STORAGE_KEYS.cards, STORAGE_KEYS.stats])(
@@ -95,7 +82,6 @@ describe('learning persistence sequencing', () => {
       expect(cards).toHaveLength(failedKey === STORAGE_KEYS.cards ? 0 : 1);
       if (failedKey === STORAGE_KEYS.stats) expect(cards[0].fsrs.reps).toBe(1);
       expect(await storage.getItem(STORAGE_KEYS.stats)).toBeNull();
-      expect(getSettings).toHaveBeenCalledTimes(failedKey === STORAGE_KEYS.cards ? 0 : 2);
       expect(await storage.getItem(STORAGE_KEYS.dataUpdatedAt)).toBeNull();
     }
   );

--- a/services/__tests__/review-timing.test.ts
+++ b/services/__tests__/review-timing.test.ts
@@ -24,7 +24,7 @@ function dailyStats(date: string, newCards: number, streak = 1): DailyStats {
   };
 }
 
-describe('review timing before calculation extraction', () => {
+describe('review-day service integration', () => {
   beforeEach(() => {
     fakeBrowser.reset();
     vi.useFakeTimers();
@@ -33,7 +33,6 @@ describe('review timing before calculation extraction', () => {
   });
 
   afterEach(() => {
-    vi.unstubAllGlobals();
     vi.useRealTimers();
   });
 
@@ -49,21 +48,14 @@ describe('review timing before calculation extraction', () => {
   it.each([
     [getTodayKey, '2024-03-14'],
     [getYesterdayKey, '2024-03-13'],
-  ])('%s samples its date before awaiting settings', async (getKey, expected) => {
-    vi.mocked(getSettings).mockImplementationOnce(async () => {
-      vi.setSystemTime(new Date('2024-03-16T12:00:00'));
-      return buildSettings({ dayStartHour: 4 });
-    });
-
+  ])('%s uses the configured review-day boundary', async (getKey, expected) => {
     await expect(getKey()).resolves.toBe(expected);
-    expect(getSettings).toHaveBeenCalledTimes(1);
   });
 
-  it('samples each unpaused card separately, then reads fresh settings and statistics for the daily limit', async () => {
-    const due = new Date('2024-03-15T04:00:00');
-    const cards = ['paused', 'before', 'after'].map((slug) => {
+  it('uses the review day for due cards and the daily new-card allowance', async () => {
+    const cards = ['paused', 'new-a', 'new-b', 'future'].map((slug) => {
       const card = createMockCard(State.New, { slug, paused: slug === 'paused' });
-      card.fsrs.due = due;
+      card.fsrs.due = new Date(slug === 'future' ? '2024-03-15T04:00:00' : '2024-03-14T12:00:00');
       return card;
     });
     await storage.setItem(
@@ -74,90 +66,32 @@ describe('review timing before calculation extraction', () => {
       '2024-03-14': dailyStats('2024-03-14', 1),
       '2024-03-15': dailyStats('2024-03-15', 0),
     });
-    vi.mocked(getSettings)
-      .mockResolvedValueOnce(buildSettings({ dayStartHour: 4, maxNewCardsPerDay: 1 }))
-      .mockResolvedValueOnce(buildSettings({ dayStartHour: 0, maxNewCardsPerDay: 0 }));
+    vi.mocked(getSettings).mockResolvedValue(buildSettings({ dayStartHour: 4, maxNewCardsPerDay: 2 }));
 
-    const ClockDate = Date;
-    const samples = [new ClockDate('2024-03-15T03:59:59.999'), due, new ClockDate('2024-03-15T03:00:00')];
-    let clockReads = 0;
-    vi.stubGlobal(
-      'Date',
-      new Proxy(ClockDate, {
-        construct(target, args) {
-          if (args.length === 0) {
-            const sample = samples[clockReads++];
-            if (!sample) throw new Error('Unexpected additional clock read');
-            return new target(sample);
-          }
-          return Reflect.construct(target, args);
-        },
-      })
-    );
-
-    const queue = await getReviewQueue();
-
-    expect(queue.map((card) => card.slug)).toEqual(['after']);
-    expect(clockReads).toBe(3);
-    expect(getSettings).toHaveBeenCalledTimes(2);
+    expect((await getReviewQueue()).map((card) => card.slug)).toEqual(['new-a']);
   });
 
-  it('reads statistics before the clock and independently samples yesterday and its settings when creating a day', async () => {
-    await storage.setItem(STORAGE_KEYS.stats, { '2024-03-15': dailyStats('2024-03-15', 0, 7) });
-    const getItem = storage.getItem.bind(storage);
-    const readStats = vi.spyOn(storage, 'getItem').mockImplementation((key, options) => {
-      if (key === STORAGE_KEYS.stats) vi.setSystemTime(new Date('2024-03-15T03:59:59.999'));
-      return getItem(key, options);
-    });
-    vi.setSystemTime(new Date('2024-03-13T12:00:00'));
-    vi.mocked(getSettings)
-      .mockImplementationOnce(async () => {
-        vi.setSystemTime(new Date('2024-03-16T03:00:00'));
-        return buildSettings({ dayStartHour: 4 });
-      })
-      .mockResolvedValueOnce(buildSettings({ dayStartHour: 0 }));
+  it('continues the previous review day streak when creating stats before the day boundary', async () => {
+    await storage.setItem(STORAGE_KEYS.stats, { '2024-03-13': dailyStats('2024-03-13', 1, 7) });
 
     await updateStats(Rating.Good, true);
 
-    expect(readStats).toHaveBeenCalledTimes(1);
-    expect(getSettings).toHaveBeenCalledTimes(2);
     expect(await storage.getItem(STORAGE_KEYS.stats)).toEqual({
-      '2024-03-15': dailyStats('2024-03-15', 0, 7),
+      '2024-03-13': dailyStats('2024-03-13', 1, 7),
       '2024-03-14': dailyStats('2024-03-14', 1, 8),
     });
   });
 
-  it.each([
-    [getLastNDaysStats, STORAGE_KEYS.stats],
-    [getNextNDaysStats, STORAGE_KEYS.cards],
-  ])('%s reads data, samples the clock, then awaits settings even for zero days', async (getBuckets, dataKey) => {
-    const getItem = storage.getItem.bind(storage);
-    const events: string[] = [];
-    vi.spyOn(storage, 'getItem').mockImplementation((key, options) => {
-      events.push(key);
-      vi.setSystemTime(new Date('2024-03-15T03:59:59'));
-      return getItem(key, options);
-    });
-    vi.mocked(getSettings).mockImplementation(async () => {
-      events.push('settings');
-      vi.setSystemTime(new Date('2024-03-16T12:00:00'));
-      return buildSettings({ dayStartHour: 4 });
-    });
-    vi.setSystemTime(new Date('2024-03-13T12:00:00'));
-
+  it.each([getLastNDaysStats, getNextNDaysStats])('%s anchors buckets to the review day', async (getBuckets) => {
     expect(await getBuckets(1)).toEqual([expect.objectContaining({ date: '2024-03-14' })]);
-    expect(events).toEqual([dataKey, 'settings']);
-    events.length = 0;
     expect(await getBuckets(0)).toEqual([]);
-    expect(events).toEqual([dataKey, 'settings']);
   });
 
-  it('does not read yesterday or settings again when today already exists', async () => {
+  it('preserves the streak when adding to an existing review day', async () => {
     await storage.setItem(STORAGE_KEYS.stats, { '2024-03-14': dailyStats('2024-03-14', 1, 3) });
 
     await updateStats(Rating.Good, true);
 
-    expect(getSettings).toHaveBeenCalledTimes(1);
     expect(await storage.getItem(STORAGE_KEYS.stats)).toEqual({ '2024-03-14': dailyStats('2024-03-14', 2, 3) });
   });
 });

--- a/services/__tests__/stats.test.ts
+++ b/services/__tests__/stats.test.ts
@@ -2,11 +2,11 @@ import { State as FsrsState, Rating } from 'ts-fsrs';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { fakeBrowser } from 'wxt/testing/fake-browser';
 import { storage } from 'wxt/utils/storage';
-import type { Difficulty } from '@/domain/cards';
 import type { DailyStats } from '@/domain/statistics';
-import type { StoredCard } from '@/infrastructure/storage/cards/codec';
+import { type StoredCard, serializeCard } from '@/infrastructure/storage/cards/codec';
 import { getStatsForDate } from '@/infrastructure/storage/stats';
 import { STORAGE_KEYS } from '@/infrastructure/storage/storage-keys';
+import { buildProblem, createMockCard } from '@/test/utils/card-mocks';
 import { addCard } from '../cards';
 import {
   getCardStateStats,
@@ -123,6 +123,7 @@ describe('Stats management', () => {
       const stats = await storage.getItem<Record<string, DailyStats>>(STORAGE_KEYS.stats);
       const todayStats = stats?.['2024-03-15'];
 
+      expect(todayStats?.streak).toBe(1);
       expect(todayStats?.totalReviews).toBe(3);
       expect(todayStats?.gradeBreakdown[Rating.Good]).toBe(1);
       expect(todayStats?.gradeBreakdown[Rating.Hard]).toBe(1);
@@ -130,19 +131,6 @@ describe('Stats management', () => {
       expect(todayStats?.gradeBreakdown[Rating.Easy]).toBe(0);
       expect(todayStats?.reviewedCards).toBe(2);
       expect(todayStats?.newCards).toBe(1);
-    });
-
-    it('should track new cards separately', async () => {
-      await updateStats(Rating.Good, true);
-      await updateStats(Rating.Easy, true);
-      await updateStats(Rating.Hard, false);
-
-      const stats = await storage.getItem<Record<string, DailyStats>>(STORAGE_KEYS.stats);
-      const todayStats = stats?.['2024-03-15'];
-
-      expect(todayStats?.newCards).toBe(2);
-      expect(todayStats?.reviewedCards).toBe(1);
-      expect(todayStats?.totalReviews).toBe(3);
     });
 
     it('should continue streak from yesterday', async () => {
@@ -222,16 +210,6 @@ describe('Stats management', () => {
       expect(stats?.['2024-03-14']?.streak).toBe(5);
     });
 
-    it('should not increment streak for multiple reviews on same day', async () => {
-      await updateStats(Rating.Good, false);
-      await updateStats(Rating.Easy, false);
-      await updateStats(Rating.Hard, false);
-
-      const stats = await storage.getItem<Record<string, DailyStats>>(STORAGE_KEYS.stats);
-      expect(stats?.['2024-03-15']?.streak).toBe(1);
-      expect(stats?.['2024-03-15']?.totalReviews).toBe(3);
-    });
-
     it('should handle streak reset after multiple day gap', async () => {
       // Create a 3-day streak
       vi.setSystemTime(new Date('2024-03-10T10:00:00'));
@@ -250,13 +228,6 @@ describe('Stats management', () => {
       const stats = await storage.getItem<Record<string, DailyStats>>(STORAGE_KEYS.stats);
       expect(stats?.['2024-03-12']?.streak).toBe(3);
       expect(stats?.['2024-03-15']?.streak).toBe(1); // Reset to 1
-    });
-
-    it('should start streak at 1 for first ever review', async () => {
-      await updateStats(Rating.Good, false);
-
-      const stats = await storage.getItem<Record<string, DailyStats>>(STORAGE_KEYS.stats);
-      expect(stats?.['2024-03-15']?.streak).toBe(1);
     });
   });
 
@@ -391,191 +362,31 @@ describe('Stats management', () => {
   });
 
   describe('getCardStateStats', () => {
-    beforeEach(() => {
-      fakeBrowser.reset();
-    });
-
-    it('should return all zeros when no cards exist', async () => {
-      const stats = await getCardStateStats();
-
-      expect(stats[FsrsState.New]).toBe(0);
-      expect(stats[FsrsState.Learning]).toBe(0);
-      expect(stats[FsrsState.Review]).toBe(0);
-      expect(stats[FsrsState.Relearning]).toBe(0);
-    });
-
-    it('should count cards by state correctly', async () => {
-      // Add some cards - new cards start in New state
-      await addCard({
-        slug: 'two-sum',
-        name: 'Two Sum',
-        leetcodeId: '1',
-        difficulty: 'Easy' as Difficulty,
-        domain: 'leetcode.com',
+    it.each([null, {}, []])('returns zero counts for empty storage %j', async (cards) => {
+      if (cards !== null) await storage.setItem(STORAGE_KEYS.cards, cards);
+      expect(await getCardStateStats()).toEqual({
+        [FsrsState.New]: 0,
+        [FsrsState.Learning]: 0,
+        [FsrsState.Review]: 0,
+        [FsrsState.Relearning]: 0,
       });
-      await addCard({
-        slug: 'add-two-numbers',
-        name: 'Add Two Numbers',
-        leetcodeId: '2',
-        difficulty: 'Medium' as Difficulty,
-        domain: 'leetcode.com',
-      });
-      await addCard({
-        slug: 'longest-substring',
-        name: 'Longest Substring',
-        leetcodeId: '3',
-        difficulty: 'Medium' as Difficulty,
-        domain: 'leetcode.com',
-      });
-
-      const stats = await getCardStateStats();
-
-      expect(stats[FsrsState.New]).toBe(3);
-      expect(stats[FsrsState.Learning]).toBe(0);
-      expect(stats[FsrsState.Review]).toBe(0);
-      expect(stats[FsrsState.Relearning]).toBe(0);
     });
 
-    it('should count all fsrs states correctly', async () => {
-      // Add cards with different states by manipulating storage directly
-      const cards = [
-        {
-          id: '1',
-          slug: 'problem-1',
-          name: 'Problem 1',
-          leetcodeId: '1',
-          difficulty: 'Easy' as Difficulty,
-          createdAt: Date.now(),
-          paused: false,
-          domain: 'leetcode.com',
-          fsrs: {
-            due: Date.now(),
-            last_review: null,
-            state: FsrsState.New,
-            stability: 0,
-            difficulty: 0,
-            elapsed_days: 0,
-            scheduled_days: 0,
-            reps: 0,
-            lapses: 0,
-          },
-        },
-        {
-          id: '2',
-          slug: 'problem-2',
-          name: 'Problem 2',
-          leetcodeId: '2',
-          difficulty: 'Medium' as Difficulty,
-          createdAt: Date.now(),
-          paused: false,
-          domain: 'leetcode.com',
-          fsrs: {
-            due: Date.now(),
-            last_review: Date.now(),
-            state: FsrsState.Learning,
-            stability: 1,
-            difficulty: 5,
-            elapsed_days: 1,
-            scheduled_days: 1,
-            reps: 1,
-            lapses: 0,
-          },
-        },
-        {
-          id: '3',
-          slug: 'problem-3',
-          name: 'Problem 3',
-          leetcodeId: '3',
-          difficulty: 'Hard' as Difficulty,
-          createdAt: Date.now(),
-          paused: false,
-          domain: 'leetcode.com',
-          fsrs: {
-            due: Date.now(),
-            last_review: Date.now(),
-            state: FsrsState.Review,
-            stability: 10,
-            difficulty: 5,
-            elapsed_days: 5,
-            scheduled_days: 10,
-            reps: 5,
-            lapses: 0,
-          },
-        },
-        {
-          id: '4',
-          slug: 'problem-4',
-          name: 'Problem 4',
-          leetcodeId: '4',
-          difficulty: 'Hard' as Difficulty,
-          createdAt: Date.now(),
-          paused: false,
-          domain: 'leetcode.com',
-          fsrs: {
-            due: Date.now(),
-            last_review: Date.now(),
-            state: FsrsState.Review,
-            stability: 20,
-            difficulty: 6,
-            elapsed_days: 10,
-            scheduled_days: 20,
-            reps: 10,
-            lapses: 0,
-          },
-        },
-        {
-          id: '5',
-          slug: 'problem-5',
-          name: 'Problem 5',
-          leetcodeId: '5',
-          difficulty: 'Medium' as Difficulty,
-          createdAt: Date.now(),
-          paused: false,
-          domain: 'leetcode.com',
-          fsrs: {
-            due: Date.now(),
-            last_review: Date.now(),
-            state: FsrsState.Relearning,
-            stability: 2,
-            difficulty: 7,
-            elapsed_days: 15,
-            scheduled_days: 2,
-            reps: 15,
-            lapses: 2,
-          },
-        },
-      ];
+    it('counts every state, including paused cards', async () => {
+      const states = [FsrsState.New, FsrsState.Learning, FsrsState.Review, FsrsState.Review, FsrsState.Relearning];
+      const cards = states.map((state, index) =>
+        createMockCard(state, { slug: `problem-${index}`, paused: index === 3 })
+      );
+      await storage.setItem(
+        STORAGE_KEYS.cards,
+        Object.fromEntries(cards.map((card) => [card.slug, serializeCard(card)]))
+      );
 
-      await storage.setItem(STORAGE_KEYS.cards, cards);
-
-      const stats = await getCardStateStats();
-
-      expect(stats[FsrsState.New]).toBe(1);
-      expect(stats[FsrsState.Learning]).toBe(1);
-      expect(stats[FsrsState.Review]).toBe(2);
-      expect(stats[FsrsState.Relearning]).toBe(1);
-    });
-
-    it('should handle empty card array', async () => {
-      await storage.setItem(STORAGE_KEYS.cards, []);
-
-      const stats = await getCardStateStats();
-
-      expect(stats[FsrsState.New]).toBe(0);
-      expect(stats[FsrsState.Learning]).toBe(0);
-      expect(stats[FsrsState.Review]).toBe(0);
-      expect(stats[FsrsState.Relearning]).toBe(0);
-    });
-
-    it('should return type-safe Record<FsrsState, number>', async () => {
-      const stats = await getCardStateStats();
-
-      // TypeScript should enforce that stats has all FsrsState keys
-      const states: FsrsState[] = [FsrsState.New, FsrsState.Learning, FsrsState.Review, FsrsState.Relearning];
-
-      states.forEach((state) => {
-        expect(typeof stats[state]).toBe('number');
-        expect(stats[state]).toBeGreaterThanOrEqual(0);
+      expect(await getCardStateStats()).toEqual({
+        [FsrsState.New]: 1,
+        [FsrsState.Learning]: 1,
+        [FsrsState.Review]: 2,
+        [FsrsState.Relearning]: 1,
       });
     });
   });
@@ -599,13 +410,7 @@ describe('Stats management', () => {
 
     it('should count cards due today', async () => {
       // Add a card that's due today
-      await addCard({
-        slug: 'problem-1',
-        name: 'Problem 1',
-        leetcodeId: '1',
-        difficulty: 'Easy' as Difficulty,
-        domain: 'leetcode.com',
-      });
+      await addCard(buildProblem({ slug: 'problem-1' }));
       const cards = (await storage.getItem(STORAGE_KEYS.cards)) as Record<string, StoredCard>;
 
       // Manually set the card to be due today
@@ -621,27 +426,9 @@ describe('Stats management', () => {
 
     it('should count cards due in the future', async () => {
       // Add cards with different due dates
-      await addCard({
-        slug: 'problem-1',
-        name: 'Problem 1',
-        leetcodeId: '1',
-        difficulty: 'Easy' as Difficulty,
-        domain: 'leetcode.com',
-      });
-      await addCard({
-        slug: 'problem-2',
-        name: 'Problem 2',
-        leetcodeId: '2',
-        difficulty: 'Medium' as Difficulty,
-        domain: 'leetcode.com',
-      });
-      await addCard({
-        slug: 'problem-3',
-        name: 'Problem 3',
-        leetcodeId: '3',
-        difficulty: 'Hard' as Difficulty,
-        domain: 'leetcode.com',
-      });
+      await addCard(buildProblem({ slug: 'problem-1' }));
+      await addCard(buildProblem({ slug: 'problem-2' }));
+      await addCard(buildProblem({ slug: 'problem-3' }));
 
       const cards = (await storage.getItem(STORAGE_KEYS.cards)) as Record<string, StoredCard>;
 
@@ -664,20 +451,8 @@ describe('Stats management', () => {
 
     it('should not count paused cards', async () => {
       // Add cards
-      await addCard({
-        slug: 'problem-1',
-        name: 'Problem 1',
-        leetcodeId: '1',
-        difficulty: 'Easy' as Difficulty,
-        domain: 'leetcode.com',
-      });
-      await addCard({
-        slug: 'problem-2',
-        name: 'Problem 2',
-        leetcodeId: '2',
-        difficulty: 'Medium' as Difficulty,
-        domain: 'leetcode.com',
-      });
+      await addCard(buildProblem({ slug: 'problem-1' }));
+      await addCard(buildProblem({ slug: 'problem-2' }));
 
       const cards = (await storage.getItem(STORAGE_KEYS.cards)) as Record<string, StoredCard>;
 
@@ -695,20 +470,8 @@ describe('Stats management', () => {
 
     it('should handle cards due in the past', async () => {
       // Add cards due in the past
-      await addCard({
-        slug: 'problem-1',
-        name: 'Problem 1',
-        leetcodeId: '1',
-        difficulty: 'Easy' as Difficulty,
-        domain: 'leetcode.com',
-      });
-      await addCard({
-        slug: 'problem-2',
-        name: 'Problem 2',
-        leetcodeId: '2',
-        difficulty: 'Medium' as Difficulty,
-        domain: 'leetcode.com',
-      });
+      await addCard(buildProblem({ slug: 'problem-1' }));
+      await addCard(buildProblem({ slug: 'problem-2' }));
 
       const cards = (await storage.getItem(STORAGE_KEYS.cards)) as Record<string, StoredCard>;
 
@@ -732,13 +495,7 @@ describe('Stats management', () => {
     });
 
     it('should exclude cards due immediately after the requested window', async () => {
-      await addCard({
-        slug: 'problem-1',
-        name: 'Problem 1',
-        leetcodeId: '1',
-        difficulty: 'Easy' as Difficulty,
-        domain: 'leetcode.com',
-      });
+      await addCard(buildProblem({ slug: 'problem-1' }));
       const cards = (await storage.getItem(STORAGE_KEYS.cards)) as Record<string, StoredCard>;
 
       cards['problem-1'].fsrs.due = new Date('2024-03-22T12:00:00').getTime();
@@ -758,13 +515,7 @@ describe('Stats management', () => {
 
     it('should respect the configured day start hour', async () => {
       await storage.setItem(STORAGE_KEYS.dayStartHour, 4);
-      await addCard({
-        slug: 'problem-1',
-        name: 'Problem 1',
-        leetcodeId: '1',
-        difficulty: 'Easy' as Difficulty,
-        domain: 'leetcode.com',
-      });
+      await addCard(buildProblem({ slug: 'problem-1' }));
       const cards = (await storage.getItem(STORAGE_KEYS.cards)) as Record<string, StoredCard>;
 
       cards['problem-1'].fsrs.due = new Date('2024-03-16T01:00:00').getTime();
@@ -779,20 +530,8 @@ describe('Stats management', () => {
     });
 
     it('should accumulate active cards due on the same review day', async () => {
-      await addCard({
-        slug: 'problem-1',
-        name: 'Problem 1',
-        leetcodeId: '1',
-        difficulty: 'Easy' as Difficulty,
-        domain: 'leetcode.com',
-      });
-      await addCard({
-        slug: 'problem-2',
-        name: 'Problem 2',
-        leetcodeId: '2',
-        difficulty: 'Medium' as Difficulty,
-        domain: 'leetcode.com',
-      });
+      await addCard(buildProblem({ slug: 'problem-1' }));
+      await addCard(buildProblem({ slug: 'problem-2' }));
       const cards = (await storage.getItem(STORAGE_KEYS.cards)) as Record<string, StoredCard>;
 
       cards['problem-1'].fsrs.due = new Date('2024-03-17T09:00:00').getTime();


### PR DESCRIPTION
- Replace clock/read-order and import event-log assertions with review-day, persistence, and data-replacement coverage.
- Consolidate card/statistics fixtures and chart scenarios; prune unused GitHub helper coverage and styling assertions.
- Reduce test code by 1,022 lines net (173 added, 1,195 removed); no production changes. Leave behavior changes to #218, #306, #307, and #308.

Closes #311
