### PR TITLE
feat: use exact due times and remove configurable day start

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,7 +31,7 @@ Prefer meaningful behavior coverage over test count. Parameterize scenarios that
 
 ## Commit & Pull Request Guidelines
 
-Use Conventional Commits for commit subjects and pull request titles, such as `fix: clean up animation timeout`. Use standard lowercase types including `feat`, `fix`, `perf`, `refactor`, `docs`, `test`, `build`, `ci`, `chore`, and `revert`; add an optional scope in parentheses. Mark breaking changes with `!` and explain them in a `BREAKING CHANGE:` footer. Keep subjects concise and imperative. For most pull requests, use concise bullet points followed by linked or closing issues; omit section headings such as `Summary` and `Testing` unless the change is genuinely complex. Include screenshots for UI changes. Do not commit generated `.output/` or `.wxt/` content.
+Use Conventional Commits for commit subjects and pull request titles, such as `fix: clean up animation timeout`. Use standard lowercase types including `feat`, `fix`, `perf`, `refactor`, `docs`, `test`, `build`, `ci`, `chore`, and `revert`; add an optional scope in parentheses. Mark breaking changes with `!` and explain them in a `BREAKING CHANGE:` footer. Keep subjects concise and imperative. For most pull requests, use concise bullet points followed by linked or closing issues; omit section headings such as `Summary` and `Testing` unless the change is genuinely complex. Do not commit generated `.output/` or `.wxt/` content.
 
 ## Code Review Rules
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -23,10 +23,10 @@ A card that has not yet received its first rating.
 A tracked card excluded from the review queue until the learner resumes it.
 
 **Review day**:
-A local day beginning at the learner's configured day-start hour, used for due-card eligibility and daily review statistics.
+A local calendar day beginning at midnight, used for daily review statistics and the new-card allowance.
 
 **Review queue**:
-The ordered set of unpaused cards due by the current review day, with new cards limited by the remaining daily allowance.
+The ordered set of unpaused cards whose due time has been reached, with new cards limited by the remaining daily allowance.
 
 **Note**:
 The learner's text attached to a card.

--- a/README.md
+++ b/README.md
@@ -34,12 +34,12 @@ LeetSRS is a [Chrome extension](https://chromewebstore.google.com/detail/odgfcig
 
 ### Review System
 
-- Daily review queue with optimized problem ordering
+- Review queue with exact due times and optimized problem ordering
 - View statistics and streaks
 - Works directly on leetcode.com
 - Easily rate after solving problems, or add to review later
 - Customizable daily new card limits
-- Configure a day start offset (0-23 hours past midnight) for when a new review day begins
+- Daily limits, statistics, and streaks follow local calendar days beginning at midnight
 
 ### Cross-Browser Sync
 

--- a/domain/__tests__/backup-import.test.ts
+++ b/domain/__tests__/backup-import.test.ts
@@ -44,10 +44,14 @@ describe('backup import policy', () => {
     });
   });
 
-  it('omits undefined settings and inherited settings on import', () => {
-    const settings = Object.assign(Object.create({ badgeEnabled: false }), { theme: undefined, dayStartHour: 5 });
-    expect(normalizeImportData({ ...payload, data: { ...payload.data, settings } }, 2).settings).toEqual({
+  it('ignores legacy day start, undefined, and inherited settings on import', () => {
+    const settings = Object.assign(Object.create({ badgeEnabled: false }), {
+      theme: undefined,
       dayStartHour: 5,
+      maxNewCardsPerDay: 8,
+    });
+    expect(normalizeImportData({ ...payload, data: { ...payload.data, settings } }, 2).settings).toEqual({
+      maxNewCardsPerDay: 8,
     });
   });
 

--- a/domain/__tests__/calendar.test.ts
+++ b/domain/__tests__/calendar.test.ts
@@ -1,18 +1,32 @@
 import { describe, expect, it } from 'vitest';
-import { formatLocalDate } from '../calendar';
+import { addLocalDays, formatLocalDate } from '../calendar';
 
 describe('calendar bucketing', () => {
   it.each([
-    ['2024-03-15T03:59:59.999', 4, '2024-03-14'],
-    ['2024-03-15T04:00:00.000', 4, '2024-03-15'],
-    ['2024-01-01T03:59:59.999', 4, '2023-12-31'],
-    ['2024-01-01T04:00:00.000', 4, '2024-01-01'],
-    ['2024-03-01T03:59:59.999', 4, '2024-02-29'],
-    ['2024-03-01T04:00:00.000', 4, '2024-03-01'],
-  ])('uses the local review day at %s', (instant, dayStartHour, expectedDay) => {
+    ['2024-03-14T23:59:59.999', '2024-03-14'],
+    ['2024-03-15T00:00:00.000', '2024-03-15'],
+    ['2023-12-31T23:59:59.999', '2023-12-31'],
+    ['2024-01-01T00:00:00.000', '2024-01-01'],
+    ['2024-02-29T23:59:59.999', '2024-02-29'],
+    ['2024-03-01T00:00:00.000', '2024-03-01'],
+  ])('uses the local calendar date at %s', (instant, expectedDay) => {
     const referenceDate = new Date(instant);
 
-    expect(formatLocalDate(referenceDate, dayStartHour)).toBe(expectedDay);
+    expect(formatLocalDate(referenceDate)).toBe(expectedDay);
     expect(referenceDate.getTime()).toBe(new Date(instant).getTime());
+  });
+
+  it.each([
+    ['2024-01-01T00:30:00', -1, '2023-12-31'],
+    ['2024-03-01T00:30:00', -1, '2024-02-29'],
+    ['2024-02-28T23:30:00', 1, '2024-02-29'],
+    ['2024-03-10T23:30:00', -1, '2024-03-09'],
+    ['2024-03-10T23:30:00', 1, '2024-03-11'],
+    ['2024-11-03T00:30:00', -1, '2024-11-02'],
+    ['2024-11-03T00:30:00', 1, '2024-11-04'],
+  ])('moves %s by %i local days across calendar and daylight saving boundaries', (instant, days, expected) => {
+    const date = new Date(instant);
+    expect(formatLocalDate(addLocalDays(date, days))).toBe(expected);
+    expect(date.getTime()).toBe(new Date(instant).getTime());
   });
 });

--- a/domain/__tests__/review.test.ts
+++ b/domain/__tests__/review.test.ts
@@ -2,46 +2,30 @@ import { State } from 'ts-fsrs';
 import { describe, expect, it } from 'vitest';
 import type { Card } from '@/domain/cards';
 import { createMockCard } from '@/test/utils/card-mocks';
-import { buildReviewQueue, calculateDelayedDueDate, isDueByDate } from '../review';
+import { buildReviewQueue, calculateDelayedDueDate, isDue } from '../review';
 
-describe('isDueByDate', () => {
+describe('isDue', () => {
   it.each([
     ['2024-01-14T10:00:00', true],
     ['2024-01-15T00:00:00', true],
-    ['2024-01-15T08:00:00', true],
-    ['2024-01-15T23:59:59.999', true],
+    ['2024-01-15T14:29:59.999', true],
+    ['2024-01-15T14:30:00.000', true],
+    ['2024-01-15T14:30:00.001', false],
+    ['2024-01-15T23:59:59.999', false],
     ['2024-01-16T00:00:00', false],
-    ['2024-01-20T10:00:00', false],
-  ])('checks due date %s against the local calendar day', (due, expected) => {
+  ])('checks due timestamp %s against the current time', (due, expected) => {
     const card = dueCard('card', due, State.Review);
-    expect(isDueByDate(card, new Date('2024-01-15T14:30:00'))).toBe(expected);
+    expect(isDue(card, new Date('2024-01-15T14:30:00'))).toBe(expected);
   });
 
   it.each([State.New, State.Learning, State.Review, State.Relearning])(
-    'includes state %s due later on the same local day',
+    'waits for the exact due timestamp in state %s',
     (state) => {
       const card = dueCard('card', '2024-01-15T23:59:59.999', state);
-      expect(isDueByDate(card, new Date('2024-01-15T00:00:00'))).toBe(true);
+      expect(isDue(card, new Date('2024-01-15T23:59:59.998'))).toBe(false);
+      expect(isDue(card, new Date('2024-01-15T23:59:59.999'))).toBe(true);
     }
   );
-});
-
-describe('review-day boundaries', () => {
-  it.each([
-    ['2024-03-15T03:59:59.999', 4, false],
-    ['2024-03-15T04:00:00.000', 4, true],
-    ['2024-01-01T03:59:59.999', 4, false],
-    ['2024-01-01T04:00:00.000', 4, true],
-    ['2024-03-01T03:59:59.999', 4, false],
-    ['2024-03-01T04:00:00.000', 4, true],
-  ])('uses the local review day at %s', (instant, dayStartHour, due) => {
-    const referenceDate = new Date(instant);
-    const card = createMockCard(State.Review);
-    card.fsrs.due = new Date(referenceDate).setHours(4, 0, 0, 0);
-
-    expect(isDueByDate(card, referenceDate, dayStartHour)).toBe(due);
-    expect(referenceDate.getTime()).toBe(new Date(instant).getTime());
-  });
 });
 
 function dueCard(slug: string, due: string, state = State.New) {

--- a/domain/__tests__/settings.test.ts
+++ b/domain/__tests__/settings.test.ts
@@ -3,7 +3,7 @@ import { buildSettings } from '@/test/utils/settings-mocks';
 import { SETTING_KEYS, settingsSchema, settingsUpdateSchema } from '../settings';
 
 describe('settings validation', () => {
-  it('parses all seven settings and strips unknown fields', () => {
+  it('parses all settings and strips unknown fields', () => {
     const settings = buildSettings();
     expect(settingsSchema.parse({ ...settings, unknown: 'ignored' })).toEqual(settings);
     expect(settingsUpdateSchema.parse({ ...settings, unknown: 'ignored' })).toEqual(settings);
@@ -17,17 +17,17 @@ describe('settings validation', () => {
 
   it('ignores inherited and unknown settings while retaining own settings', () => {
     const changes = Object.create({ theme: 'invalid', badgeEnabled: false });
-    Object.defineProperty(changes, 'dayStartHour', { value: 5 });
+    Object.defineProperty(changes, 'theme', { value: 'dark' });
     Object.assign(changes, { maxNewCardsPerDay: 8, unknown: 'ignored' });
-    expect(settingsUpdateSchema.parse(changes)).toEqual({ maxNewCardsPerDay: 8, dayStartHour: 5 });
+    expect(settingsUpdateSchema.parse(changes)).toEqual({ maxNewCardsPerDay: 8, theme: 'dark' });
   });
 
-  it.each([
-    { maxNewCardsPerDay: 0, dayStartHour: 0 },
-    { maxNewCardsPerDay: 100, dayStartHour: 23 },
-  ])('accepts inclusive numeric boundaries %j', (changes) => {
-    expect(settingsUpdateSchema.parse(changes)).toEqual(changes);
-  });
+  it.each([{ maxNewCardsPerDay: 0 }, { maxNewCardsPerDay: 100 }])(
+    'accepts inclusive numeric boundaries %j',
+    (changes) => {
+      expect(settingsUpdateSchema.parse(changes)).toEqual(changes);
+    }
+  );
 
   it.each(['EN', 'toString', 'constructor', '__proto__'])(
     'rejects unsupported language %s with the full error',

--- a/domain/__tests__/statistics.test.ts
+++ b/domain/__tests__/statistics.test.ts
@@ -12,7 +12,7 @@ import {
 
 describe('statistics calculations', () => {
   it('should return empty days when no stats exist', () => {
-    const stats = calculateHistoryStats({}, 7, new Date('2024-03-15T10:00:00'), 0);
+    const stats = calculateHistoryStats({}, 7, new Date('2024-03-15T10:00:00'));
 
     expect(stats).toHaveLength(7);
     stats.forEach((stat) => {
@@ -27,13 +27,11 @@ describe('statistics calculations', () => {
   });
 
   it('should handle large number of days', () => {
-    const stats = calculateHistoryStats({}, 45, new Date('2024-03-15T10:00:00'), 0);
+    const stats = calculateHistoryStats({}, 45, new Date('2024-03-15T10:00:00'));
 
     expect(stats).toHaveLength(45);
 
     // Check first and last dates
-    const firstDate = new Date('2024-03-15');
-    firstDate.setDate(firstDate.getDate() - 44);
     expect(stats[0].date).toBe('2024-01-31');
     expect(stats[44].date).toBe('2024-03-15');
   });
@@ -56,11 +54,11 @@ describe('statistics calculations', () => {
     expect(yesterday.totalReviews).toBe(0);
   });
 
-  it('preserves saved history and inserts independent empty days using the supplied review day', () => {
-    const saved = createDailyStats('2024-03-13', undefined);
+  it('preserves saved history and inserts independent empty days using the supplied local date', () => {
+    const saved = createDailyStats('2024-03-14', undefined);
     recordReview(saved, Rating.Good, true);
-    const result = calculateHistoryStats({ '2024-03-13': saved }, 3, new Date('2024-03-15T03:59:59'), 4);
-    expect(result.map((day) => day.date)).toEqual(['2024-03-12', '2024-03-13', '2024-03-14']);
+    const result = calculateHistoryStats({ '2024-03-14': saved }, 3, new Date('2024-03-15T03:59:59'));
+    expect(result.map((day) => day.date)).toEqual(['2024-03-13', '2024-03-14', '2024-03-15']);
     expect(result[1]).toBe(saved);
     expect(result[0].streak).toBe(0);
     expect(result[2].streak).toBe(0);
@@ -70,9 +68,9 @@ describe('statistics calculations', () => {
   it('includes paused cards in state counts but excludes them from upcoming buckets', () => {
     const cards = [State.New, State.Learning, State.Review, State.Relearning].map((state) => createMockCard(state));
     cards[0].fsrs.due = new Date('2024-03-10T12:00:00').getTime();
-    cards[1].fsrs.due = new Date('2024-03-15T03:59:59').getTime();
-    cards[2].fsrs.due = new Date('2024-03-15T04:00:00').getTime();
-    cards[3].fsrs.due = new Date('2024-03-15T04:00:00').getTime();
+    cards[1].fsrs.due = new Date('2024-03-15T23:59:59.999').getTime();
+    cards[2].fsrs.due = new Date('2024-03-16T00:00:00').getTime();
+    cards[3].fsrs.due = new Date('2024-03-16T00:00:00').getTime();
     cards[3].paused = true;
     expect(countCardStates(cards)).toEqual({
       [State.New]: 1,
@@ -80,16 +78,26 @@ describe('statistics calculations', () => {
       [State.Review]: 1,
       [State.Relearning]: 1,
     });
-    expect(calculateUpcomingStats(cards, 2, new Date('2024-03-15T03:59:59'), 4)).toEqual([
-      { date: '2024-03-14', count: 2 },
-      { date: '2024-03-15', count: 1 },
+    expect(calculateUpcomingStats(cards, 2, new Date('2024-03-15T03:59:59'))).toEqual([
+      { date: '2024-03-15', count: 2 },
+      { date: '2024-03-16', count: 1 },
     ]);
+  });
+
+  it.each([
+    ['2024-12-31T23:30:00', ['2024-12-30', '2024-12-31'], ['2024-12-31', '2025-01-01']],
+    ['2024-03-10T23:30:00', ['2024-03-09', '2024-03-10'], ['2024-03-10', '2024-03-11']],
+    ['2024-11-03T00:30:00', ['2024-11-02', '2024-11-03'], ['2024-11-03', '2024-11-04']],
+  ])('keeps chart buckets on consecutive local dates at %s', (instant, history, upcoming) => {
+    const today = new Date(instant);
+    expect(calculateHistoryStats({}, 2, today).map((day) => day.date)).toEqual(history);
+    expect(calculateUpcomingStats([], 2, today).map((day) => day.date)).toEqual(upcoming);
   });
 
   it.each([0, -1])('returns no buckets for %i days', (days) => {
     const today = new Date('2024-03-15T10:00:00');
-    expect(calculateHistoryStats({}, days, today, 4)).toEqual([]);
-    expect(calculateUpcomingStats([], days, today, 4)).toEqual([]);
+    expect(calculateHistoryStats({}, days, today)).toEqual([]);
+    expect(calculateUpcomingStats([], days, today)).toEqual([]);
   });
 });
 

--- a/domain/calendar.ts
+++ b/domain/calendar.ts
@@ -1,10 +1,10 @@
-export function formatLocalDate(date: Date, dayStartHour: number = 0): string {
-  const adjustedDate = new Date(date);
-  if (dayStartHour) {
-    adjustedDate.setHours(adjustedDate.getHours() - dayStartHour);
-  }
-  const year = adjustedDate.getFullYear();
-  const month = String(adjustedDate.getMonth() + 1).padStart(2, '0');
-  const day = String(adjustedDate.getDate()).padStart(2, '0');
+export function formatLocalDate(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
   return `${year}-${month}-${day}`;
+}
+
+export function addLocalDays(date: Date, days: number): Date {
+  return new Date(date.getFullYear(), date.getMonth(), date.getDate() + days);
 }

--- a/domain/review.ts
+++ b/domain/review.ts
@@ -1,13 +1,8 @@
 import { State as FsrsState } from 'ts-fsrs';
-import { formatLocalDate } from './calendar';
 import type { Card } from './cards';
 
-export function isDueByDate(card: Card, referenceDate: Date, dayStartHour: number = 0): boolean {
-  const dueDate = new Date(card.fsrs.due);
-
-  const referenceDateStr = formatLocalDate(referenceDate, dayStartHour);
-  const dueStr = formatLocalDate(dueDate, dayStartHour);
-  return dueStr <= referenceDateStr;
+export function isDue(card: Card, now: Date): boolean {
+  return card.fsrs.due <= now.getTime();
 }
 
 const sortByDueDateThenSlug = (a: Card, b: Card): number => {

--- a/domain/settings.ts
+++ b/domain/settings.ts
@@ -3,7 +3,6 @@ import { languageSchema } from './language';
 
 export const SETTINGS_CONSTRAINTS = {
   maxNewCardsPerDay: { min: 0, max: 100 },
-  dayStartHour: { min: 0, max: 23 },
 } as const;
 
 function boundedWholeNumber(label: string, bounds: { min: number; max: number }) {
@@ -18,7 +17,6 @@ function boundedWholeNumber(label: string, bounds: { min: number; max: number })
 
 export const settingsSchema = z.object({
   maxNewCardsPerDay: boundedWholeNumber('Max new cards per day', SETTINGS_CONSTRAINTS.maxNewCardsPerDay),
-  dayStartHour: boundedWholeNumber('Day start hour', SETTINGS_CONSTRAINTS.dayStartHour),
   theme: z.enum(['system', 'light', 'dark'], { error: 'Theme must be "system", "light", or "dark"' }),
   resetEditorOnEveryProblem: z.boolean({ error: 'Reset editor on every problem must be a boolean' }),
   resetEditorOnDueReview: z.boolean({ error: 'Reset editor on due review must be a boolean' }),
@@ -31,7 +29,6 @@ export type Theme = Settings['theme'];
 // Language defaults are resolved from browser preferences by the service.
 export const DEFAULT_SETTINGS = {
   maxNewCardsPerDay: 3,
-  dayStartHour: 0,
   theme: 'system',
   resetEditorOnEveryProblem: false,
   resetEditorOnDueReview: false,

--- a/domain/statistics.ts
+++ b/domain/statistics.ts
@@ -1,6 +1,6 @@
 import { State as FsrsState, type Grade, Rating } from 'ts-fsrs';
 import { z } from 'zod';
-import { formatLocalDate } from './calendar';
+import { addLocalDays, formatLocalDate } from './calendar';
 import type { Card } from './cards';
 
 const count = z.int().nonnegative();
@@ -79,17 +79,10 @@ export function countCardStates(cards: Card[]): Record<FsrsState, number> {
   return stateStats;
 }
 
-export function calculateHistoryStats(
-  stats: Record<string, DailyStats>,
-  days: number,
-  today: Date,
-  dayStartHour: number
-): DailyStats[] {
+export function calculateHistoryStats(stats: Record<string, DailyStats>, days: number, today: Date): DailyStats[] {
   const result: DailyStats[] = [];
   for (let i = days - 1; i >= 0; i--) {
-    const date = new Date(today);
-    date.setDate(date.getDate() - i);
-    const dateKey = formatLocalDate(date, dayStartHour);
+    const dateKey = formatLocalDate(addLocalDays(today, -i));
 
     if (stats[dateKey]) {
       result.push(stats[dateKey]);
@@ -106,18 +99,11 @@ export function calculateHistoryStats(
   return result;
 }
 
-export function calculateUpcomingStats(
-  cards: Card[],
-  days: number,
-  today: Date,
-  dayStartHour: number
-): UpcomingReviewStats[] {
+export function calculateUpcomingStats(cards: Card[], days: number, today: Date): UpcomingReviewStats[] {
   const result: UpcomingReviewStats[] = [];
   const dateToIndex = new Map<string, number>();
   for (let i = 0; i < days; i++) {
-    const date = new Date(today);
-    date.setDate(date.getDate() + i);
-    const dateKey = formatLocalDate(date, dayStartHour);
+    const dateKey = formatLocalDate(addLocalDays(today, i));
     result.push({
       date: dateKey,
       count: 0,
@@ -132,7 +118,7 @@ export function calculateUpcomingStats(
   for (const card of cards) {
     if (card.paused) continue;
 
-    const dueKey = formatLocalDate(new Date(card.fsrs.due), dayStartHour);
+    const dueKey = formatLocalDate(new Date(card.fsrs.due));
 
     if (dueKey <= firstDate) {
       result[0].count++;

--- a/entrypoints/popup/queries/__tests__/cards.test.tsx
+++ b/entrypoints/popup/queries/__tests__/cards.test.tsx
@@ -2,6 +2,7 @@
  * @vitest-environment happy-dom
  */
 
+import { focusManager } from '@tanstack/react-query';
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { type Grade, Rating, State } from 'ts-fsrs';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -22,6 +23,7 @@ import {
   usePauseCardMutation,
   useRateCardMutation,
   useRemoveCardMutation,
+  useReviewQueueQuery,
 } from '../cards';
 import { statsQueryKeys } from '../stats';
 
@@ -40,6 +42,36 @@ describe('useCardsQuery', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
     expect(sendMessage).toHaveBeenCalledWith('getAllCards');
+  });
+});
+
+describe('useReviewQueueQuery polling', () => {
+  it('pauses polling while hidden and stops after unmount', async () => {
+    vi.useFakeTimers();
+    focusManager.setFocused(true);
+    createMessageMock(vi.mocked(sendMessage)).reset().resolve('getReviewQueue', []);
+    const view = renderHook(() => useReviewQueueQuery(), { wrapper: createTestWrapper().wrapper });
+
+    try {
+      await act(() => vi.advanceTimersByTimeAsync(1));
+      expect(sendMessage).toHaveBeenCalledTimes(1);
+
+      focusManager.setFocused(false);
+      await act(() => vi.advanceTimersByTimeAsync(30_000));
+      expect(sendMessage).toHaveBeenCalledTimes(1);
+
+      focusManager.setFocused(true);
+      await act(() => vi.advanceTimersByTimeAsync(15_000));
+      expect(sendMessage).toHaveBeenCalledTimes(2);
+
+      view.unmount();
+      await act(() => vi.advanceTimersByTimeAsync(30_000));
+      expect(sendMessage).toHaveBeenCalledTimes(2);
+    } finally {
+      view.unmount();
+      focusManager.setFocused(undefined);
+      vi.useRealTimers();
+    }
   });
 });
 
@@ -203,8 +235,33 @@ describe('card queries through JSON messaging and background handlers', () => {
     createMessageMock(vi.mocked(sendMessage))
       .reset()
       .handle('getAllCards', (data) => runner.execute<'getAllCards'>(backgroundMessages.getAllCards, data))
+      .handle('getReviewQueue', (data) => runner.execute<'getReviewQueue'>(backgroundMessages.getReviewQueue, data))
       .handle('rateCard', (data) => runner.execute<'rateCard'>(backgroundMessages.rateCard, data));
   });
+
+  it.each([State.Learning, State.Relearning])(
+    'refreshes an empty queue when a state %i card becomes due',
+    async (state) => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2024-03-15T10:00:00'));
+      const card = createMockCard(state);
+      card.fsrs.due = Date.now() + 10_000;
+      await saveCards([card]);
+      const view = renderHook(() => useReviewQueueQuery(), { wrapper: createTestWrapper().wrapper });
+
+      try {
+        await act(() => vi.advanceTimersByTimeAsync(1));
+        expect(view.result.current.isSuccess).toBe(true);
+        expect(view.result.current.data).toEqual([]);
+
+        await act(() => vi.advanceTimersByTimeAsync(15_000));
+        expect(view.result.current.data).toEqual([card]);
+      } finally {
+        view.unmount();
+        vi.useRealTimers();
+      }
+    }
+  );
 
   it.each([0, undefined])('preserves numeric dates and last_review=%s in query results', async (lastReview) => {
     const card = createMockCard(State.Review, { createdAt: 0 });

--- a/entrypoints/popup/queries/__tests__/cards.test.tsx
+++ b/entrypoints/popup/queries/__tests__/cards.test.tsx
@@ -2,7 +2,6 @@
  * @vitest-environment happy-dom
  */
 
-import { focusManager } from '@tanstack/react-query';
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { type Grade, Rating, State } from 'ts-fsrs';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -42,36 +41,6 @@ describe('useCardsQuery', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
     expect(sendMessage).toHaveBeenCalledWith('getAllCards');
-  });
-});
-
-describe('useReviewQueueQuery polling', () => {
-  it('pauses polling while hidden and stops after unmount', async () => {
-    vi.useFakeTimers();
-    focusManager.setFocused(true);
-    createMessageMock(vi.mocked(sendMessage)).reset().resolve('getReviewQueue', []);
-    const view = renderHook(() => useReviewQueueQuery(), { wrapper: createTestWrapper().wrapper });
-
-    try {
-      await act(() => vi.advanceTimersByTimeAsync(1));
-      expect(sendMessage).toHaveBeenCalledTimes(1);
-
-      focusManager.setFocused(false);
-      await act(() => vi.advanceTimersByTimeAsync(30_000));
-      expect(sendMessage).toHaveBeenCalledTimes(1);
-
-      focusManager.setFocused(true);
-      await act(() => vi.advanceTimersByTimeAsync(15_000));
-      expect(sendMessage).toHaveBeenCalledTimes(2);
-
-      view.unmount();
-      await act(() => vi.advanceTimersByTimeAsync(30_000));
-      expect(sendMessage).toHaveBeenCalledTimes(2);
-    } finally {
-      view.unmount();
-      focusManager.setFocused(undefined);
-      vi.useRealTimers();
-    }
   });
 });
 

--- a/entrypoints/popup/queries/__tests__/settings.test.tsx
+++ b/entrypoints/popup/queries/__tests__/settings.test.tsx
@@ -7,7 +7,6 @@ import { expect, it, vi } from 'vitest';
 import { createTestWrapper } from '@/test/utils/test-wrapper';
 import { cardQueryKeys } from '../cards';
 import { settingsQueryKeys, useUpdateSettingsMutation } from '../settings';
-import { statsQueryKeys } from '../stats';
 
 vi.mock('@/infrastructure/browser/messages', () => ({
   sendMessage: vi.fn(() => Promise.resolve(undefined)),
@@ -26,5 +25,4 @@ it('invalidates only the queries affected by each settings change', async () => 
 
   await expectInvalidations({ theme: 'dark' }, [settingsQueryKeys.all]);
   await expectInvalidations({ maxNewCardsPerDay: 10 }, [settingsQueryKeys.all, cardQueryKeys.all]);
-  await expectInvalidations({ dayStartHour: 4 }, [settingsQueryKeys.all, cardQueryKeys.all, statsQueryKeys.all]);
 });

--- a/entrypoints/popup/queries/cards.ts
+++ b/entrypoints/popup/queries/cards.ts
@@ -30,6 +30,7 @@ export function useReviewQueueQuery(options?: { enabled?: boolean; refetchOnWind
     enabled,
     staleTime: 0,
     gcTime: 0,
+    refetchInterval: 15_000,
     refetchOnWindowFocus,
   });
 }

--- a/entrypoints/popup/queries/settings.ts
+++ b/entrypoints/popup/queries/settings.ts
@@ -2,7 +2,6 @@ import { useMutation, useQueryClient, useSuspenseQuery } from '@tanstack/react-q
 import type { Settings } from '@/domain/settings';
 import { sendMessage } from '@/infrastructure/browser/messages';
 import { cardQueryKeys } from './cards';
-import { statsQueryKeys } from './stats';
 
 export const settingsQueryKeys = {
   all: ['settings'] as const,
@@ -23,12 +22,8 @@ export function useUpdateSettingsMutation() {
     onSuccess: (_data, changes) => {
       queryClient.invalidateQueries({ queryKey: settingsQueryKeys.all });
 
-      if ('maxNewCardsPerDay' in changes || 'dayStartHour' in changes) {
+      if ('maxNewCardsPerDay' in changes) {
         queryClient.invalidateQueries({ queryKey: cardQueryKeys.all });
-      }
-
-      if ('dayStartHour' in changes) {
-        queryClient.invalidateQueries({ queryKey: statsQueryKeys.all });
       }
     },
   });

--- a/entrypoints/popup/views/settings/ReviewSettingsSection.tsx
+++ b/entrypoints/popup/views/settings/ReviewSettingsSection.tsx
@@ -9,14 +9,9 @@ export function ReviewSettingsSection() {
   const { data: settings } = useSettingsQuery();
   const updateSettingsMutation = useUpdateSettingsMutation();
   const [inputValue, setInputValue] = useState('');
-  const [dayStartHourValue, setDayStartHourValue] = useState('');
 
   useEffect(() => {
     setInputValue(settings.maxNewCardsPerDay.toString());
-  }, [settings]);
-
-  useEffect(() => {
-    setDayStartHourValue(settings.dayStartHour.toString());
   }, [settings]);
 
   const handleBlur = () => {
@@ -29,19 +24,6 @@ export function ReviewSettingsSection() {
       updateSettingsMutation.mutate({ maxNewCardsPerDay: value });
     } else {
       setInputValue(settings.maxNewCardsPerDay.toString());
-    }
-  };
-
-  const handleDayStartBlur = () => {
-    const value = parseInt(dayStartHourValue, 10);
-    if (
-      !Number.isNaN(value) &&
-      value >= SETTINGS_CONSTRAINTS.dayStartHour.min &&
-      value <= SETTINGS_CONSTRAINTS.dayStartHour.max
-    ) {
-      updateSettingsMutation.mutate({ dayStartHour: value });
-    } else {
-      setDayStartHourValue(settings.dayStartHour.toString());
     }
   };
 
@@ -59,20 +41,6 @@ export function ReviewSettingsSection() {
             min={SETTINGS_CONSTRAINTS.maxNewCardsPerDay.min.toString()}
             max={SETTINGS_CONSTRAINTS.maxNewCardsPerDay.max.toString()}
             placeholder={settings.maxNewCardsPerDay.toString()}
-            className="w-20 px-2 py-1 rounded border bg-tertiary text-primary border-current"
-          />
-        </TextField>
-        <TextField className="flex items-center justify-between">
-          <Label>{t.settings.reviewSettings.dayStartHour}</Label>
-          <Input
-            type="number"
-            value={dayStartHourValue}
-            onChange={(e) => setDayStartHourValue(e.target.value)}
-            onBlur={handleDayStartBlur}
-            min={SETTINGS_CONSTRAINTS.dayStartHour.min.toString()}
-            max={SETTINGS_CONSTRAINTS.dayStartHour.max.toString()}
-            step="1"
-            placeholder={settings.dayStartHour.toString()}
             className="w-20 px-2 py-1 rounded border bg-tertiary text-primary border-current"
           />
         </TextField>

--- a/entrypoints/popup/views/settings/__tests__/ReviewSettingsSection.test.tsx
+++ b/entrypoints/popup/views/settings/__tests__/ReviewSettingsSection.test.tsx
@@ -1,0 +1,30 @@
+/** @vitest-environment happy-dom */
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { expect, it, vi } from 'vitest';
+import { settingsQueryKeys } from '@/entrypoints/popup/queries/settings';
+import { sendMessage } from '@/infrastructure/browser/messages';
+import { createMessageMock } from '@/test/utils/message-mocks';
+import { buildSettings } from '@/test/utils/settings-mocks';
+import { createTestWrapper } from '@/test/utils/test-wrapper';
+import { ReviewSettingsSection } from '../ReviewSettingsSection';
+
+vi.mock('@/infrastructure/browser/messages', () => ({ sendMessage: vi.fn() }));
+
+it('offers only the daily new-card limit and saves changes', async () => {
+  createMessageMock(vi.mocked(sendMessage))
+    .resolve('getSettings', buildSettings())
+    .resolve('updateSettings', undefined);
+  const { wrapper, queryClient } = createTestWrapper();
+  queryClient.setQueryData(settingsQueryKeys.all, buildSettings());
+  render(<ReviewSettingsSection />, { wrapper });
+
+  const input = screen.getByRole('spinbutton', { name: 'New Cards Per Day' });
+  expect(screen.getAllByRole('spinbutton')).toEqual([input]);
+  expect(input).toHaveValue(3);
+  fireEvent.change(input, { target: { value: '8' } });
+  fireEvent.blur(input);
+
+  await waitFor(() =>
+    expect(sendMessage).toHaveBeenCalledWith('updateSettings', { changes: { maxNewCardsPerDay: 8 } })
+  );
+});

--- a/i18n/de.ts
+++ b/i18n/de.ts
@@ -126,7 +126,6 @@ const de: Translations = {
     reviewSettings: {
       title: 'Wiederholungseinstellungen',
       newCardsPerDay: 'Neue Karten pro Tag',
-      dayStartHour: 'Tagesbeginn (Stunden nach Mitternacht)',
     },
     problemAutoClear: {
       title: 'Aufgabe automatisch zurücksetzen',

--- a/i18n/en.ts
+++ b/i18n/en.ts
@@ -163,7 +163,6 @@ const en = {
     reviewSettings: {
       title: 'Review Settings',
       newCardsPerDay: 'New Cards Per Day',
-      dayStartHour: 'Next Day Offset (hours past midnight)',
     },
 
     problemAutoClear: {

--- a/i18n/hi.ts
+++ b/i18n/hi.ts
@@ -145,7 +145,6 @@ const hi: Translations = {
     reviewSettings: {
       title: 'रिव्यु सेटिंग्स',
       newCardsPerDay: 'प्रति दिन नए कार्ड',
-      dayStartHour: 'अगले दिन का ऑफ़सेट (मध्यरात्रि के बाद घंटे)',
     },
     problemAutoClear: {
       title: 'प्रॉब्लम ऑटो रीसेट',

--- a/i18n/pl.ts
+++ b/i18n/pl.ts
@@ -164,7 +164,6 @@ const pl: Translations = {
     reviewSettings: {
       title: 'Ustawienia powtórek',
       newCardsPerDay: 'Nowe karty dziennie',
-      dayStartHour: 'Przesunięcie nowego dnia (godziny po północy)',
     },
 
     problemAutoClear: {

--- a/i18n/zh-CN.ts
+++ b/i18n/zh-CN.ts
@@ -145,7 +145,6 @@ const zhCN: Translations = {
     reviewSettings: {
       title: '复习设置',
       newCardsPerDay: '每日新卡片数量',
-      dayStartHour: '新一天偏移（午夜后小时数）',
     },
 
     problemAutoClear: {

--- a/infrastructure/storage/__tests__/migrations.test.ts
+++ b/infrastructure/storage/__tests__/migrations.test.ts
@@ -36,12 +36,12 @@ describe('migrations', () => {
       expect(await fakeBrowser.storage.local.get(null)).toEqual(before);
     });
 
-    it.each([1, 2])('does not reapply the domain migration to schema %s', (schemaVersion) => {
+    it.each([1, 2, 3])('does not reapply the domain migration to schema %s', (schemaVersion) => {
       const data = { cards: { 'two-sum': createMockCard(State.Review, { slug: 'two-sum' }) } };
       expect(migrateBackupData(data, schemaVersion)).toEqual(data);
     });
 
-    it.each([-1, 0.5, 3])('rejects unsupported schema %s', (schemaVersion) => {
+    it.each([-1, 0.5, 4])('rejects unsupported schema %s', (schemaVersion) => {
       expect(() => migrateBackupData({ cards: {} }, schemaVersion)).toThrow('Unsupported schema version');
     });
   });
@@ -250,7 +250,7 @@ describe('migrations', () => {
           ...cards,
           'two-sum': { ...cards['two-sum'], domain: 'leetcode.com' },
         },
-        [STORAGE_KEYS.schemaVersion.slice('local:'.length)]: 2,
+        [STORAGE_KEYS.schemaVersion.slice('local:'.length)]: 3,
       });
     });
 
@@ -316,14 +316,53 @@ describe('migrations', () => {
 
       expect(await fakeBrowser.storage.local.get(null)).toEqual({
         ...expectedAfterCardWrite,
-        [STORAGE_KEYS.schemaVersion.slice('local:'.length)]: 2,
+        [STORAGE_KEYS.schemaVersion.slice('local:'.length)]: 3,
       });
     });
 
     it('should handle empty or missing cards storage', async () => {
       await runStartupMigrations();
 
-      expect(await getCurrentSchemaVersion()).toBe(2);
+      expect(await getCurrentSchemaVersion()).toBe(3);
+    });
+  });
+
+  describe('migration v3: remove configurable day start', () => {
+    it('removes the legacy setting while retaining cards, history, and other settings', async () => {
+      await setSchemaVersion(2);
+      const card = createMockCard(State.Review);
+      await storage.setItem(STORAGE_KEYS.cards, { [card.slug]: card });
+      await storage.setItem(STORAGE_KEYS.stats, { '2024-03-14': { streak: 7 } });
+      await storage.setItem('sync:leetsrs:dayStartHour', 4);
+      await storage.setItem(STORAGE_KEYS.maxNewCardsPerDay, 8);
+      const localBefore = await fakeBrowser.storage.local.get(null);
+      const syncBefore = await fakeBrowser.storage.sync.get(null);
+      const { 'leetsrs:dayStartHour': _legacy, ...remainingSettings } = syncBefore;
+
+      await runStartupMigrations();
+      await runStartupMigrations();
+
+      expect(await getCurrentSchemaVersion()).toBe(3);
+      expect(await fakeBrowser.storage.sync.get(null)).toEqual(remainingSettings);
+      expect(await fakeBrowser.storage.local.get(null)).toEqual({
+        ...localBefore,
+        'leetsrs:schemaVersion': 3,
+      });
+    });
+
+    it('retries legacy setting removal before advancing the schema after a storage failure', async () => {
+      await setSchemaVersion(2);
+      await storage.setItem('sync:leetsrs:dayStartHour', 4);
+      const remove = vi.spyOn(storage, 'removeItems').mockRejectedValueOnce(new Error('storage unavailable'));
+      try {
+        await expect(runStartupMigrations()).rejects.toThrow('Failed to run migration 3');
+        expect(await getCurrentSchemaVersion()).toBe(2);
+        await runStartupMigrations();
+        expect(await storage.getItem('sync:leetsrs:dayStartHour')).toBeNull();
+        expect(await getCurrentSchemaVersion()).toBe(3);
+      } finally {
+        remove.mockRestore();
+      }
     });
   });
 
@@ -334,7 +373,7 @@ describe('migrations', () => {
 
       await runStartupMigrations();
 
-      expect(await getCurrentSchemaVersion()).toBe(2);
+      expect(await getCurrentSchemaVersion()).toBe(3);
       expect(await storage.getItem(STORAGE_KEYS.theme)).toBe('dark');
     });
   });

--- a/infrastructure/storage/migrations.ts
+++ b/infrastructure/storage/migrations.ts
@@ -1,3 +1,4 @@
+import type { StorageItemKey } from 'wxt/utils/storage';
 import { storage } from '#imports';
 import { STORAGE_KEYS } from './storage-keys';
 
@@ -8,6 +9,7 @@ interface MigrationData {
 
 export interface Migration {
   description: string;
+  removeKeys?: readonly StorageItemKey[];
   migrate: (data: MigrationData) => MigrationData;
 }
 
@@ -40,6 +42,11 @@ const migrations: readonly Migration[] = [
     description: 'Add system theme preference',
     migrate: (data: MigrationData): MigrationData => data,
   },
+  {
+    description: 'Remove configurable day start',
+    migrate: (data: MigrationData): MigrationData => data,
+    removeKeys: ['sync:leetsrs:dayStartHour'],
+  },
 ];
 
 export function migrateBackupData(data: MigrationData, schemaVersion: number): MigrationData {
@@ -63,6 +70,9 @@ export async function runStartupMigrations(steps: readonly Migration[] = migrati
       const migrated = migration.migrate(data);
       if (migrated.cards !== undefined) {
         await storage.setItem(STORAGE_KEYS.cards, migrated.cards);
+      }
+      if (migration.removeKeys) {
+        await storage.removeItems([...migration.removeKeys]);
       }
       await setSchemaVersion(version);
     } catch (error) {

--- a/infrastructure/storage/storage-keys.ts
+++ b/infrastructure/storage/storage-keys.ts
@@ -3,7 +3,6 @@ export const STORAGE_KEYS = {
   stats: 'local:leetsrs:stats',
   notes: 'local:leetsrs:notes',
   maxNewCardsPerDay: 'sync:leetsrs:maxNewCardsPerDay',
-  dayStartHour: 'sync:leetsrs:dayStartHour',
   theme: 'sync:leetsrs:theme',
   resetEditorOnEveryProblem: 'sync:leetsrs:autoClearLeetcode',
   resetEditorOnDueReview: 'sync:leetsrs:resetEditorOnDueReview',

--- a/services/__tests__/cards.test.ts
+++ b/services/__tests__/cards.test.ts
@@ -805,42 +805,20 @@ describe('rateCard', () => {
     expect(todayStats?.gradeBreakdown[Rating.Good]).toBe(1);
   });
 
-  it('should return shouldRequeue based on whether card is still due today', async () => {
-    // Test with Rating.Again - card should still be due today
-    const againResult = await rateCard({
-      slug: 'test-again',
-      name: 'Test Again',
-      rating: Rating.Again,
-      leetcodeId: '2001',
-      difficulty: 'Easy',
-      domain: 'leetcode.com',
-    });
-    expect(againResult.shouldRequeue).toBe(true); // Again typically schedules for same day
+  it.each([Rating.Again, Rating.Hard, Rating.Good, Rating.Easy] as const)(
+    'waits for the FSRS due time after rating %i instead of requeueing immediately',
+    async (rating) => {
+      const result = await rateCard({ ...buildProblem(), rating });
+      expect(result.card.fsrs.due).toBeGreaterThan(Date.now());
+      expect(result.shouldRequeue).toBe(false);
+      expect(await getReviewQueue()).toEqual([]);
 
-    // Test with Rating.Good on a new card - might schedule for tomorrow
-    const goodResult = await rateCard({
-      slug: 'test-good',
-      name: 'Test Good',
-      rating: Rating.Good,
-      leetcodeId: '2002',
-      difficulty: 'Medium',
-      domain: 'leetcode.com',
-    });
-    // New cards rated Good typically get scheduled for the next day or later
-    // The exact value depends on FSRS algorithm, but we can verify the field exists
-    expect(typeof goodResult.shouldRequeue).toBe('boolean');
-
-    // Test with Rating.Hard - often keeps cards due today
-    const hardResult = await rateCard({
-      slug: 'test-hard',
-      name: 'Test Hard',
-      rating: Rating.Hard,
-      leetcodeId: '2003',
-      difficulty: 'Hard',
-      domain: 'leetcode.com',
-    });
-    expect(typeof hardResult.shouldRequeue).toBe('boolean');
-  });
+      vi.setSystemTime(result.card.fsrs.due - 1);
+      expect(await getReviewQueue()).toEqual([]);
+      vi.setSystemTime(result.card.fsrs.due);
+      expect(await getReviewQueue()).toEqual([result.card]);
+    }
+  );
 
   it('should update stats correctly for review cards vs new cards', async () => {
     // Create a card
@@ -1119,74 +1097,28 @@ describe('getReviewQueue', () => {
     expect(queue).toHaveLength(0);
   });
 
-  it('should include cards due today regardless of time', async () => {
-    // Test that cards due at any time today are included
-    await addCard({
-      slug: 'morning',
-      name: 'Morning Card',
-      leetcodeId: '5001',
-      difficulty: 'Easy',
-      domain: 'leetcode.com',
-    });
-    await addCard({
-      slug: 'evening',
-      name: 'Evening Card',
-      leetcodeId: '5002',
-      difficulty: 'Medium',
-      domain: 'leetcode.com',
-    });
-    await addCard({
-      slug: 'midnight',
-      name: 'Midnight Card',
-      leetcodeId: '5003',
-      difficulty: 'Hard',
-      domain: 'leetcode.com',
-    });
+  it.each([FsrsState.New, FsrsState.Learning, FsrsState.Review, FsrsState.Relearning])(
+    'includes state %i cards only as each due timestamp is reached',
+    async (state) => {
+      vi.setSystemTime(new Date('2024-01-15T12:00:00'));
+      const cards = [
+        ['morning', '2024-01-15T06:00:00'],
+        ['evening', '2024-01-15T20:00:00'],
+        ['midnight', '2024-01-15T23:59:59.999'],
+      ].map(([slug, due]) => {
+        const card = createMockCard(state, { slug });
+        card.fsrs.due = new Date(due).getTime();
+        return card;
+      });
+      await storage.setItem(STORAGE_KEYS.cards, Object.fromEntries(cards.map((card) => [card.slug, card])));
 
-    // Rate them to move out of New state
-    await rateCard({
-      slug: 'morning',
-      name: 'Morning Card',
-      rating: Rating.Good,
-      leetcodeId: '5001',
-      difficulty: 'Easy',
-      domain: 'leetcode.com',
-    });
-    await rateCard({
-      slug: 'evening',
-      name: 'Evening Card',
-      rating: Rating.Good,
-      leetcodeId: '5002',
-      difficulty: 'Medium',
-      domain: 'leetcode.com',
-    });
-    await rateCard({
-      slug: 'midnight',
-      name: 'Midnight Card',
-      rating: Rating.Good,
-      leetcodeId: '5003',
-      difficulty: 'Hard',
-      domain: 'leetcode.com',
-    });
-
-    // Set due times to various times today
-    const cards = await storage.getItem<Record<string, Card>>(STORAGE_KEYS.cards);
-    requireDefined(cards).morning.fsrs.due = new Date('2024-01-15T06:00:00Z').getTime(); // 6 AM today
-    requireDefined(cards).evening.fsrs.due = new Date('2024-01-15T20:00:00Z').getTime(); // 8 PM today
-    requireDefined(cards).midnight.fsrs.due = new Date('2024-01-15T23:59:59Z').getTime(); // End of today
-    await storage.setItem(STORAGE_KEYS.cards, cards);
-
-    const queue = await getReviewQueue();
-
-    // All three should be included even though they're due at different times today
-    const reviewCards = queue.filter((card) => card.fsrs.state !== FsrsState.New);
-    expect(reviewCards).toHaveLength(3);
-
-    const slugs = reviewCards.map((card) => card.slug);
-    expect(slugs).toContain('morning');
-    expect(slugs).toContain('evening');
-    expect(slugs).toContain('midnight');
-  });
+      expect((await getReviewQueue()).map((card) => card.slug)).toEqual(['morning']);
+      vi.setSystemTime(new Date('2024-01-15T20:00:00'));
+      expect((await getReviewQueue()).map((card) => card.slug)).toEqual(['morning', 'evening']);
+      vi.setSystemTime(new Date('2024-01-15T23:59:59.999'));
+      expect((await getReviewQueue()).map((card) => card.slug)).toEqual(['morning', 'evening', 'midnight']);
+    }
+  );
 
   it('should exclude cards due tomorrow even if due at 00:00:01', async () => {
     await addCard({
@@ -1562,48 +1494,21 @@ describe('getReviewQueue', () => {
     expect(queue1.length).toBe(3); // Limited by max new cards per day
   });
 
-  it('should place cards rated "Again" at the back of the queue', async () => {
-    // Create cards
-    await addCard({
-      slug: 'first-card',
-      name: 'First Card',
-      leetcodeId: '1001',
-      difficulty: 'Easy',
-      domain: 'leetcode.com',
-    });
-    await addCard({
-      slug: 'second-card',
-      name: 'Second Card',
-      leetcodeId: '1002',
-      difficulty: 'Medium',
-      domain: 'leetcode.com',
-    });
-    await addCard({
-      slug: 'third-card',
-      name: 'Third Card',
-      leetcodeId: '1003',
-      difficulty: 'Hard',
-      domain: 'leetcode.com',
-    });
+  it.each([Rating.Again, Rating.Hard] as const)(
+    'restores rating %i cards in due order when their interval ends',
+    async (rating) => {
+      const first = buildProblem({ slug: 'first-card' });
+      await addCard(first);
+      await addCard(buildProblem({ slug: 'second-card' }));
+      await addCard(buildProblem({ slug: 'third-card' }));
 
-    // Rate first card as "Again" - it should get a due date later today
-    await rateCard({
-      slug: 'first-card',
-      name: 'First Card',
-      rating: Rating.Again,
-      leetcodeId: '1001',
-      difficulty: 'Easy',
-      domain: 'leetcode.com',
-    });
+      const result = await rateCard({ ...first, rating });
+      expect((await getReviewQueue()).map((card) => card.slug)).toEqual(['second-card', 'third-card']);
 
-    const queue = await getReviewQueue();
-
-    // First card should now be at the end (due later today)
-    const slugs = queue.map((c) => c.slug);
-    expect(slugs[0]).toBe('second-card');
-    expect(slugs[1]).toBe('third-card');
-    expect(slugs[2]).toBe('first-card');
-  });
+      vi.setSystemTime(result.card.fsrs.due);
+      expect((await getReviewQueue()).map((card) => card.slug)).toEqual(['second-card', 'third-card', 'first-card']);
+    }
+  );
 
   it('should select the same new cards consistently when limit applies', async () => {
     // Create more new cards than the daily limit
@@ -1620,7 +1525,7 @@ describe('getReviewQueue', () => {
 
     // Set all cards to have the same due date for predictable ordering
     const cards = await storage.getItem<Record<string, Card>>(STORAGE_KEYS.cards);
-    const sameTime = new Date('2024-01-15T10:00:00').getTime();
+    const sameTime = Date.now();
     for (const slug of cardSlugs) {
       requireDefined(cards)[slug].fsrs.due = sameTime;
     }
@@ -1636,6 +1541,7 @@ describe('getReviewQueue', () => {
   });
 
   it('should maintain order when mixing review and new cards', async () => {
+    vi.setSystemTime(new Date('2024-01-15T12:00:00'));
     // Create new cards with early due dates
     await addCard({
       slug: 'new-early',
@@ -1682,39 +1588,6 @@ describe('getReviewQueue', () => {
     expect(queue[0].slug).toBe('new-early');
     expect(queue[1].slug).toBe('review-middle');
     expect(queue[2].slug).toBe('new-late');
-  });
-
-  it('should handle cards rated "Hard" moving to later in the day', async () => {
-    // Set time to morning
-    vi.setSystemTime(new Date('2024-01-15T09:00:00'));
-
-    // Create cards
-    await addCard({ slug: 'card-1', name: 'Card 1', leetcodeId: '1001', difficulty: 'Easy', domain: 'leetcode.com' });
-    await addCard({ slug: 'card-2', name: 'Card 2', leetcodeId: '1002', difficulty: 'Medium', domain: 'leetcode.com' });
-    await addCard({ slug: 'card-3', name: 'Card 3', leetcodeId: '1003', difficulty: 'Hard', domain: 'leetcode.com' });
-
-    // Get initial queue
-    const initialQueue = await getReviewQueue();
-    expect(initialQueue[0].slug).toBe('card-1');
-
-    // Rate first card as "Hard" - should move to later today
-    await rateCard({
-      slug: 'card-1',
-      name: 'Card 1',
-      rating: Rating.Hard,
-      leetcodeId: '1001',
-      difficulty: 'Easy',
-      domain: 'leetcode.com',
-    });
-
-    // Get queue again
-    const updatedQueue = await getReviewQueue();
-
-    // Card-1 should now be at the end (due later)
-    const slugs = updatedQueue.map((c) => c.slug);
-    expect(slugs[0]).toBe('card-2');
-    expect(slugs[1]).toBe('card-3');
-    expect(slugs[2]).toBe('card-1'); // Moved to end
   });
 
   it('should handle dynamic changes to max new cards setting', async () => {
@@ -1829,6 +1702,9 @@ describe('getReviewQueue', () => {
       difficulty: 'Medium',
       domain: 'leetcode.com',
     });
+
+    // Wait until the learning cards are due.
+    vi.setSystemTime(new Date('2024-01-15T11:00:00'));
 
     // Pause some cards
     await setPauseStatus('new2', true); // Pause a new card

--- a/services/__tests__/cards.test.ts
+++ b/services/__tests__/cards.test.ts
@@ -1120,36 +1120,6 @@ describe('getReviewQueue', () => {
     }
   );
 
-  it('should exclude cards due tomorrow even if due at 00:00:01', async () => {
-    await addCard({
-      slug: 'tomorrow',
-      name: 'Tomorrow Card',
-      leetcodeId: '5004',
-      difficulty: 'Medium',
-      domain: 'leetcode.com',
-    });
-    await rateCard({
-      slug: 'tomorrow',
-      name: 'Tomorrow Card',
-      rating: Rating.Good,
-      leetcodeId: '5004',
-      difficulty: 'Medium',
-      domain: 'leetcode.com',
-    });
-
-    // Set due to one second after midnight tomorrow in local timezone
-    const now = new Date();
-    const tomorrow = new Date(now.getFullYear(), now.getMonth(), now.getDate() + 1, 0, 0, 1);
-    const cards = await storage.getItem<Record<string, Card>>(STORAGE_KEYS.cards);
-    requireDefined(cards).tomorrow.fsrs.due = tomorrow.getTime();
-    await storage.setItem(STORAGE_KEYS.cards, cards);
-
-    const queue = await getReviewQueue();
-
-    // Should not include the card due tomorrow
-    expect(queue).toHaveLength(0);
-  });
-
   it('should handle mix of new, due, and future cards', async () => {
     // Reset stats to ensure clean state
     await storage.setItem(STORAGE_KEYS.stats, {});

--- a/services/__tests__/editor-reset.test.ts
+++ b/services/__tests__/editor-reset.test.ts
@@ -1,5 +1,5 @@
 import { createEmptyCard, State as FsrsState } from 'ts-fsrs';
-import { beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { fakeBrowser } from 'wxt/testing/fake-browser';
 import { storage } from 'wxt/utils/storage';
 import type { Card } from '@/domain/cards';
@@ -8,7 +8,12 @@ import { shouldResetEditor } from '../editor-reset';
 import { updateSettings } from '../settings';
 
 describe('shouldResetEditor', () => {
-  beforeEach(() => fakeBrowser.reset());
+  beforeEach(() => {
+    fakeBrowser.reset();
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2025-01-01T10:00:00'));
+  });
+  afterEach(() => vi.useRealTimers());
 
   it('resets every problem when the global setting is enabled', async () => {
     await updateSettings({ resetEditorOnEveryProblem: true });
@@ -32,6 +37,14 @@ describe('shouldResetEditor', () => {
     if (enableSetting) await updateSettings({ resetEditorOnDueReview: true });
     await storeCard(makeCard(overrides));
     await expect(shouldResetEditor('two-sum', 'leetcode.com')).resolves.toBe(false);
+  });
+
+  it('waits for the exact due timestamp before resetting the editor', async () => {
+    await updateSettings({ resetEditorOnDueReview: true });
+    await storeCard(makeCard({ due: new Date('2025-01-01T10:05:00') }));
+    await expect(shouldResetEditor('two-sum', 'leetcode.com')).resolves.toBe(false);
+    vi.setSystemTime(new Date('2025-01-01T10:05:00'));
+    await expect(shouldResetEditor('two-sum', 'leetcode.com')).resolves.toBe(true);
   });
 
   it('does not reset a card from the other LeetCode domain', async () => {

--- a/services/__tests__/import-export.test.ts
+++ b/services/__tests__/import-export.test.ts
@@ -68,7 +68,6 @@ describe('import-export', () => {
 
       const mockSettings = buildSettings({
         maxNewCardsPerDay: 5,
-        dayStartHour: 4,
         theme: 'dark',
         resetEditorOnEveryProblem: true,
         resetEditorOnDueReview: true,
@@ -81,7 +80,7 @@ describe('import-export', () => {
       await storage.setItem(STORAGE_KEYS.stats, mockStats);
       await storage.setItem(`${STORAGE_KEYS.notes}:${cardUuid}` as const, mockNotes[cardUuid]);
       await storage.setItem(STORAGE_KEYS.maxNewCardsPerDay, mockSettings.maxNewCardsPerDay);
-      await storage.setItem(STORAGE_KEYS.dayStartHour, mockSettings.dayStartHour);
+      await storage.setItem('sync:leetsrs:dayStartHour', 4);
       await storage.setItem(STORAGE_KEYS.theme, mockSettings.theme);
       await storage.setItem(STORAGE_KEYS.resetEditorOnEveryProblem, mockSettings.resetEditorOnEveryProblem);
       await storage.setItem(STORAGE_KEYS.resetEditorOnDueReview, mockSettings.resetEditorOnDueReview);
@@ -129,10 +128,10 @@ describe('import-export', () => {
       expect(parsed.data.monthlyStats).toBeUndefined();
     });
 
-    it('should export schema version 2 after migrations run', async () => {
+    it('should export schema version 3 after migrations run', async () => {
       await runStartupMigrations();
       const parsed = JSON.parse(await exportData());
-      expect(parsed.schemaVersion).toBe(2);
+      expect(parsed.schemaVersion).toBe(3);
     });
 
     it('does not export legacy monthly stats', async () => {
@@ -263,7 +262,6 @@ describe('import-export', () => {
         },
         settings: buildSettings({
           maxNewCardsPerDay: 5,
-          dayStartHour: 2,
           theme: 'light',
           resetEditorOnEveryProblem: true,
           resetEditorOnDueReview: true,
@@ -432,7 +430,7 @@ describe('import-export', () => {
       const notes = { ...validExportData.data.notes, 'cn-card-id': { text: 'Keep the carry' } };
       const dataUpdatedAt = '2024-01-15T10:00:00.000Z';
 
-      it.each([0, undefined, 2])(
+      it.each([0, undefined, 2, 3])(
         'prepares and imports schema %s cards identically to startup migration',
         async (schemaVersion) => {
           await storage.setItem(STORAGE_KEYS.cards, legacyCards);
@@ -452,7 +450,8 @@ describe('import-export', () => {
             dataUpdatedAt,
             data: {
               ...validExportData.data,
-              cards: schemaVersion === 2 ? currentCards : legacyCards,
+              cards: schemaVersion ? currentCards : legacyCards,
+              settings: { ...validExportData.data.settings, dayStartHour: 4 },
               notes,
             },
           });
@@ -476,7 +475,9 @@ describe('import-export', () => {
           expect(await storage.getItem(STORAGE_KEYS.theme)).toBe('light');
           expect(await storage.getItem(STORAGE_KEYS.githubPat)).toBe('existing-pat');
           expect(await storage.getItem(STORAGE_KEYS.dataUpdatedAt)).toBe(dataUpdatedAt);
-          expect(await storage.getItem(STORAGE_KEYS.schemaVersion)).toBe(2);
+          expect(await storage.getItem(STORAGE_KEYS.schemaVersion)).toBe(3);
+          expect(await storage.getItem('sync:leetsrs:dayStartHour')).toBeNull();
+          expect(JSON.parse(await exportData()).data.settings).toEqual(validExportData.data.settings);
         }
       );
 
@@ -672,7 +673,6 @@ describe('import-export', () => {
       const legacyMonthlyStats = { '2023-12': { totalReviews: 5 } };
       await storage.setItem(legacyMonthlyStatsKey, legacyMonthlyStats);
       await storage.setItem(STORAGE_KEYS.maxNewCardsPerDay, 5);
-      await storage.setItem(STORAGE_KEYS.dayStartHour, 3);
       await storage.setItem(STORAGE_KEYS.theme, 'dark');
       await storage.setItem(STORAGE_KEYS.resetEditorOnEveryProblem, true);
       await storage.setItem(STORAGE_KEYS.resetEditorOnDueReview, true);
@@ -696,7 +696,6 @@ describe('import-export', () => {
       expect(await storage.getItem(STORAGE_KEYS.stats)).toBeNull();
       expect(await storage.getItem(legacyMonthlyStatsKey)).toEqual(legacyMonthlyStats);
       expect(await storage.getItem(STORAGE_KEYS.maxNewCardsPerDay)).toBeNull();
-      expect(await storage.getItem(STORAGE_KEYS.dayStartHour)).toBeNull();
       expect(await storage.getItem(STORAGE_KEYS.theme)).toBeNull();
       expect(await storage.getItem(STORAGE_KEYS.resetEditorOnEveryProblem)).toBeNull();
       expect(await storage.getItem(STORAGE_KEYS.resetEditorOnDueReview)).toBeNull();

--- a/services/__tests__/review-timing.test.ts
+++ b/services/__tests__/review-timing.test.ts
@@ -5,12 +5,9 @@ import { storage } from 'wxt/utils/storage';
 import type { DailyStats } from '@/domain/statistics';
 import { STORAGE_KEYS } from '@/infrastructure/storage/storage-keys';
 import { createMockCard } from '@/test/utils/card-mocks';
-import { buildSettings } from '@/test/utils/settings-mocks';
-import { getReviewQueue, isDueByDate } from '../cards';
-import { getSettings } from '../settings';
+import { getReviewQueue } from '../cards';
+import { updateSettings } from '../settings';
 import { getLastNDaysStats, getNextNDaysStats, getTodayKey, getYesterdayKey, updateStats } from '../stats';
-
-vi.mock('../settings', () => ({ getSettings: vi.fn() }));
 
 function dailyStats(date: string, newCards: number, streak = 1): DailyStats {
   return {
@@ -23,35 +20,25 @@ function dailyStats(date: string, newCards: number, streak = 1): DailyStats {
   };
 }
 
-describe('review-day service integration', () => {
+describe('review timing service integration', () => {
   beforeEach(() => {
     fakeBrowser.reset();
     vi.useFakeTimers();
-    vi.setSystemTime(new Date('2024-03-15T03:59:59.999'));
-    vi.mocked(getSettings).mockResolvedValue(buildSettings({ dayStartHour: 4 }));
+    vi.setSystemTime(new Date('2024-03-15T00:00:00.000'));
   });
 
   afterEach(() => {
     vi.useRealTimers();
   });
 
-  it('defaults an omitted reference date to the service clock at each call', () => {
-    const card = createMockCard(State.Review);
-    card.fsrs.due = new Date('2024-03-15T04:00:00').getTime();
-
-    expect(isDueByDate(card, undefined, 4)).toBe(false);
-    vi.setSystemTime(new Date('2024-03-15T04:00:00'));
-    expect(isDueByDate(card, undefined, 4)).toBe(true);
-  });
-
   it.each([
-    [getTodayKey, '2024-03-14'],
-    [getYesterdayKey, '2024-03-13'],
-  ])('%s uses the configured review-day boundary', async (getKey, expected) => {
+    [getTodayKey, '2024-03-15'],
+    [getYesterdayKey, '2024-03-14'],
+  ])('%s uses the local midnight boundary', async (getKey, expected) => {
     await expect(getKey()).resolves.toBe(expected);
   });
 
-  it('uses the review day for due cards and the daily new-card allowance', async () => {
+  it('uses exact due times and resets the daily new-card allowance at midnight', async () => {
     const cards = ['paused', 'new-a', 'new-b', 'future'].map((slug) => {
       const card = createMockCard(State.New, { slug, paused: slug === 'paused' });
       card.fsrs.due = new Date(slug === 'future' ? '2024-03-15T04:00:00' : '2024-03-14T12:00:00').getTime();
@@ -59,35 +46,47 @@ describe('review-day service integration', () => {
     });
     await storage.setItem(STORAGE_KEYS.cards, Object.fromEntries(cards.map((card) => [card.slug, card])));
     await storage.setItem(STORAGE_KEYS.stats, {
-      '2024-03-14': dailyStats('2024-03-14', 1),
-      '2024-03-15': dailyStats('2024-03-15', 0),
+      '2024-03-14': dailyStats('2024-03-14', 2),
+      '2024-03-15': dailyStats('2024-03-15', 1),
     });
-    vi.mocked(getSettings).mockResolvedValue(buildSettings({ dayStartHour: 4, maxNewCardsPerDay: 2 }));
+    await updateSettings({ maxNewCardsPerDay: 2 });
 
+    vi.setSystemTime(new Date('2024-03-14T23:59:59.999'));
+    expect(await getReviewQueue()).toEqual([]);
+    vi.setSystemTime(new Date('2024-03-15T00:00:00'));
     expect((await getReviewQueue()).map((card) => card.slug)).toEqual(['new-a']);
   });
 
-  it('continues the previous review day streak when creating stats before the day boundary', async () => {
-    await storage.setItem(STORAGE_KEYS.stats, { '2024-03-13': dailyStats('2024-03-13', 1, 7) });
+  it.each([
+    ['2024-03-15T00:00:00', '2024-03-14', '2024-03-15'],
+    ['2024-01-01T00:00:00', '2023-12-31', '2024-01-01'],
+    ['2024-03-11T00:00:00', '2024-03-10', '2024-03-11'],
+    ['2024-11-04T00:00:00', '2024-11-03', '2024-11-04'],
+  ])('continues the streak at local midnight %s', async (instant, yesterday, today) => {
+    vi.setSystemTime(new Date(instant));
+    await storage.setItem(STORAGE_KEYS.stats, { [yesterday]: dailyStats(yesterday, 1, 7) });
 
     await updateStats(Rating.Good, true);
 
     expect(await storage.getItem(STORAGE_KEYS.stats)).toEqual({
-      '2024-03-13': dailyStats('2024-03-13', 1, 7),
-      '2024-03-14': dailyStats('2024-03-14', 1, 8),
+      [yesterday]: dailyStats(yesterday, 1, 7),
+      [today]: dailyStats(today, 1, 8),
     });
   });
 
-  it.each([getLastNDaysStats, getNextNDaysStats])('%s anchors buckets to the review day', async (getBuckets) => {
-    expect(await getBuckets(1)).toEqual([expect.objectContaining({ date: '2024-03-14' })]);
-    expect(await getBuckets(0)).toEqual([]);
-  });
+  it.each([getLastNDaysStats, getNextNDaysStats])(
+    '%s anchors buckets to the local calendar day',
+    async (getBuckets) => {
+      expect(await getBuckets(1)).toEqual([expect.objectContaining({ date: '2024-03-15' })]);
+      expect(await getBuckets(0)).toEqual([]);
+    }
+  );
 
-  it('preserves the streak when adding to an existing review day', async () => {
-    await storage.setItem(STORAGE_KEYS.stats, { '2024-03-14': dailyStats('2024-03-14', 1, 3) });
+  it('preserves the streak when adding to an existing local calendar day', async () => {
+    await storage.setItem(STORAGE_KEYS.stats, { '2024-03-15': dailyStats('2024-03-15', 1, 3) });
 
     await updateStats(Rating.Good, true);
 
-    expect(await storage.getItem(STORAGE_KEYS.stats)).toEqual({ '2024-03-14': dailyStats('2024-03-14', 2, 3) });
+    expect(await storage.getItem(STORAGE_KEYS.stats)).toEqual({ '2024-03-15': dailyStats('2024-03-15', 2, 3) });
   });
 });

--- a/services/__tests__/settings.test.ts
+++ b/services/__tests__/settings.test.ts
@@ -32,10 +32,9 @@ describe('settings service', () => {
     expect((await getSettings()).language).toBe('pl');
   });
 
-  it('persists and exports all seven settings', async () => {
+  it('persists and exports all settings', async () => {
     const settings = buildSettings({
       maxNewCardsPerDay: 0,
-      dayStartHour: 0,
       theme: 'dark',
       resetEditorOnEveryProblem: true,
       resetEditorOnDueReview: true,
@@ -49,7 +48,6 @@ describe('settings service', () => {
 
   it.each([
     ['maxNewCardsPerDay', -1],
-    ['dayStartHour', 24],
     ['theme', 'blue'],
     ['resetEditorOnEveryProblem', 1],
     ['resetEditorOnDueReview', 'true'],
@@ -73,8 +71,8 @@ describe('settings service', () => {
     expect(setItem).not.toHaveBeenCalled();
     expect(await exportSettings()).toEqual({ theme: 'dark' });
 
-    await updateSettings({ theme: undefined, dayStartHour: 5 });
-    expect(await exportSettings()).toEqual({ theme: 'dark', dayStartHour: 5 });
+    await updateSettings({ theme: undefined, maxNewCardsPerDay: 5 });
+    expect(await exportSettings()).toEqual({ theme: 'dark', maxNewCardsPerDay: 5 });
   });
 
   it('validates and persists partial changes', async () => {
@@ -94,11 +92,6 @@ describe('settings service', () => {
     [
       { maxNewCardsPerDay: SETTINGS_CONSTRAINTS.maxNewCardsPerDay.max + 1 },
       `Max new cards per day must be between ${SETTINGS_CONSTRAINTS.maxNewCardsPerDay.min} and ${SETTINGS_CONSTRAINTS.maxNewCardsPerDay.max}`,
-    ],
-    [{ dayStartHour: 1.5 }, 'Day start hour must be a whole number'],
-    [
-      { dayStartHour: SETTINGS_CONSTRAINTS.dayStartHour.max + 1 },
-      `Day start hour must be between ${SETTINGS_CONSTRAINTS.dayStartHour.min} and ${SETTINGS_CONSTRAINTS.dayStartHour.max}`,
     ],
     [{ theme: 'blue' }, 'Theme must be "system", "light", or "dark"'],
     [{ resetEditorOnEveryProblem: 1 }, 'Reset editor on every problem must be a boolean'],
@@ -147,7 +140,6 @@ describe('settings service', () => {
     const pending = readSettings();
     expect(getItem.mock.calls.map(([key]) => key)).toEqual([
       STORAGE_KEYS.maxNewCardsPerDay,
-      STORAGE_KEYS.dayStartHour,
       STORAGE_KEYS.theme,
       STORAGE_KEYS.resetEditorOnEveryProblem,
       STORAGE_KEYS.resetEditorOnDueReview,
@@ -211,7 +203,6 @@ describe('settings service', () => {
     const pending = resetSettings();
     expect(removeItem.mock.calls.map(([key]) => key)).toEqual([
       STORAGE_KEYS.maxNewCardsPerDay,
-      STORAGE_KEYS.dayStartHour,
       STORAGE_KEYS.theme,
       STORAGE_KEYS.resetEditorOnEveryProblem,
       STORAGE_KEYS.resetEditorOnDueReview,

--- a/services/__tests__/stats.test.ts
+++ b/services/__tests__/stats.test.ts
@@ -510,8 +510,8 @@ describe('Stats management', () => {
       await expect(getNextNDaysStats(0)).resolves.toEqual([]);
     });
 
-    it('should respect the configured day start hour', async () => {
-      await storage.setItem(STORAGE_KEYS.dayStartHour, 4);
+    it('ignores a legacy day start hour when bucketing upcoming reviews', async () => {
+      await storage.setItem('sync:leetsrs:dayStartHour', 4);
       await addCard(buildProblem({ slug: 'problem-1' }));
       const cards = (await storage.getItem(STORAGE_KEYS.cards)) as Record<string, Card>;
 
@@ -521,8 +521,8 @@ describe('Stats management', () => {
       const stats = await getNextNDaysStats(2);
 
       expect(stats).toEqual([
-        { date: '2024-03-15', count: 1 },
-        { date: '2024-03-16', count: 0 },
+        { date: '2024-03-15', count: 0 },
+        { date: '2024-03-16', count: 1 },
       ]);
     });
 

--- a/services/cards.ts
+++ b/services/cards.ts
@@ -1,6 +1,6 @@
 import { createEmptyCard, FSRS, State as FsrsState, generatorParameters } from 'ts-fsrs';
 import type { Card, ProblemDescriptor, RateCardInput } from '@/domain/cards';
-import { buildReviewQueue, calculateDelayedDueDate, isDueByDate as calculateIsDueByDate } from '@/domain/review';
+import { buildReviewQueue, calculateDelayedDueDate, isDue } from '@/domain/review';
 import { getAllCards, saveCards } from '@/infrastructure/storage/cards';
 
 import { deleteNote } from '@/infrastructure/storage/notes';
@@ -98,19 +98,15 @@ export async function rateCard(input: RateCardInput): Promise<{ card: Card; shou
   };
   await saveCards(cards);
   await updateStats(rating, isNewCard);
-  const settings = await getSettings();
-  const shouldRequeue = isDueByDate(card, now, settings.dayStartHour);
+  const shouldRequeue = isDue(card, now);
   return { card, shouldRequeue };
-}
-
-export function isDueByDate(card: Card, referenceDate: Date = new Date(), dayStartHour: number = 0): boolean {
-  return calculateIsDueByDate(card, referenceDate, dayStartHour);
 }
 
 export async function getReviewQueue(): Promise<Card[]> {
   const allCards = await getAllCards();
   const settings = await getSettings();
-  const dueCards = allCards.filter((card) => !card.paused && isDueByDate(card, new Date(), settings.dayStartHour));
+  const now = new Date();
+  const dueCards = allCards.filter((card) => !card.paused && isDue(card, now));
   const todayStats = await getTodayStats();
   const newCardsCompletedToday = todayStats?.newCards ?? 0;
   return buildReviewQueue(dueCards, settings.maxNewCardsPerDay, newCardsCompletedToday);

--- a/services/editor-reset.ts
+++ b/services/editor-reset.ts
@@ -1,5 +1,5 @@
 import type { LeetcodeDomain } from '@/domain/cards';
-import { isDueByDate } from '@/domain/review';
+import { isDue } from '@/domain/review';
 import { getAllCards } from '@/infrastructure/storage/cards';
 import { getSettings } from './settings';
 
@@ -17,5 +17,5 @@ export async function shouldResetEditor(slug: string, domain: LeetcodeDomain): P
     return false;
   }
 
-  return isDueByDate(card, new Date(), settings.dayStartHour);
+  return isDue(card, new Date());
 }

--- a/services/stats.ts
+++ b/services/stats.ts
@@ -1,5 +1,5 @@
 import type { State as FsrsState, Grade } from 'ts-fsrs';
-import { formatLocalDate } from '@/domain/calendar';
+import { addLocalDays, formatLocalDate } from '@/domain/calendar';
 import {
   calculateHistoryStats,
   calculateUpcomingStats,
@@ -11,27 +11,22 @@ import {
 } from '@/domain/statistics';
 import { getAllCards } from '@/infrastructure/storage/cards';
 import { getStats, getStatsForDate, saveStats } from '@/infrastructure/storage/stats';
-import { getSettings } from './settings';
 
 export async function getTodayKey(): Promise<string> {
-  const now = new Date();
-  const settings = await getSettings();
-  return formatLocalDate(now, settings.dayStartHour);
+  return formatLocalDate(new Date());
 }
 
 export async function getYesterdayKey(): Promise<string> {
-  const yesterday = new Date();
-  yesterday.setDate(yesterday.getDate() - 1);
-  const settings = await getSettings();
-  return formatLocalDate(yesterday, settings.dayStartHour);
+  return formatLocalDate(addLocalDays(new Date(), -1));
 }
 
 export async function updateStats(grade: Grade, isNewCard: boolean = false): Promise<void> {
   const stats = await getStats();
-  const todayKey = await getTodayKey();
+  const now = new Date();
+  const todayKey = formatLocalDate(now);
 
   if (!stats[todayKey]) {
-    const yesterdayKey = await getYesterdayKey();
+    const yesterdayKey = formatLocalDate(addLocalDays(now, -1));
     const yesterdayStats = stats[yesterdayKey];
     stats[todayKey] = createDailyStats(todayKey, yesterdayStats);
   }
@@ -55,13 +50,11 @@ export async function getCardStateStats(): Promise<Record<FsrsState, number>> {
 export async function getLastNDaysStats(days: number): Promise<DailyStats[]> {
   const stats = await getStats();
   const today = new Date();
-  const { dayStartHour } = await getSettings();
-  return calculateHistoryStats(stats, days, today, dayStartHour);
+  return calculateHistoryStats(stats, days, today);
 }
 
 export async function getNextNDaysStats(days: number): Promise<UpcomingReviewStats[]> {
   const cards = await getAllCards();
   const today = new Date();
-  const { dayStartHour } = await getSettings();
-  return calculateUpcomingStats(cards, days, today, dayStartHour);
+  return calculateUpcomingStats(cards, days, today);
 }

--- a/test/utils/settings-mocks.ts
+++ b/test/utils/settings-mocks.ts
@@ -3,7 +3,6 @@ import type { Settings } from '@/domain/settings';
 export function buildSettings(overrides: Partial<Settings> = {}): Settings {
   return {
     maxNewCardsPerDay: 3,
-    dayStartHour: 0,
     theme: 'system',
     resetEditorOnEveryProblem: false,
     resetEditorOnDueReview: false,


### PR DESCRIPTION
- Use exact FSRS due times for queue eligibility, requeue decisions, and editor reset; refresh the visible popup queue every 15 seconds.
- Use local midnight for daily limits, statistics, streaks, and chart buckets; remove configurable day start with migration and legacy-import support.
- Remove the mandatory PR screenshot instruction from `AGENTS.md`.
- Verified `npm run check` (970 tests), production build, and calendar tests in Los Angeles and Kolkata timezones.

Closes #126
