### PR TITLE
test: consolidate overlapping service and UI coverage

### DIFF
--- a/entrypoints/popup/queries/__tests__/cards.test.tsx
+++ b/entrypoints/popup/queries/__tests__/cards.test.tsx
@@ -3,7 +3,7 @@
  */
 
 import { act, renderHook, waitFor } from '@testing-library/react';
-import { type Grade, Rating, State } from 'ts-fsrs';
+import { Rating, State } from 'ts-fsrs';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { fakeBrowser } from 'wxt/testing/fake-browser';
 import type { Card } from '@/domain/cards';
@@ -40,57 +40,6 @@ describe('useCardsQuery', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
     expect(sendMessage).toHaveBeenCalledWith('getAllCards');
-  });
-});
-
-describe('useRateCardMutation', () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-    vi.mocked(sendMessage).mockResolvedValue(undefined);
-  });
-
-  it('should call sendMessage with correct parameters when mutate is called', async () => {
-    const mockCard = {
-      slug: 'two-sum',
-      name: 'Two Sum',
-      rating: Rating.Good as Grade,
-      leetcodeId: '1',
-      difficulty: 'Easy' as const,
-      domain: 'leetcode.com' as const,
-    };
-
-    const mockResponse: Card = {
-      id: 'test-id',
-      slug: mockCard.slug,
-      name: mockCard.name,
-      leetcodeId: mockCard.leetcodeId,
-      difficulty: mockCard.difficulty,
-      domain: 'leetcode.com',
-      createdAt: Date.now(),
-      fsrs: createMockCard(State.New).fsrs,
-      paused: false,
-    };
-
-    vi.mocked(sendMessage).mockResolvedValue(mockResponse);
-
-    const { result } = renderHook(() => useRateCardMutation(), {
-      wrapper: createTestWrapper().wrapper,
-    });
-
-    result.current.mutate(mockCard);
-
-    await waitFor(() => {
-      expect(sendMessage).toHaveBeenCalledWith('rateCard', {
-        input: {
-          slug: 'two-sum',
-          name: 'Two Sum',
-          rating: Rating.Good,
-          leetcodeId: '1',
-          difficulty: 'Easy',
-          domain: 'leetcode.com',
-        },
-      });
-    });
   });
 });
 
@@ -247,6 +196,8 @@ describe('card queries through JSON messaging and background handlers', () => {
 
     await act(async () => {
       const { card } = await result.current.mutateAsync({ ...buildProblem(), rating: Rating.Good });
+      expect(sendMessage).toHaveBeenCalledWith('rateCard', { input: { ...buildProblem(), rating: Rating.Good } });
+      expect(card).toMatchObject(buildProblem());
       expect(card.createdAt).toEqual(expect.any(Number));
       expect(card.fsrs.due).toEqual(expect.any(Number));
       expect(card.fsrs.last_review).toEqual(expect.any(Number));

--- a/entrypoints/popup/queries/__tests__/notes.test.tsx
+++ b/entrypoints/popup/queries/__tests__/notes.test.tsx
@@ -17,30 +17,9 @@ describe('useSaveNoteMutation', () => {
     vi.clearAllMocks();
   });
 
-  it.each([
-    ['ordinary text', 'test-card-123', 'This is my solution using two pointers approach'],
-    ['empty text', 'test-card-456', ''],
-    ['maximum length text', 'test-card-789', 'a'.repeat(500)],
-  ])('sends %s unchanged', async (_case, cardId, noteText) => {
-    vi.mocked(sendMessage).mockResolvedValue(undefined);
-
-    const { result } = renderHook(() => useSaveNoteMutation(cardId), {
-      wrapper: createTestWrapper().wrapper,
-    });
-
-    result.current.mutate(noteText);
-
-    await waitFor(() => {
-      expect(sendMessage).toHaveBeenCalledWith('saveNote', {
-        cardId,
-        text: noteText,
-      });
-    });
-  });
-
-  it('should invalidate note query cache on successful save', async () => {
+  it('sends note edits and invalidates the saved card note', async () => {
     const cardId = 'test-card-cache';
-    const noteText = 'Test note for cache invalidation';
+    const noteText = '  Solution with whitespace  ';
     const { wrapper, queryClient } = createTestWrapper();
     const invalidateQueriesSpy = vi.spyOn(queryClient, 'invalidateQueries');
 
@@ -56,6 +35,7 @@ describe('useSaveNoteMutation', () => {
       expect(result.current.isSuccess).toBe(true);
     });
 
+    expect(sendMessage).toHaveBeenCalledWith('saveNote', { cardId, text: noteText });
     expect(invalidateQueriesSpy).toHaveBeenCalledWith({
       queryKey: noteQueryKeys.detail(cardId),
     });
@@ -69,25 +49,7 @@ describe('useDeleteNoteMutation', () => {
     vi.clearAllMocks();
   });
 
-  it('should call sendMessage with correct parameters when mutate is called', async () => {
-    const cardId = 'test-card-123';
-
-    vi.mocked(sendMessage).mockResolvedValue(undefined);
-
-    const { result } = renderHook(() => useDeleteNoteMutation(cardId), {
-      wrapper: createTestWrapper().wrapper,
-    });
-
-    result.current.mutate();
-
-    await waitFor(() => {
-      expect(sendMessage).toHaveBeenCalledWith('deleteNote', {
-        cardId: 'test-card-123',
-      });
-    });
-  });
-
-  it('should invalidate note query cache on successful delete', async () => {
+  it('sends deletion and invalidates the deleted card note', async () => {
     const cardId = 'test-card-delete';
     const { wrapper, queryClient } = createTestWrapper();
     const invalidateQueriesSpy = vi.spyOn(queryClient, 'invalidateQueries');
@@ -104,6 +66,7 @@ describe('useDeleteNoteMutation', () => {
       expect(result.current.isSuccess).toBe(true);
     });
 
+    expect(sendMessage).toHaveBeenCalledWith('deleteNote', { cardId });
     expect(invalidateQueriesSpy).toHaveBeenCalledWith({
       queryKey: noteQueryKeys.detail(cardId),
     });

--- a/entrypoints/popup/views/home/__tests__/ActionsSection.test.tsx
+++ b/entrypoints/popup/views/home/__tests__/ActionsSection.test.tsx
@@ -23,64 +23,20 @@ describe('ActionsSection', () => {
   };
 
   describe('Expand/Collapse', () => {
-    it('should render with collapsed state by default', () => {
-      render(<ActionsSection {...defaultProps} />);
-
-      expect(screen.getByText('Actions')).toBeInTheDocument();
-      expect(screen.getByText('▶')).toBeInTheDocument();
-      expect(screen.queryByText('1 Day')).not.toBeInTheDocument();
-      expect(screen.queryByText('Delete Card')).not.toBeInTheDocument();
-    });
-
-    it('should expand when header is clicked', () => {
-      render(<ActionsSection {...defaultProps} />);
-
-      const expandButton = screen.getByRole('button', { name: /Actions/i });
-      fireEvent.click(expandButton);
-
-      expect(screen.getByText('1 Day')).toBeInTheDocument();
-      expect(screen.getByText('5 Days')).toBeInTheDocument();
-      expect(screen.getByText('Pause')).toBeInTheDocument();
-      expect(screen.getByText('Delete Card')).toBeInTheDocument();
-    });
-
-    it('should collapse when header is clicked again', () => {
-      render(<ActionsSection {...defaultProps} />);
-
-      const expandButton = screen.getByRole('button', { name: /Actions/i });
-
-      // Expand
-      fireEvent.click(expandButton);
-      expect(screen.getByText('1 Day')).toBeInTheDocument();
-
-      // Collapse
-      fireEvent.click(expandButton);
-      expect(screen.queryByText('1 Day')).not.toBeInTheDocument();
-    });
-
-    it('should rotate arrow icon when expanded', () => {
-      render(<ActionsSection {...defaultProps} />);
-
-      const arrow = screen.getByText('▶');
-      expect(arrow).not.toHaveClass('rotate-90');
-
-      const expandButton = screen.getByRole('button', { name: /Actions/i });
-      fireEvent.click(expandButton);
-
-      expect(arrow).toHaveClass('rotate-90');
-    });
-
-    it('should set aria-expanded attribute correctly', () => {
+    it('expands and collapses the available actions with accessible state', () => {
       render(<ActionsSection {...defaultProps} />);
 
       const expandButton = screen.getByRole('button', { name: /Actions/i });
       expect(expandButton).toHaveAttribute('aria-expanded', 'false');
+      expect(screen.queryByRole('button', { name: 'Delete Card' })).not.toBeInTheDocument();
 
       fireEvent.click(expandButton);
       expect(expandButton).toHaveAttribute('aria-expanded', 'true');
+      expect(screen.getByRole('button', { name: 'Delete Card' })).toBeInTheDocument();
 
       fireEvent.click(expandButton);
       expect(expandButton).toHaveAttribute('aria-expanded', 'false');
+      expect(screen.queryByRole('button', { name: 'Delete Card' })).not.toBeInTheDocument();
     });
   });
 
@@ -96,17 +52,6 @@ describe('ActionsSection', () => {
 
       expect(mockOnDelay).toHaveBeenCalledWith(days);
       expect(mockOnDelay).toHaveBeenCalledTimes(1);
-    });
-
-    it('should display delay card section with both delay options', () => {
-      render(<ActionsSection {...defaultProps} />);
-
-      const expandButton = screen.getByRole('button', { name: /Actions/i });
-      fireEvent.click(expandButton);
-
-      expect(screen.getByRole('button', { name: /1 Day/i })).toBeInTheDocument();
-      expect(screen.getByRole('button', { name: /5 Days/i })).toBeInTheDocument();
-      expect(screen.getByRole('button', { name: /Pause/i })).toBeInTheDocument();
     });
   });
 
@@ -125,39 +70,7 @@ describe('ActionsSection', () => {
   });
 
   describe('Delete Functionality', () => {
-    it('should show confirmation when delete button is first clicked', () => {
-      render(<ActionsSection {...defaultProps} />);
-
-      // Expand first
-      const expandButton = screen.getByRole('button', { name: /Actions/i });
-      fireEvent.click(expandButton);
-
-      const deleteButton = screen.getByRole('button', { name: 'Delete Card' });
-      fireEvent.click(deleteButton);
-
-      expect(screen.getByRole('button', { name: 'Confirm Delete?' })).toBeInTheDocument();
-      expect(mockOnDelete).not.toHaveBeenCalled();
-    });
-
-    it('should call onDelete when confirmation is clicked', () => {
-      render(<ActionsSection {...defaultProps} />);
-
-      // Expand first
-      const expandButton = screen.getByRole('button', { name: /Actions/i });
-      fireEvent.click(expandButton);
-
-      // First click - show confirmation
-      const deleteButton = screen.getByRole('button', { name: 'Delete Card' });
-      fireEvent.click(deleteButton);
-
-      // Second click - confirm deletion
-      const confirmButton = screen.getByRole('button', { name: 'Confirm Delete?' });
-      fireEvent.click(confirmButton);
-
-      expect(mockOnDelete).toHaveBeenCalledTimes(1);
-    });
-
-    it('should reset confirmation immediately after delete', () => {
+    it('deletes only after confirmation and resets the confirmation afterward', () => {
       render(<ActionsSection {...defaultProps} />);
 
       // Expand first
@@ -167,55 +80,17 @@ describe('ActionsSection', () => {
       // First click - show confirmation
       let deleteButton = screen.getByRole('button', { name: 'Delete Card' });
       fireEvent.click(deleteButton);
+      expect(mockOnDelete).not.toHaveBeenCalled();
 
       // Second click - confirm deletion
       const confirmButton = screen.getByRole('button', { name: 'Confirm Delete?' });
       fireEvent.click(confirmButton);
+      expect(mockOnDelete).toHaveBeenCalledTimes(1);
 
       // Should reset to initial state immediately
       deleteButton = screen.getByRole('button', { name: 'Delete Card' });
       expect(deleteButton).toBeInTheDocument();
       expect(screen.queryByRole('button', { name: 'Confirm Delete?' })).not.toBeInTheDocument();
-    });
-  });
-
-  describe('Visual Styling', () => {
-    it('should apply correct styles to container', () => {
-      render(<ActionsSection {...defaultProps} />);
-
-      const container = screen.getByText('Actions').closest('.border');
-      expect(container).toHaveClass('border', 'rounded-lg', 'overflow-hidden');
-    });
-
-    it('should apply bounce animation class to action buttons', () => {
-      render(<ActionsSection {...defaultProps} />);
-
-      const expandButton = screen.getByRole('button', { name: /Actions/i });
-      fireEvent.click(expandButton);
-
-      const delay1Button = screen.getByRole('button', { name: /1 Day/i });
-      const delay5Button = screen.getByRole('button', { name: /5 Days/i });
-      const pauseButton = screen.getByRole('button', { name: /Pause/i });
-      const deleteButton = screen.getByRole('button', { name: 'Delete Card' });
-
-      // Check for bounceButton class effects (from imported styles)
-      expect(delay1Button.className).toMatch(/active:translate-y-\[1px\]/);
-      expect(delay5Button.className).toMatch(/active:translate-y-\[1px\]/);
-      expect(pauseButton.className).toMatch(/active:translate-y-\[1px\]/);
-      expect(deleteButton.className).toMatch(/active:translate-y-\[1px\]/);
-    });
-
-    it('should have proper spacing between sections', () => {
-      render(<ActionsSection {...defaultProps} />);
-
-      const expandButton = screen.getByRole('button', { name: /Actions/i });
-      fireEvent.click(expandButton);
-
-      const contentDiv = screen.getByText('Delete Card').closest('div')?.parentElement;
-      expect(contentDiv).toHaveClass('mt-3', 'space-y-3');
-
-      const deleteSection = screen.getByRole('button', { name: 'Delete Card' }).parentElement;
-      expect(deleteSection).toHaveClass('pt-2', 'border-t');
     });
   });
 
@@ -230,37 +105,6 @@ describe('ActionsSection', () => {
       expect(screen.getByRole('button', { name: /5 Days/i })).toBeDisabled();
       expect(screen.getByRole('button', { name: /Pause/i })).toBeDisabled();
       expect(screen.getByRole('button', { name: 'Delete Card' })).toBeDisabled();
-    });
-
-    it('should handle rapid clicks on expand button', () => {
-      render(<ActionsSection {...defaultProps} />);
-
-      const expandButton = screen.getByRole('button', { name: /Actions/i });
-
-      // Rapid clicks
-      fireEvent.click(expandButton);
-      fireEvent.click(expandButton);
-      fireEvent.click(expandButton);
-
-      // Should end up expanded (odd number of clicks)
-      expect(screen.getByText('1 Day')).toBeInTheDocument();
-    });
-
-    it('should handle rapid clicks on delay buttons', () => {
-      render(<ActionsSection {...defaultProps} />);
-
-      const expandButton = screen.getByRole('button', { name: /Actions/i });
-      fireEvent.click(expandButton);
-
-      const delay1Button = screen.getByRole('button', { name: /1 Day/i });
-
-      // Rapid clicks
-      fireEvent.click(delay1Button);
-      fireEvent.click(delay1Button);
-      fireEvent.click(delay1Button);
-
-      expect(mockOnDelay).toHaveBeenCalledTimes(3);
-      expect(mockOnDelay).toHaveBeenCalledWith(1);
     });
   });
 });

--- a/entrypoints/popup/views/home/__tests__/ReviewCard.test.tsx
+++ b/entrypoints/popup/views/home/__tests__/ReviewCard.test.tsx
@@ -2,7 +2,7 @@
  * @vitest-environment happy-dom
  */
 
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { Rating } from 'ts-fsrs';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { Card } from '@/domain/cards';
@@ -58,69 +58,14 @@ describe('ReviewCard', () => {
       }
     );
 
-    it('should render the problem ID', () => {
+    it('renders the problem identity and its external LeetCode link', () => {
       renderWithProviders();
       expect(screen.getByText('#1')).toBeInTheDocument();
-    });
-
-    it('should render the problem name', () => {
-      renderWithProviders();
       expect(screen.getByText('Two Sum')).toBeInTheDocument();
-    });
-
-    it('should render the external link to LeetCode problem', () => {
-      renderWithProviders();
       const link = screen.getByRole('link', { name: /LeetCode/i });
       expect(link).toHaveAttribute('href', 'https://leetcode.com/problems/two-sum/description/');
       expect(link).toHaveAttribute('target', '_blank');
       expect(link).toHaveAttribute('rel', 'noopener noreferrer');
-    });
-  });
-
-  describe('Interactions', () => {
-    it.each([
-      ['Again', Rating.Again],
-      ['Hard', Rating.Hard],
-      ['Good', Rating.Good],
-      ['Easy', Rating.Easy],
-    ] as const)('should call onRate with the %s rating', async (label, rating) => {
-      renderWithProviders();
-      fireEvent.click(screen.getByRole('button', { name: label }));
-
-      await waitFor(() => {
-        expect(mockOnRate).toHaveBeenCalledWith(rating);
-      });
-    });
-
-    it('should only call onRate once per button click', async () => {
-      renderWithProviders();
-      const goodButton = screen.getByRole('button', { name: 'Good' });
-
-      fireEvent.click(goodButton);
-
-      await waitFor(() => {
-        expect(mockOnRate).toHaveBeenCalledTimes(1);
-      });
-    });
-  });
-
-  describe('Styling', () => {
-    it('should have cursor pointer on rating buttons', () => {
-      renderWithProviders();
-      const buttons = screen.getAllByRole('button');
-
-      buttons.forEach((button) => {
-        expect(button).toHaveClass('cursor-pointer');
-      });
-    });
-
-    it('should have consistent button width', () => {
-      renderWithProviders();
-      const buttons = screen.getAllByRole('button');
-
-      buttons.forEach((button) => {
-        expect(button).toHaveClass('w-20');
-      });
     });
   });
 

--- a/entrypoints/popup/views/home/__tests__/ReviewQueue.test.tsx
+++ b/entrypoints/popup/views/home/__tests__/ReviewQueue.test.tsx
@@ -136,6 +136,8 @@ describe('ReviewQueue', () => {
       await waitFor(() => {
         expect(screen.getByText('No cards to review!')).toBeInTheDocument();
         expect(screen.getByText(/Add problems on LeetCode/)).toBeInTheDocument();
+        expect(screen.queryByTestId('review-card')).not.toBeInTheDocument();
+        expect(screen.queryByTestId('delete-button')).not.toBeInTheDocument();
       });
     });
   });
@@ -149,20 +151,9 @@ describe('ReviewQueue', () => {
         expect(screen.getByText('Two Sum')).toBeInTheDocument();
         expect(screen.getByTestId('notes-section')).toBeInTheDocument();
         expect(screen.getByText('Notes for 1')).toBeInTheDocument();
+        expect(screen.queryByText('Add Two Numbers')).not.toBeInTheDocument();
+        expect(screen.queryByText('Longest Substring')).not.toBeInTheDocument();
       });
-    });
-
-    it('should only display one card at a time', async () => {
-      render(<ReviewQueue />, { wrapper });
-
-      // Wait for state to initialize
-      await waitFor(() => {
-        expect(screen.getByText('Two Sum')).toBeInTheDocument();
-      });
-
-      // Should not display other cards
-      expect(screen.queryByText('Add Two Numbers')).not.toBeInTheDocument();
-      expect(screen.queryByText('Longest Substring')).not.toBeInTheDocument();
     });
   });
 
@@ -355,21 +346,6 @@ describe('ReviewQueue', () => {
 
       consoleSpy.mockRestore();
     });
-
-    it('should not crash when queue is empty and handleRating is called', async () => {
-      seedQueue([]);
-
-      render(<ReviewQueue />, { wrapper });
-
-      // Wait for empty state
-      await waitFor(() => {
-        expect(screen.getByText('No cards to review!')).toBeInTheDocument();
-      });
-
-      // Even though there are no buttons to click, we can test the function doesn't crash
-      // by checking that mutateAsync is never called
-      expect(mockMutateAsync).not.toHaveBeenCalled();
-    });
   });
 
   describe('Card Deletion', () => {
@@ -461,23 +437,6 @@ describe('ReviewQueue', () => {
         expect(goodButton).toBeDisabled();
         expect(easyButton).toBeDisabled();
       });
-    });
-
-    it('should not crash when queue is empty and handleDelete is called', async () => {
-      seedQueue([]);
-
-      render(<ReviewQueue />, { wrapper });
-
-      // Wait for empty state
-      await waitFor(() => {
-        expect(screen.getByText('No cards to review!')).toBeInTheDocument();
-      });
-
-      // Delete button shouldn't be visible when queue is empty
-      expect(screen.queryByTestId('delete-button')).not.toBeInTheDocument();
-
-      // Verify remove mutation is never called
-      expect(mockRemoveMutateAsync).not.toHaveBeenCalled();
     });
 
     it('should handle rapid delete clicks correctly', async () => {
@@ -648,40 +607,6 @@ describe('ReviewQueue', () => {
 
       const cardContainer = screen.getByTestId('review-card').parentElement;
       await waitFor(() => expect(cardContainer).toHaveClass(animationClass));
-    });
-  });
-
-  describe('Component Integration', () => {
-    it('should pass correct props to ReviewCard', async () => {
-      render(<ReviewQueue />, { wrapper });
-
-      // Wait for initial render
-      await waitFor(() => {
-        const reviewCard = screen.getByTestId('review-card');
-        expect(reviewCard).toBeInTheDocument();
-        expect(screen.getByText('Two Sum')).toBeInTheDocument();
-      });
-    });
-
-    it('should pass correct callbacks to ActionsSection', async () => {
-      render(<ReviewQueue />, { wrapper });
-
-      // Wait for initial render
-      await waitFor(() => {
-        expect(screen.getByTestId('actions-section')).toBeInTheDocument();
-        expect(screen.getByTestId('delete-button')).toBeInTheDocument();
-        expect(screen.getByTestId('delay-1-button')).toBeInTheDocument();
-        expect(screen.getByTestId('delay-5-button')).toBeInTheDocument();
-      });
-    });
-
-    it('should pass correct cardId to NotesSection', async () => {
-      render(<ReviewQueue />, { wrapper });
-
-      // Wait for initial render
-      await waitFor(() => {
-        expect(screen.getByText('Notes for 1')).toBeInTheDocument();
-      });
     });
   });
 });

--- a/infrastructure/storage/__tests__/notes.test.ts
+++ b/infrastructure/storage/__tests__/notes.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it } from 'vitest';
 import { fakeBrowser } from 'wxt/testing/fake-browser';
 import { storage } from 'wxt/utils/storage';
 import { ZodError } from 'zod';
-import { NOTES_MAX_LENGTH, type Note } from '@/domain/notes';
+import { NOTES_MAX_LENGTH } from '@/domain/notes';
 import { getNoteStorageKey } from '@/infrastructure/storage/storage-keys';
 import { deleteNote, getNote, saveNote } from '../notes';
 
@@ -10,45 +10,6 @@ describe('Note persistence', () => {
   beforeEach(() => {
     // Reset the fake browser state before each test
     fakeBrowser.reset();
-  });
-
-  describe('getNote', () => {
-    it('should return null when note does not exist', async () => {
-      const note = await getNote('non-existent-card');
-      expect(note).toBeNull();
-    });
-
-    it('should return the note when it exists', async () => {
-      const cardId = 'test-card-1';
-      const key = getNoteStorageKey(cardId);
-      const testNote: Note = {
-        text: 'This is a test note',
-      };
-
-      // Manually store a note
-      await storage.setItem(key, testNote);
-
-      // Retrieve the note
-      const retrievedNote = await getNote(cardId);
-      expect(retrievedNote).toEqual(testNote);
-      expect(retrievedNote?.text).toBe('This is a test note');
-    });
-
-    it('should handle multiple different notes correctly', async () => {
-      const cardId1 = 'card-1';
-      const cardId2 = 'card-2';
-      const note1: Note = { text: 'Note for card 1' };
-      const note2: Note = { text: 'Note for card 2' };
-
-      await storage.setItem(getNoteStorageKey(cardId1), note1);
-      await storage.setItem(getNoteStorageKey(cardId2), note2);
-
-      const retrieved1 = await getNote(cardId1);
-      const retrieved2 = await getNote(cardId2);
-
-      expect(retrieved1?.text).toBe('Note for card 1');
-      expect(retrieved2?.text).toBe('Note for card 2');
-    });
   });
 
   it.each([{ text: 'a'.repeat(NOTES_MAX_LENGTH + 1) }, { text: 42 }, {}, [], false])(
@@ -73,114 +34,23 @@ describe('Note persistence', () => {
     expect(await getNote('card')).toEqual(existing ? { text } : null);
   });
 
-  describe('saveNote', () => {
-    it('should save a new note', async () => {
-      const cardId = 'test-card-2';
-      const noteText = 'This is my solution approach';
+  it('round-trips notes independently through creation, replacement, and deletion', async () => {
+    expect(await getNote('first-card')).toBeNull();
+    await saveNote('first-card', 'Original solution');
+    await saveNote('second-card', 'Other solution');
+    expect(await getNote('first-card')).toEqual({ text: 'Original solution' });
+    expect(await getNote('second-card')).toEqual({ text: 'Other solution' });
 
-      await saveNote(cardId, noteText);
+    await saveNote('first-card', 'Revised solution');
+    expect(await getNote('first-card')).toEqual({ text: 'Revised solution' });
+    expect(await getNote('second-card')).toEqual({ text: 'Other solution' });
 
-      // Verify the note was stored
-      const key = getNoteStorageKey(cardId);
-      const storedNote = await storage.getItem<Note>(key);
+    await deleteNote('first-card');
+    expect(await getNote('first-card')).toBeNull();
+    expect(await storage.getItem(getNoteStorageKey('first-card'))).toBeNull();
+    expect(await getNote('second-card')).toEqual({ text: 'Other solution' });
 
-      expect(storedNote).toBeDefined();
-      expect(storedNote?.text).toBe(noteText);
-    });
-
-    it('should overwrite an existing note', async () => {
-      const cardId = 'test-card-3';
-      const originalText = 'Original note';
-      const updatedText = 'Updated note with new solution';
-
-      // Save original note
-      await saveNote(cardId, originalText);
-
-      // Verify original was saved
-      let note = await getNote(cardId);
-      expect(note?.text).toBe(originalText);
-
-      // Update the note
-      await saveNote(cardId, updatedText);
-
-      // Verify it was overwritten
-      note = await getNote(cardId);
-      expect(note?.text).toBe(updatedText);
-    });
-
-    it('should store notes with unique keys per card', async () => {
-      const cardId1 = 'unique-1';
-      const cardId2 = 'unique-2';
-
-      await saveNote(cardId1, 'Note 1');
-      await saveNote(cardId2, 'Note 2');
-
-      // Verify both notes exist independently
-      const key1 = getNoteStorageKey(cardId1);
-      const key2 = getNoteStorageKey(cardId2);
-
-      const stored1 = await storage.getItem<Note>(key1);
-      const stored2 = await storage.getItem<Note>(key2);
-
-      expect(stored1?.text).toBe('Note 1');
-      expect(stored2?.text).toBe('Note 2');
-      expect(key1).not.toBe(key2);
-    });
-  });
-
-  describe('deleteNote', () => {
-    it('should delete an existing note', async () => {
-      const cardId = 'test-card-delete';
-      const noteText = 'Note to be deleted';
-
-      // First save a note
-      await saveNote(cardId, noteText);
-
-      // Verify it exists
-      let note = await getNote(cardId);
-      expect(note?.text).toBe(noteText);
-
-      // Delete the note
-      await deleteNote(cardId);
-
-      // Verify it's gone
-      note = await getNote(cardId);
-      expect(note).toBeNull();
-
-      // Also verify directly in storage
-      const key = getNoteStorageKey(cardId);
-      const storedNote = await storage.getItem<Note>(key);
-      expect(storedNote).toBeNull();
-    });
-
-    it('should handle deleting non-existent note gracefully', async () => {
-      const cardId = 'non-existent';
-
-      // Should not throw
-      await expect(deleteNote(cardId)).resolves.toBeUndefined();
-
-      // Verify nothing exists
-      const note = await getNote(cardId);
-      expect(note).toBeNull();
-    });
-
-    it('should only delete the specified note when multiple exist', async () => {
-      const cardId1 = 'card-to-delete';
-      const cardId2 = 'card-to-keep';
-
-      await saveNote(cardId1, 'Delete me');
-      await saveNote(cardId2, 'Keep me');
-
-      // Delete only the first note
-      await deleteNote(cardId1);
-
-      // Verify first is deleted
-      const deleted = await getNote(cardId1);
-      expect(deleted).toBeNull();
-
-      // Verify second still exists
-      const kept = await getNote(cardId2);
-      expect(kept?.text).toBe('Keep me');
-    });
+    await expect(deleteNote('first-card')).resolves.toBeUndefined();
+    expect(await getNote('second-card')).toEqual({ text: 'Other solution' });
   });
 });

--- a/infrastructure/storage/__tests__/storage-keys.test.ts
+++ b/infrastructure/storage/__tests__/storage-keys.test.ts
@@ -1,31 +1,8 @@
-import { describe, expect, it } from 'vitest';
-import { getNoteStorageKey, STORAGE_KEYS } from '../storage-keys';
+import { expect, it } from 'vitest';
+import { getNoteStorageKey } from '../storage-keys';
 
-describe('Storage Keys', () => {
-  describe('getNoteStorageKey', () => {
-    it('should handle UUID-style card IDs', () => {
-      const uuid = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890';
-      const key = getNoteStorageKey(uuid);
-
-      expect(key).toBe(`${STORAGE_KEYS.notes}:${uuid}`);
-    });
-
-    it('should generate consistent keys for the same card', () => {
-      const cardId = 'consistent-card';
-      const key1 = getNoteStorageKey(cardId);
-      const key2 = getNoteStorageKey(cardId);
-      const key3 = getNoteStorageKey(cardId);
-
-      expect(key1).toBe(key2);
-      expect(key2).toBe(key3);
-    });
-
-    it('should handle very long card IDs', () => {
-      const longId = 'a'.repeat(100);
-      const key = getNoteStorageKey(longId);
-
-      expect(key).toBe(`local:leetsrs:notes:${longId}`);
-      expect(key.length).toBe('local:leetsrs:notes:'.length + 100);
-    });
-  });
+it('preserves the persisted note key format', () => {
+  expect(getNoteStorageKey('a1b2c3d4-e5f6-7890-abcd-ef1234567890')).toBe(
+    'local:leetsrs:notes:a1b2c3d4-e5f6-7890-abcd-ef1234567890'
+  );
 });

--- a/infrastructure/storage/__tests__/translations.test.ts
+++ b/infrastructure/storage/__tests__/translations.test.ts
@@ -17,20 +17,6 @@ describe('stored translations', () => {
     fakeBrowser.reset();
   });
 
-  describe('getStoredTranslations', () => {
-    it('should return translations object', async () => {
-      const t = await getStoredTranslations();
-      expect(t).toBeDefined();
-      expect(t.app.name).toBe('LeetSRS');
-    });
-
-    it('should have all required translation keys', async () => {
-      const t = await getStoredTranslations();
-      expect(t.settings.gistSync.gistDescription).toBeDefined();
-      expect(typeof t.settings.gistSync.gistDescription).toBe('string');
-    });
-  });
-
   describe('stored language', () => {
     it.each(['de', 'en', 'hi', 'pl', 'zh-CN'] as const)('uses stored language %s', async (language) => {
       await storage.setItem(STORAGE_KEYS.language, language);

--- a/services/__tests__/cards.test.ts
+++ b/services/__tests__/cards.test.ts
@@ -1,4 +1,4 @@
-import { FSRS, State as FsrsState, generatorParameters, Rating } from 'ts-fsrs';
+import { State as FsrsState, Rating } from 'ts-fsrs';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { fakeBrowser } from 'wxt/testing/fake-browser';
 import { storage } from 'wxt/utils/storage';
@@ -12,7 +12,6 @@ import { buildSettings } from '@/test/utils/settings-mocks';
 import { addCard, delayCard, getAllCards, getReviewQueue, rateCard, removeCard, setPauseStatus } from '../cards';
 
 const { mockGetSettings } = vi.hoisted(() => ({ mockGetSettings: vi.fn() }));
-const MOCK_MAX_NEW_CARDS_PER_DAY = buildSettings().maxNewCardsPerDay;
 
 // Mock the notes module
 vi.mock('@/infrastructure/storage/notes', () => ({
@@ -84,42 +83,24 @@ describe('addCard', () => {
     fakeBrowser.reset();
   });
 
-  it('should create and store a new card', async () => {
-    const card = await addCard({
-      slug: 'two-sum',
-      name: 'Two Sum',
-      leetcodeId: '1',
-      difficulty: 'Easy',
-      domain: 'leetcode.com',
+  it('round-trips a new card with its creation time and numeric schedule', async () => {
+    const problem = buildProblem();
+    const before = Date.now();
+    const card = await addCard(problem);
+    const after = Date.now();
+
+    expect(card).toMatchObject({
+      ...problem,
+      id: expect.stringMatching(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i),
+      paused: false,
+      fsrs: { state: FsrsState.New, stability: 0, difficulty: 0, reps: 0, lapses: 0 },
     });
-
-    expect(card.id).toBeDefined();
-    expect(card.id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i);
-    expect(card.slug).toBe('two-sum');
-    expect(card.name).toBe('Two Sum');
-    expect(card.difficulty).toBe('Easy');
-    expect(card.domain).toBe('leetcode.com');
-    expect(card.createdAt).toEqual(expect.any(Number));
-
-    // Verify FSRS card is created
-    expect(card.fsrs).toBeDefined();
-    expect(card.fsrs.due).toEqual(expect.any(Number));
-    expect(card.fsrs.stability).toBeDefined();
-    expect(card.fsrs.difficulty).toBeDefined();
-    expect(card.fsrs.reps).toBe(0);
-    expect(card.fsrs.lapses).toBe(0);
-
-    // Verify the card was actually stored using WXT storage
-    const cards = await storage.getItem<Record<string, Card>>(STORAGE_KEYS.cards);
-
-    expect(cards).toBeDefined();
-    expect(requireDefined(cards)['two-sum']).toBeDefined();
-    expect(requireDefined(cards)['two-sum'].slug).toBe('two-sum');
-    expect(requireDefined(cards)['two-sum'].name).toBe('Two Sum');
-
-    // Verify FSRS data is stored properly
-    expect(requireDefined(cards)['two-sum'].fsrs).toBeDefined();
-    expect(typeof requireDefined(cards)['two-sum'].fsrs.due).toBe('number');
+    expect(card.createdAt).toBeGreaterThanOrEqual(before);
+    expect(card.createdAt).toBeLessThanOrEqual(after);
+    expect(card.fsrs.due).toBe(card.createdAt);
+    expect(card.fsrs.last_review).toBeUndefined();
+    expect(await storage.getItem(STORAGE_KEYS.cards)).toEqual({ [problem.slug]: card });
+    expect(await getAllCards()).toEqual([card]);
   });
 
   it('should return existing card when adding same slug (idempotent)', async () => {
@@ -185,61 +166,12 @@ describe('addCard', () => {
     expect(requireDefined(cards)['valid-parentheses']).toBeDefined();
     expect(requireDefined(cards)['merge-two-sorted-lists']).toBeDefined();
   });
-
-  it('should set createdAt to current date', async () => {
-    const beforeTime = new Date();
-    const card = await addCard({
-      slug: 'test-problem',
-      name: 'Test Problem',
-      leetcodeId: '999',
-      difficulty: 'Medium',
-      domain: 'leetcode.com',
-    });
-    const afterTime = new Date();
-
-    expect(card.createdAt).toEqual(expect.any(Number));
-    expect(card.createdAt).toBeGreaterThanOrEqual(beforeTime.getTime());
-    expect(card.createdAt).toBeLessThanOrEqual(afterTime.getTime());
-  });
-
-  it('should properly serialize card when storing', async () => {
-    const card = await addCard({
-      slug: 'serialize-test',
-      name: 'Serialize Test',
-      leetcodeId: '1000',
-      difficulty: 'Easy',
-      domain: 'leetcode.com',
-    });
-
-    const cards = await storage.getItem<Record<string, Card>>(STORAGE_KEYS.cards);
-    const storedCard = requireDefined(cards)[card.slug];
-
-    expect(typeof storedCard.createdAt).toBe('number');
-    expect(storedCard.slug).toBe(card.slug);
-    expect(storedCard.name).toBe(card.name);
-  });
 });
 
 describe('removeCard', () => {
   beforeEach(() => {
     // Reset the fake browser state before each test
     fakeBrowser.reset();
-  });
-
-  it('should remove an existing card and its slug mapping', async () => {
-    // Add a card first
-    await addCard({ slug: 'two-sum', name: 'Two Sum', leetcodeId: '1', difficulty: 'Easy', domain: 'leetcode.com' });
-
-    // Verify it exists
-    let cards = await storage.getItem<Record<string, Card>>(STORAGE_KEYS.cards);
-    expect(requireDefined(cards)['two-sum']).toBeDefined();
-
-    // Remove the card
-    await removeCard('two-sum');
-
-    // Verify it's removed
-    cards = await storage.getItem<Record<string, Card>>(STORAGE_KEYS.cards);
-    expect(requireDefined(cards)['two-sum']).toBeUndefined();
   });
 
   it('should handle removing non-existent card gracefully', async () => {
@@ -249,101 +181,6 @@ describe('removeCard', () => {
     // Verify storage is still empty/unchanged
     const cards = await storage.getItem<Record<string, Card>>(STORAGE_KEYS.cards);
     expect(cards || {}).toEqual({});
-  });
-
-  it('should only remove the specified card when multiple cards exist', async () => {
-    // Add multiple cards
-    await addCard({ slug: 'two-sum', name: 'Two Sum', leetcodeId: '1', difficulty: 'Easy', domain: 'leetcode.com' });
-    await addCard({
-      slug: 'valid-parentheses',
-      name: 'Valid Parentheses',
-      leetcodeId: '20',
-      difficulty: 'Medium',
-      domain: 'leetcode.com',
-    });
-    await addCard({
-      slug: 'merge-intervals',
-      name: 'Merge Intervals',
-      leetcodeId: '56',
-      difficulty: 'Hard',
-      domain: 'leetcode.com',
-    });
-
-    // Remove the middle card
-    await removeCard('valid-parentheses');
-
-    // Verify only the specified card is removed
-    const cards = await storage.getItem<Record<string, Card>>(STORAGE_KEYS.cards);
-
-    expect(Object.keys(cards || {}).length).toBe(2);
-
-    // Card 1 should still exist
-    expect(requireDefined(cards)['two-sum']).toBeDefined();
-
-    // Card 2 should be removed
-    expect(requireDefined(cards)['valid-parentheses']).toBeUndefined();
-
-    // Card 3 should still exist
-    expect(requireDefined(cards)['merge-intervals']).toBeDefined();
-  });
-
-  it('should verify card is actually removed from getAllCards', async () => {
-    // Add multiple cards
-    await addCard({ slug: 'two-sum', name: 'Two Sum', leetcodeId: '1', difficulty: 'Easy', domain: 'leetcode.com' });
-    await addCard({
-      slug: 'valid-parentheses',
-      name: 'Valid Parentheses',
-      leetcodeId: '20',
-      difficulty: 'Medium',
-      domain: 'leetcode.com',
-    });
-    await addCard({
-      slug: 'merge-intervals',
-      name: 'Merge Intervals',
-      leetcodeId: '56',
-      difficulty: 'Hard',
-      domain: 'leetcode.com',
-    });
-
-    // Get initial count
-    let allCards = await getAllCards();
-    expect(allCards).toHaveLength(3);
-
-    // Remove one card
-    await removeCard('valid-parentheses');
-
-    // Verify it's not in getAllCards
-    allCards = await getAllCards();
-    expect(allCards).toHaveLength(2);
-    expect(allCards.some((c) => c.slug === 'valid-parentheses')).toBe(false);
-    expect(allCards.some((c) => c.slug === 'two-sum')).toBe(true);
-    expect(allCards.some((c) => c.slug === 'merge-intervals')).toBe(true);
-  });
-
-  it('should delete associated note when removing a card', async () => {
-    // Clear any previous mock calls
-    vi.clearAllMocks();
-
-    // Add a card
-    const card = await addCard({
-      slug: 'test-with-note',
-      name: 'Test With Note',
-      leetcodeId: '123',
-      difficulty: 'Medium',
-      domain: 'leetcode.com',
-    });
-    const cardId = card.id;
-
-    // Remove the card
-    await removeCard('test-with-note');
-
-    // Verify deleteNote was called with the correct card ID
-    expect(notesModule.deleteNote).toHaveBeenCalledTimes(1);
-    expect(notesModule.deleteNote).toHaveBeenCalledWith(cardId);
-
-    // Verify the card is actually removed
-    const cards = await storage.getItem<Record<string, Card>>(STORAGE_KEYS.cards);
-    expect(requireDefined(cards)['test-with-note']).toBeUndefined();
   });
 
   it('should not call deleteNote when removing non-existent card', async () => {
@@ -395,42 +232,6 @@ describe('delayCard', () => {
     const cards = await storage.getItem<Record<string, Card>>(STORAGE_KEYS.cards);
     const storedCard = requireDefined(cards)['two-sum'];
     expect(storedCard.fsrs.due).toBe(expectedDueDate.getTime());
-  });
-
-  it('should handle delaying by 1 day', async () => {
-    const card = await addCard({
-      slug: 'test-problem',
-      name: 'Test Problem',
-      leetcodeId: '999',
-      difficulty: 'Medium',
-      domain: 'leetcode.com',
-    });
-    const originalDueDate = new Date(card.fsrs.due);
-
-    const delayedCard = await delayCard('test-problem', 1);
-
-    const expectedDueDate = new Date(originalDueDate);
-    expectedDueDate.setDate(expectedDueDate.getDate() + 1);
-
-    expect(delayedCard.fsrs.due).toBe(expectedDueDate.getTime());
-  });
-
-  it('should handle delaying by large number of days', async () => {
-    const card = await addCard({
-      slug: 'large-delay',
-      name: 'Large Delay',
-      leetcodeId: '1000',
-      difficulty: 'Hard',
-      domain: 'leetcode.com',
-    });
-    const originalDueDate = new Date(card.fsrs.due);
-
-    const delayedCard = await delayCard('large-delay', 30);
-
-    const expectedDueDate = new Date(originalDueDate);
-    expectedDueDate.setDate(expectedDueDate.getDate() + 30);
-
-    expect(delayedCard.fsrs.due).toBe(expectedDueDate.getTime());
   });
 
   it('should throw error when card does not exist', async () => {
@@ -582,26 +383,6 @@ describe('setPauseStatus', () => {
 });
 
 describe('rateCard', () => {
-  it('FSRS schedules numeric card dates identically to Date objects', () => {
-    const scheduler = new FSRS(generatorParameters({ maximum_interval: 1000, enable_fuzz: false }));
-    const numericCard = createMockCard(FsrsState.Review).fsrs;
-    numericCard.due = Date.parse('2024-03-14T10:00:00Z');
-    numericCard.last_review = Date.parse('2024-03-13T10:00:00Z');
-    const dateCard = {
-      ...numericCard,
-      due: new Date(numericCard.due),
-      last_review: new Date(numericCard.last_review),
-    };
-    const now = new Date('2024-03-15T10:00:00Z');
-
-    const numericResult = scheduler.next(numericCard, now, Rating.Good);
-    const dateResult = scheduler.next(dateCard, now, Rating.Good);
-
-    expect(numericResult).toEqual(dateResult);
-    expect(numericResult.card.last_review).toEqual(now);
-    expect(numericResult.card.due.getTime()).toBeGreaterThan(now.getTime());
-  });
-
   beforeEach(() => {
     // Reset the fake browser state before each test
     fakeBrowser.reset();
@@ -690,99 +471,6 @@ describe('rateCard', () => {
     expect(easyResult.card.fsrs.reps).toBeGreaterThan(0);
   });
 
-  it('should update the due date after rating', async () => {
-    const card = await addCard({
-      slug: 'merge-sort',
-      name: 'Merge Sort',
-      leetcodeId: '88',
-      difficulty: 'Hard',
-      domain: 'leetcode.com',
-    });
-    const initialDue = card.fsrs.due;
-
-    const result = await rateCard({
-      slug: 'merge-sort',
-      name: 'Merge Sort',
-      rating: Rating.Good,
-      leetcodeId: '88',
-      difficulty: 'Hard',
-      domain: 'leetcode.com',
-    });
-
-    expect(result.card.fsrs.due).toEqual(expect.any(Number));
-    expect(result.card.fsrs.due).toBeGreaterThan(initialDue);
-  });
-
-  it('should persist card updates to storage', async () => {
-    await addCard({
-      slug: 'binary-search',
-      name: 'Binary Search',
-      leetcodeId: '704',
-      difficulty: 'Medium',
-      domain: 'leetcode.com',
-    });
-
-    // Rate the card
-    await rateCard({
-      slug: 'binary-search',
-      name: 'Binary Search',
-      rating: Rating.Hard,
-      leetcodeId: '704',
-      difficulty: 'Medium',
-      domain: 'leetcode.com',
-    });
-
-    // Verify the updated card is in storage
-    const cards = await storage.getItem<Record<string, Card>>(STORAGE_KEYS.cards);
-    const storedCard = requireDefined(cards)['binary-search'];
-
-    expect(storedCard).toBeDefined();
-    expect(typeof storedCard.fsrs.last_review).toBe('number');
-  });
-
-  it('should handle multiple ratings on the same card', async () => {
-    const slug = 'dynamic-programming';
-
-    // First rating (creates card)
-    const result1 = await rateCard({
-      slug: slug,
-      name: 'Multi Rate',
-      rating: Rating.Again,
-      leetcodeId: '9998',
-      difficulty: 'Hard',
-      domain: 'leetcode.com',
-    });
-    expect(result1.card.fsrs.reps).toBe(1);
-    expect(result1.card.fsrs.lapses).toBe(0);
-
-    // Second rating
-    const result2 = await rateCard({
-      slug: slug,
-      name: 'Multi Rate',
-      rating: Rating.Hard,
-      leetcodeId: '9998',
-      difficulty: 'Hard',
-      domain: 'leetcode.com',
-    });
-    expect(result2.card.fsrs.reps).toBeGreaterThan(0);
-
-    // Third rating
-    const result3 = await rateCard({
-      slug: slug,
-      name: 'Multi Rate',
-      rating: Rating.Good,
-      leetcodeId: '9998',
-      difficulty: 'Hard',
-      domain: 'leetcode.com',
-    });
-    expect(result3.card.fsrs.reps).toBeGreaterThan(result2.card.fsrs.reps);
-
-    // Verify only one card exists in storage
-    const allCards = await getAllCards();
-    const dpCards = allCards.filter((c) => c.slug === slug);
-    expect(dpCards).toHaveLength(1);
-  });
-
   it('should update stats when rating a new card', async () => {
     // Rate a new card (doesn't exist yet)
     await rateCard({
@@ -869,599 +557,34 @@ describe('rateCard', () => {
 });
 
 describe('getReviewQueue', () => {
-  // Helper function to create test stats with sensible defaults
-  const createTestStats = (overrides: Partial<DailyStats> = {}): Record<string, DailyStats> => {
-    const todayKey = '2024-01-15';
-    const defaults: DailyStats = {
-      date: todayKey,
-      totalReviews: 0,
-      gradeBreakdown: {
-        [Rating.Again]: 0,
-        [Rating.Hard]: 0,
-        [Rating.Good]: 0,
-        [Rating.Easy]: 0,
-      },
-      newCards: 0,
-      reviewedCards: 0,
-      streak: 1,
-    };
-
-    // Auto-calculate totalReviews if not provided
-    const stats = { ...defaults, ...overrides };
-    if (!overrides.totalReviews) {
-      stats.totalReviews = stats.newCards + stats.reviewedCards;
-    }
-
-    return { [todayKey]: stats };
-  };
-
   beforeEach(() => {
     fakeBrowser.reset();
     vi.useFakeTimers();
-    vi.setSystemTime(new Date('2024-01-15T12:00:00Z'));
+    vi.setSystemTime(new Date('2024-01-15T12:00:00'));
   });
 
   afterEach(() => {
     vi.useRealTimers();
   });
 
-  it('should return empty array when no cards exist', async () => {
-    const queue = await getReviewQueue();
-    expect(queue).toEqual([]);
-  });
-
-  it('should return only new cards when no reviews are due', async () => {
-    // Create cards - all new
-    await addCard({
-      slug: 'problem1',
-      name: 'Problem 1',
-      leetcodeId: '1001',
-      difficulty: 'Easy',
-      domain: 'leetcode.com',
-    });
-    await addCard({
-      slug: 'problem2',
-      name: 'Problem 2',
-      leetcodeId: '1002',
-      difficulty: 'Medium',
-      domain: 'leetcode.com',
-    });
-    await addCard({
-      slug: 'problem3',
-      name: 'Problem 3',
-      leetcodeId: '1003',
-      difficulty: 'Hard',
-      domain: 'leetcode.com',
-    });
-    await addCard({
-      slug: 'problem4',
-      name: 'Problem 4',
-      leetcodeId: '1004',
-      difficulty: 'Easy',
-      domain: 'leetcode.com',
-    });
-    await addCard({
-      slug: 'problem5',
-      name: 'Problem 5',
-      leetcodeId: '1005',
-      difficulty: 'Medium',
-      domain: 'leetcode.com',
-    });
-
-    const queue = await getReviewQueue();
-
-    // Should only get the configured maximum
-    expect(queue).toHaveLength(MOCK_MAX_NEW_CARDS_PER_DAY);
-    expect(queue.every((card) => card.fsrs.state === FsrsState.New)).toBe(true);
-  });
-
-  it('should return only review cards when they are due', async () => {
-    // Create and rate cards to make them review cards
-    await addCard({
-      slug: 'problem1',
-      name: 'Problem 1',
-      leetcodeId: '1001',
-      difficulty: 'Easy',
-      domain: 'leetcode.com',
-    });
-    await addCard({
-      slug: 'problem2',
-      name: 'Problem 2',
-      leetcodeId: '1002',
-      difficulty: 'Medium',
-      domain: 'leetcode.com',
-    });
-
-    // Rate them to move out of New state
-    await rateCard({
-      slug: 'problem1',
-      name: 'Problem 1',
-      rating: Rating.Good,
-      leetcodeId: '1001',
-      difficulty: 'Easy',
-      domain: 'leetcode.com',
-    });
-    await rateCard({
-      slug: 'problem2',
-      name: 'Problem 2',
-      rating: Rating.Good,
-      leetcodeId: '1002',
-      difficulty: 'Medium',
-      domain: 'leetcode.com',
-    });
-
-    // Manually update their due dates to be in the past
-    const cards = await storage.getItem<Record<string, Card>>(STORAGE_KEYS.cards);
-    const pastTime = new Date('2024-01-14T12:00:00Z').getTime();
-    requireDefined(cards).problem1.fsrs.due = pastTime;
-    requireDefined(cards).problem2.fsrs.due = pastTime;
-    await storage.setItem(STORAGE_KEYS.cards, cards);
-
-    const queue = await getReviewQueue();
-
-    expect(queue).toHaveLength(2);
-    expect(queue.every((card) => card.fsrs.state !== FsrsState.New)).toBe(true);
-  });
-
-  it('should interleave review and new cards', async () => {
-    // Reset stats to ensure clean state
-    await storage.setItem(STORAGE_KEYS.stats, {});
-
-    // Create some new cards
-    await addCard({ slug: 'new1', name: 'New 1', leetcodeId: '2001', difficulty: 'Easy', domain: 'leetcode.com' });
-    await addCard({ slug: 'new2', name: 'New 2', leetcodeId: '2002', difficulty: 'Medium', domain: 'leetcode.com' });
-    await addCard({ slug: 'new3', name: 'New 3', leetcodeId: '2003', difficulty: 'Hard', domain: 'leetcode.com' });
-    await addCard({ slug: 'new4', name: 'New 4', leetcodeId: '2004', difficulty: 'Easy', domain: 'leetcode.com' }); // This won't be included (exceeds limit)
-
-    // Create some review cards
-    await addCard({
-      slug: 'review1',
-      name: 'Review 1',
-      leetcodeId: '3001',
-      difficulty: 'Medium',
-      domain: 'leetcode.com',
-    });
-    await addCard({
-      slug: 'review2',
-      name: 'Review 2',
-      leetcodeId: '3002',
-      difficulty: 'Hard',
-      domain: 'leetcode.com',
-    });
-
-    // Rate review cards to move them out of New state
-    await rateCard({
-      slug: 'review1',
-      name: 'Review 1',
-      rating: Rating.Good,
-      leetcodeId: '3001',
-      difficulty: 'Medium',
-      domain: 'leetcode.com',
-    });
-    await rateCard({
-      slug: 'review2',
-      name: 'Review 2',
-      rating: Rating.Good,
-      leetcodeId: '3002',
-      difficulty: 'Hard',
-      domain: 'leetcode.com',
-    });
-
-    // Set their due dates to the past
-    const cards = await storage.getItem<Record<string, Card>>(STORAGE_KEYS.cards);
-    const pastTime = new Date('2024-01-14T12:00:00Z').getTime();
-    requireDefined(cards).review1.fsrs.due = pastTime;
-    requireDefined(cards).review2.fsrs.due = pastTime;
-    await storage.setItem(STORAGE_KEYS.cards, cards);
-
-    const queue = await getReviewQueue();
-
-    // Rating the cards created stats entries, so we need to account for that
-    // We rated 2 cards as new (review1 and review2 were new when first rated)
-    // So remaining new cards = configured maximum - 2 = 1
-    // Total = 2 review cards + 1 new card = 3
-    expect(queue).toHaveLength(3);
-
-    const newCards = queue.filter((card) => card.fsrs.state === FsrsState.New);
-    const reviewCards = queue.filter((card) => card.fsrs.state !== FsrsState.New);
-
-    expect(newCards).toHaveLength(1); // Only 1 new card left after rating 2
-    expect(reviewCards).toHaveLength(2);
-  });
-
-  it('should not include future due cards', async () => {
-    await addCard({
-      slug: 'future1',
-      name: 'Future 1',
-      leetcodeId: '4001',
-      difficulty: 'Easy',
-      domain: 'leetcode.com',
-    });
-    await rateCard({
-      slug: 'future1',
-      name: 'Future 1',
-      rating: Rating.Good,
-      leetcodeId: '4001',
-      difficulty: 'Easy',
-      domain: 'leetcode.com',
-    });
-
-    // Set due date to future
-    const cards = await storage.getItem<Record<string, Card>>(STORAGE_KEYS.cards);
-    const futureTime = new Date('2024-01-16T12:00:00Z').getTime();
-    requireDefined(cards).future1.fsrs.due = futureTime;
-    await storage.setItem(STORAGE_KEYS.cards, cards);
-
-    const queue = await getReviewQueue();
-
-    expect(queue).toHaveLength(0);
-  });
-
-  it.each([FsrsState.New, FsrsState.Learning, FsrsState.Review, FsrsState.Relearning])(
-    'includes state %i cards only as each due timestamp is reached',
-    async (state) => {
-      vi.setSystemTime(new Date('2024-01-15T12:00:00'));
-      const cards = [
-        ['morning', '2024-01-15T06:00:00'],
-        ['evening', '2024-01-15T20:00:00'],
-        ['midnight', '2024-01-15T23:59:59.999'],
-      ].map(([slug, due]) => {
-        const card = createMockCard(state, { slug });
-        card.fsrs.due = new Date(due).getTime();
-        return card;
-      });
-      await storage.setItem(STORAGE_KEYS.cards, Object.fromEntries(cards.map((card) => [card.slug, card])));
-
-      expect((await getReviewQueue()).map((card) => card.slug)).toEqual(['morning']);
-      vi.setSystemTime(new Date('2024-01-15T20:00:00'));
-      expect((await getReviewQueue()).map((card) => card.slug)).toEqual(['morning', 'evening']);
-      vi.setSystemTime(new Date('2024-01-15T23:59:59.999'));
-      expect((await getReviewQueue()).map((card) => card.slug)).toEqual(['morning', 'evening', 'midnight']);
-    }
-  );
-
-  it('should handle mix of new, due, and future cards', async () => {
-    // Reset stats to ensure clean state
-    await storage.setItem(STORAGE_KEYS.stats, {});
-
-    // Create new cards
-    await addCard({ slug: 'new1', name: 'New 1', leetcodeId: '2001', difficulty: 'Easy', domain: 'leetcode.com' });
-    await addCard({ slug: 'new2', name: 'New 2', leetcodeId: '2002', difficulty: 'Medium', domain: 'leetcode.com' });
-
-    // Create due review cards
-    await addCard({ slug: 'due1', name: 'Due 1', leetcodeId: '5001', difficulty: 'Medium', domain: 'leetcode.com' });
-    await rateCard({
-      slug: 'due1',
-      name: 'Due 1',
-      rating: Rating.Good,
-      leetcodeId: '5001',
-      difficulty: 'Medium',
-      domain: 'leetcode.com',
-    });
-
-    // Create future review cards
-    await addCard({
-      slug: 'future1',
-      name: 'Future 1',
-      leetcodeId: '4001',
-      difficulty: 'Easy',
-      domain: 'leetcode.com',
-    });
-    await rateCard({
-      slug: 'future1',
-      name: 'Future 1',
-      rating: Rating.Easy,
-      leetcodeId: '4001',
-      difficulty: 'Easy',
-      domain: 'leetcode.com',
-    });
-
-    // Manually set due dates
-    const cards = await storage.getItem<Record<string, Card>>(STORAGE_KEYS.cards);
-    const pastTime = new Date('2024-01-14T12:00:00Z').getTime();
-    const futureTime = new Date('2024-01-16T12:00:00Z').getTime();
-    requireDefined(cards).due1.fsrs.due = pastTime;
-    requireDefined(cards).future1.fsrs.due = futureTime;
-    await storage.setItem(STORAGE_KEYS.cards, cards);
-
-    const queue = await getReviewQueue();
-
-    // We rated 2 cards (due1 and future1), using up 2 of our 3 daily new cards
-    // So only 1 new card slot remains: 1 new card + 1 due review = 2 total
-    expect(queue).toHaveLength(2);
-
-    const slugs = queue.map((card) => card.slug);
-    // Should have due1 (review) and one of the new cards
-    expect(slugs).toContain('due1');
-    expect(slugs.some((s) => s === 'new1' || s === 'new2')).toBe(true);
-    expect(slugs).not.toContain('future1');
-    expect(slugs).toHaveLength(2);
-  });
-
-  it('should respect max new cards per day limit from settings', async () => {
-    // Create many new cards
-    for (let i = 1; i <= 10; i++) {
-      await addCard({
-        slug: `new${i}`,
-        name: `New ${i}`,
-        leetcodeId: `${6000 + i}`,
-        difficulty: 'Medium',
-        domain: 'leetcode.com',
-      });
+  it('uses the full allowance when no completion stats exist', async () => {
+    for (const slug of ['alpha', 'bravo', 'charlie', 'delta']) {
+      await addCard(buildProblem({ slug }));
     }
 
-    const queue = await getReviewQueue();
-
-    // Should only include the configured maximum of new cards
-    expect(queue).toHaveLength(MOCK_MAX_NEW_CARDS_PER_DAY);
-    expect(queue.every((card) => card.fsrs.state === FsrsState.New)).toBe(true);
+    expect((await getReviewQueue()).map((card) => card.slug)).toEqual(['alpha', 'bravo', 'charlie']);
   });
 
-  it('should include all due review cards regardless of limit', async () => {
-    // Create many review cards
-    for (let i = 1; i <= 10; i++) {
-      await addCard({
-        slug: `review${i}`,
-        name: `Review ${i}`,
-        leetcodeId: `${7000 + i}`,
-        difficulty: 'Medium',
-        domain: 'leetcode.com',
-      });
-      await rateCard({
-        slug: `review${i}`,
-        name: `Review ${i}`,
-        rating: Rating.Good,
-        leetcodeId: `${7000 + i}`,
-        difficulty: 'Medium',
-        domain: 'leetcode.com',
-      });
+  it('combines persisted rating completions with current settings', async () => {
+    const completed = buildProblem({ slug: 'completed' });
+    await rateCard({ ...completed, rating: Rating.Good });
+    for (const slug of ['alpha', 'bravo', 'charlie', 'delta']) {
+      await addCard(buildProblem({ slug }));
     }
 
-    // Set all to be due
-    const cards = await storage.getItem<Record<string, Card>>(STORAGE_KEYS.cards);
-    const pastTime = new Date('2024-01-14T12:00:00Z').getTime();
-    for (let i = 1; i <= 10; i++) {
-      requireDefined(cards)[`review${i}`].fsrs.due = pastTime;
-    }
-    await storage.setItem(STORAGE_KEYS.cards, cards);
-
-    const queue = await getReviewQueue();
-
-    // Should include all 10 review cards (no limit on reviews)
-    expect(queue).toHaveLength(10);
-    expect(queue.every((card) => card.fsrs.state !== FsrsState.New)).toBe(true);
-  });
-
-  it('should respect daily new cards already completed when building queue', async () => {
-    // Create stats showing 1 new card already done today
-    await storage.setItem(
-      STORAGE_KEYS.stats,
-      createTestStats({
-        newCards: 1,
-        gradeBreakdown: {
-          [Rating.Again]: 0,
-          [Rating.Hard]: 0,
-          [Rating.Good]: 1,
-          [Rating.Easy]: 0,
-        },
-      })
-    );
-
-    // Create 5 new cards
-    for (let i = 1; i <= 5; i++) {
-      await addCard({
-        slug: `new${i}`,
-        name: `New ${i}`,
-        leetcodeId: `${6000 + i}`,
-        difficulty: 'Medium',
-        domain: 'leetcode.com',
-      });
-    }
-
-    const queue = await getReviewQueue();
-
-    // Should only get one less than the configured maximum since 1 was already done
-    expect(queue).toHaveLength(MOCK_MAX_NEW_CARDS_PER_DAY - 1);
-    expect(queue.every((card) => card.fsrs.state === FsrsState.New)).toBe(true);
-  });
-
-  it('should return no new cards when daily limit already reached', async () => {
-    // Create stats showing MAX_NEW_CARDS_PER_DAY already done
-    await storage.setItem(
-      STORAGE_KEYS.stats,
-      createTestStats({
-        newCards: MOCK_MAX_NEW_CARDS_PER_DAY,
-        gradeBreakdown: {
-          [Rating.Again]: 0,
-          [Rating.Hard]: 0,
-          [Rating.Good]: MOCK_MAX_NEW_CARDS_PER_DAY,
-          [Rating.Easy]: 0,
-        },
-      })
-    );
-
-    // Create new cards
-    for (let i = 1; i <= 5; i++) {
-      await addCard({
-        slug: `new${i}`,
-        name: `New ${i}`,
-        leetcodeId: `${8000 + i}`,
-        difficulty: 'Easy',
-        domain: 'leetcode.com',
-      });
-    }
-
-    const queue = await getReviewQueue();
-
-    // Should have no cards since daily limit reached
-    expect(queue).toHaveLength(0);
-  });
-
-  it('should still include review cards when new card limit is reached', async () => {
-    // Create stats showing new card limit reached
-    await storage.setItem(
-      STORAGE_KEYS.stats,
-      createTestStats({
-        newCards: MOCK_MAX_NEW_CARDS_PER_DAY,
-        reviewedCards: 2,
-        totalReviews: MOCK_MAX_NEW_CARDS_PER_DAY + 2,
-        gradeBreakdown: {
-          [Rating.Again]: 0,
-          [Rating.Hard]: 2,
-          [Rating.Good]: MOCK_MAX_NEW_CARDS_PER_DAY,
-          [Rating.Easy]: 0,
-        },
-      })
-    );
-
-    // Create new cards (won't be included)
-    await addCard({ slug: 'new1', name: 'New 1', leetcodeId: '2001', difficulty: 'Easy', domain: 'leetcode.com' });
-    await addCard({ slug: 'new2', name: 'New 2', leetcodeId: '2002', difficulty: 'Medium', domain: 'leetcode.com' });
-
-    // Create review cards (should be included)
-    await addCard({
-      slug: 'review1',
-      name: 'Review 1',
-      leetcodeId: '3001',
-      difficulty: 'Medium',
-      domain: 'leetcode.com',
-    });
-    await addCard({
-      slug: 'review2',
-      name: 'Review 2',
-      leetcodeId: '3002',
-      difficulty: 'Hard',
-      domain: 'leetcode.com',
-    });
-    await rateCard({
-      slug: 'review1',
-      name: 'Review 1',
-      rating: Rating.Good,
-      leetcodeId: '3001',
-      difficulty: 'Medium',
-      domain: 'leetcode.com',
-    });
-    await rateCard({
-      slug: 'review2',
-      name: 'Review 2',
-      rating: Rating.Good,
-      leetcodeId: '3002',
-      difficulty: 'Hard',
-      domain: 'leetcode.com',
-    });
-
-    // Set review cards to be due
-    const cards = await storage.getItem<Record<string, Card>>(STORAGE_KEYS.cards);
-    const pastTime = new Date('2024-01-14T12:00:00Z').getTime();
-    requireDefined(cards).review1.fsrs.due = pastTime;
-    requireDefined(cards).review2.fsrs.due = pastTime;
-    await storage.setItem(STORAGE_KEYS.cards, cards);
-
-    const queue = await getReviewQueue();
-
-    // Should only have the 2 review cards
-    expect(queue).toHaveLength(2);
-    expect(queue.every((card) => card.fsrs.state !== FsrsState.New)).toBe(true);
-  });
-
-  it('should handle partial new card limit correctly', async () => {
-    // Configured maximum is 3, already did 2
-    await storage.setItem(
-      STORAGE_KEYS.stats,
-      createTestStats({
-        newCards: 2,
-        gradeBreakdown: {
-          [Rating.Again]: 0,
-          [Rating.Hard]: 0,
-          [Rating.Good]: 2,
-          [Rating.Easy]: 0,
-        },
-      })
-    );
-
-    // Create 10 new cards
-    for (let i = 1; i <= 10; i++) {
-      await addCard({
-        slug: `new${i}`,
-        name: `New ${i}`,
-        leetcodeId: `${6000 + i}`,
-        difficulty: 'Medium',
-        domain: 'leetcode.com',
-      });
-    }
-
-    const queue = await getReviewQueue();
-
-    // Should only get 1 more new card (3 - 2 = 1)
-    expect(queue).toHaveLength(1);
-    expect(queue[0].fsrs.state).toBe(FsrsState.New);
-  });
-
-  it('should handle no stats (first use) correctly', async () => {
-    // No stats exist (getTodayStats returns null)
-
-    // Create new cards
-    for (let i = 1; i <= 5; i++) {
-      await addCard({
-        slug: `new${i}`,
-        name: `New ${i}`,
-        leetcodeId: `${8000 + i}`,
-        difficulty: 'Easy',
-        domain: 'leetcode.com',
-      });
-    }
-
-    const queue = await getReviewQueue();
-
-    // Should get the full configured maximum when no stats exist
-    expect(queue).toHaveLength(MOCK_MAX_NEW_CARDS_PER_DAY);
-    expect(queue.every((card) => card.fsrs.state === FsrsState.New)).toBe(true);
-  });
-
-  it('should respect custom max new cards per day setting', async () => {
-    // Set custom max new cards per day
-    const { getSettings } = await import('../settings');
-    vi.mocked(getSettings).mockResolvedValue(buildSettings({ maxNewCardsPerDay: 5 }));
-
-    // Create new cards
-    for (let i = 1; i <= 10; i++) {
-      await addCard({
-        slug: `new${i}`,
-        name: `New ${i}`,
-        leetcodeId: `${9000 + i}`,
-        difficulty: 'Easy',
-        domain: 'leetcode.com',
-      });
-    }
-
-    const queue = await getReviewQueue();
-
-    // Should get 5 new cards based on custom setting
-    expect(queue).toHaveLength(5);
-    expect(queue.every((card) => card.fsrs.state === FsrsState.New)).toBe(true);
-  });
-
-  it('should maintain stable order across multiple calls', async () => {
-    // Create multiple cards
-    for (let i = 1; i <= 5; i++) {
-      await addCard({
-        slug: `card-${i}`,
-        name: `Card ${i}`,
-        leetcodeId: `${1000 + i}`,
-        difficulty: 'Medium',
-        domain: 'leetcode.com',
-      });
-    }
-
-    // Get queue multiple times
-    const queue1 = await getReviewQueue();
-    const queue2 = await getReviewQueue();
-    const queue3 = await getReviewQueue();
-
-    // All queues should be identical
-    expect(queue1.map((c) => c.slug)).toEqual(queue2.map((c) => c.slug));
-    expect(queue2.map((c) => c.slug)).toEqual(queue3.map((c) => c.slug));
-    expect(queue1.length).toBe(3); // Limited by max new cards per day
+    expect((await getReviewQueue()).map((card) => card.slug)).toEqual(['alpha', 'bravo']);
+    mockGetSettings.mockResolvedValue(buildSettings({ maxNewCardsPerDay: 4 }));
+    expect((await getReviewQueue()).map((card) => card.slug)).toEqual(['alpha', 'bravo', 'charlie']);
   });
 
   it.each([Rating.Again, Rating.Hard] as const)(
@@ -1479,170 +602,6 @@ describe('getReviewQueue', () => {
       expect((await getReviewQueue()).map((card) => card.slug)).toEqual(['second-card', 'third-card', 'first-card']);
     }
   );
-
-  it('should select the same new cards consistently when limit applies', async () => {
-    // Create more new cards than the daily limit
-    const cardSlugs = ['alpha', 'bravo', 'charlie', 'delta', 'echo', 'foxtrot'];
-    for (let i = 0; i < cardSlugs.length; i++) {
-      await addCard({
-        slug: cardSlugs[i],
-        name: `Card ${cardSlugs[i]}`,
-        leetcodeId: `${2000 + i}`,
-        difficulty: 'Medium',
-        domain: 'leetcode.com',
-      });
-    }
-
-    // Set all cards to have the same due date for predictable ordering
-    const cards = await storage.getItem<Record<string, Card>>(STORAGE_KEYS.cards);
-    const sameTime = Date.now();
-    for (const slug of cardSlugs) {
-      requireDefined(cards)[slug].fsrs.due = sameTime;
-    }
-    await storage.setItem(STORAGE_KEYS.cards, cards);
-
-    // Get queue multiple times
-    const queue1 = await getReviewQueue();
-    const queue2 = await getReviewQueue();
-
-    // Should always select the same new cards (first 3 alphabetically)
-    expect(queue1.map((c) => c.slug)).toEqual(['alpha', 'bravo', 'charlie']);
-    expect(queue2.map((c) => c.slug)).toEqual(['alpha', 'bravo', 'charlie']);
-  });
-
-  it('should maintain order when mixing review and new cards', async () => {
-    vi.setSystemTime(new Date('2024-01-15T12:00:00'));
-    // Create new cards with early due dates
-    await addCard({
-      slug: 'new-early',
-      name: 'New Early',
-      leetcodeId: '1001',
-      difficulty: 'Easy',
-      domain: 'leetcode.com',
-    });
-    await addCard({
-      slug: 'new-late',
-      name: 'New Late',
-      leetcodeId: '1002',
-      difficulty: 'Medium',
-      domain: 'leetcode.com',
-    });
-
-    // Create review cards
-    await addCard({
-      slug: 'review-middle',
-      name: 'Review Middle',
-      leetcodeId: '2001',
-      difficulty: 'Hard',
-      domain: 'leetcode.com',
-    });
-    await rateCard({
-      slug: 'review-middle',
-      name: 'Review Middle',
-      rating: Rating.Good,
-      leetcodeId: '2001',
-      difficulty: 'Hard',
-      domain: 'leetcode.com',
-    });
-
-    // Set specific due dates
-    const cards = await storage.getItem<Record<string, Card>>(STORAGE_KEYS.cards);
-    requireDefined(cards)['new-early'].fsrs.due = new Date('2024-01-15T08:00:00').getTime();
-    requireDefined(cards)['review-middle'].fsrs.due = new Date('2024-01-15T10:00:00').getTime();
-    requireDefined(cards)['new-late'].fsrs.due = new Date('2024-01-15T12:00:00').getTime();
-    await storage.setItem(STORAGE_KEYS.cards, cards);
-
-    const queue = await getReviewQueue();
-
-    // Should be ordered by due date regardless of card type
-    expect(queue[0].slug).toBe('new-early');
-    expect(queue[1].slug).toBe('review-middle');
-    expect(queue[2].slug).toBe('new-late');
-  });
-
-  it('should handle dynamic changes to max new cards setting', async () => {
-    const { getSettings } = await import('../settings');
-
-    // Create many new cards
-    for (let i = 1; i <= 10; i++) {
-      await addCard({
-        slug: `card-${i}`,
-        name: `Card ${i}`,
-        leetcodeId: `${3000 + i}`,
-        difficulty: 'Medium',
-        domain: 'leetcode.com',
-      });
-    }
-
-    // Start with default (3)
-    vi.mocked(getSettings).mockResolvedValue(buildSettings({ maxNewCardsPerDay: 3 }));
-    let queue = await getReviewQueue();
-    expect(queue.length).toBe(3);
-
-    // Increase to 5
-    vi.mocked(getSettings).mockResolvedValue(buildSettings({ maxNewCardsPerDay: 5 }));
-    queue = await getReviewQueue();
-    expect(queue.length).toBe(5);
-
-    // Decrease to 2
-    vi.mocked(getSettings).mockResolvedValue(buildSettings({ maxNewCardsPerDay: 2 }));
-    queue = await getReviewQueue();
-    expect(queue.length).toBe(2);
-
-    // Cards selected should be consistent (first N alphabetically)
-    expect(queue[0].slug).toBe('card-1');
-    expect(queue[1].slug).toBe('card-10'); // '10' comes after '1' in string sort
-  });
-
-  it('should handle queue with only paused cards', async () => {
-    await addCard({
-      slug: 'paused-1',
-      name: 'Paused 1',
-      leetcodeId: '1001',
-      difficulty: 'Easy',
-      domain: 'leetcode.com',
-    });
-    await addCard({
-      slug: 'paused-2',
-      name: 'Paused 2',
-      leetcodeId: '1002',
-      difficulty: 'Medium',
-      domain: 'leetcode.com',
-    });
-
-    await setPauseStatus('paused-1', true);
-    await setPauseStatus('paused-2', true);
-
-    const queue = await getReviewQueue();
-    expect(queue).toEqual([]);
-  });
-
-  it('should handle queue with only future cards', async () => {
-    await addCard({
-      slug: 'future-1',
-      name: 'Future 1',
-      leetcodeId: '1001',
-      difficulty: 'Easy',
-      domain: 'leetcode.com',
-    });
-    await addCard({
-      slug: 'future-2',
-      name: 'Future 2',
-      leetcodeId: '1002',
-      difficulty: 'Medium',
-      domain: 'leetcode.com',
-    });
-
-    // Set due dates to tomorrow
-    const cards = await storage.getItem<Record<string, Card>>(STORAGE_KEYS.cards);
-    const tomorrow = new Date('2024-01-16T10:00:00').getTime();
-    requireDefined(cards)['future-1'].fsrs.due = tomorrow;
-    requireDefined(cards)['future-2'].fsrs.due = tomorrow;
-    await storage.setItem(STORAGE_KEYS.cards, cards);
-
-    const queue = await getReviewQueue();
-    expect(queue).toEqual([]);
-  });
 
   it('should exclude paused cards from review queue', async () => {
     // Set up time

--- a/services/__tests__/stats.test.ts
+++ b/services/__tests__/stats.test.ts
@@ -44,95 +44,19 @@ describe('Stats management', () => {
       await updateStats(Rating.Good, false);
       await updateStats(Rating.Hard, true);
       await updateStats(Rating.Again, false);
+      await updateStats(Rating.Easy, true);
 
       const stats = await storage.getItem<Record<string, DailyStats>>(STORAGE_KEYS.stats);
       const todayStats = stats?.['2024-03-15'];
 
       expect(todayStats?.streak).toBe(1);
-      expect(todayStats?.totalReviews).toBe(3);
-      expect(todayStats?.gradeBreakdown[Rating.Good]).toBe(1);
-      expect(todayStats?.gradeBreakdown[Rating.Hard]).toBe(1);
-      expect(todayStats?.gradeBreakdown[Rating.Again]).toBe(1);
-      expect(todayStats?.gradeBreakdown[Rating.Easy]).toBe(0);
-      expect(todayStats?.reviewedCards).toBe(2);
-      expect(todayStats?.newCards).toBe(1);
-    });
-
-    it('should continue streak from yesterday', async () => {
-      // Create yesterday's stats
-      vi.setSystemTime(new Date('2024-03-14T10:00:00'));
-      await updateStats(Rating.Good, false);
-
-      // Move to today
-      vi.setSystemTime(new Date('2024-03-15T10:00:00'));
-      await updateStats(Rating.Good, false);
-
-      const stats = await storage.getItem<Record<string, DailyStats>>(STORAGE_KEYS.stats);
-      expect(stats?.['2024-03-14']?.streak).toBe(1);
-      expect(stats?.['2024-03-15']?.streak).toBe(2);
-    });
-
-    it('should reset streak if yesterday has no stats', async () => {
-      // Create stats for 2 days ago
-      vi.setSystemTime(new Date('2024-03-13T10:00:00'));
-      await updateStats(Rating.Good, false);
-      await updateStats(Rating.Easy, false);
-
-      const stats1 = await storage.getItem<Record<string, DailyStats>>(STORAGE_KEYS.stats);
-      expect(stats1?.['2024-03-13']?.streak).toBe(1);
-
-      // Skip a day, then create today's stats
-      vi.setSystemTime(new Date('2024-03-15T10:00:00'));
-      await updateStats(Rating.Good, false);
-
-      const stats2 = await storage.getItem<Record<string, DailyStats>>(STORAGE_KEYS.stats);
-      expect(stats2?.['2024-03-15']?.streak).toBe(1); // Reset to 1
-    });
-
-    it('should handle all grade types', async () => {
-      await updateStats(Rating.Again, false);
-      await updateStats(Rating.Hard, false);
-      await updateStats(Rating.Good, false);
-      await updateStats(Rating.Easy, false);
-
-      const stats = await storage.getItem<Record<string, DailyStats>>(STORAGE_KEYS.stats);
-      const todayStats = stats?.['2024-03-15'];
-
-      expect(todayStats?.gradeBreakdown[Rating.Again]).toBe(1);
-      expect(todayStats?.gradeBreakdown[Rating.Hard]).toBe(1);
-      expect(todayStats?.gradeBreakdown[Rating.Good]).toBe(1);
-      expect(todayStats?.gradeBreakdown[Rating.Easy]).toBe(1);
       expect(todayStats?.totalReviews).toBe(4);
-    });
-
-    it('should maintain streak across multiple consecutive days', async () => {
-      // Day 1
-      vi.setSystemTime(new Date('2024-03-10T10:00:00'));
-      await updateStats(Rating.Good, false);
-
-      // Day 2
-      vi.setSystemTime(new Date('2024-03-11T10:00:00'));
-      await updateStats(Rating.Easy, false);
-
-      // Day 3
-      vi.setSystemTime(new Date('2024-03-12T10:00:00'));
-      await updateStats(Rating.Good, false);
-
-      // Day 4
-      vi.setSystemTime(new Date('2024-03-13T10:00:00'));
-      await updateStats(Rating.Hard, false);
-
-      // Day 5
-      vi.setSystemTime(new Date('2024-03-14T10:00:00'));
-      await updateStats(Rating.Good, false);
-
-      const stats = await storage.getItem<Record<string, DailyStats>>(STORAGE_KEYS.stats);
-
-      expect(stats?.['2024-03-10']?.streak).toBe(1);
-      expect(stats?.['2024-03-11']?.streak).toBe(2);
-      expect(stats?.['2024-03-12']?.streak).toBe(3);
-      expect(stats?.['2024-03-13']?.streak).toBe(4);
-      expect(stats?.['2024-03-14']?.streak).toBe(5);
+      expect(todayStats?.gradeBreakdown[Rating.Good]).toBe(1);
+      expect(todayStats?.gradeBreakdown[Rating.Hard]).toBe(1);
+      expect(todayStats?.gradeBreakdown[Rating.Again]).toBe(1);
+      expect(todayStats?.gradeBreakdown[Rating.Easy]).toBe(1);
+      expect(todayStats?.reviewedCards).toBe(2);
+      expect(todayStats?.newCards).toBe(2);
     });
 
     it('should handle streak reset after multiple day gap', async () => {
@@ -157,19 +81,6 @@ describe('Stats management', () => {
   });
 
   describe('getStatsForDate', () => {
-    it('should return stats for specific date', async () => {
-      await updateStats(Rating.Good, false);
-      await updateStats(Rating.Hard, true);
-
-      const stats = await getStatsForDate('2024-03-15');
-
-      expect(stats).toBeDefined();
-      expect(stats?.date).toBe('2024-03-15');
-      expect(stats?.totalReviews).toBe(2);
-      expect(stats?.gradeBreakdown[Rating.Good]).toBe(1);
-      expect(stats?.gradeBreakdown[Rating.Hard]).toBe(1);
-    });
-
     it('should return correct stats when multiple dates exist', async () => {
       // Day 1
       vi.setSystemTime(new Date('2024-03-14T10:00:00'));
@@ -194,40 +105,24 @@ describe('Stats management', () => {
     });
   });
 
-  describe('getTodayStats', () => {
-    it('should return null when no stats exist for today', async () => {
-      const stats = await getTodayStats();
-      expect(stats).toBeNull();
+  it('reads only the current day as reviews are saved and the day changes', async () => {
+    expect(await getTodayStats()).toBeNull();
+    await updateStats(Rating.Good, false);
+    await updateStats(Rating.Easy, true);
+    expect(await getTodayStats()).toMatchObject({
+      date: '2024-03-15',
+      totalReviews: 2,
+      newCards: 1,
+      reviewedCards: 1,
     });
 
-    it("should return today's stats", async () => {
-      await updateStats(Rating.Good, false);
-      await updateStats(Rating.Easy, true);
-
-      const stats = await getTodayStats();
-
-      expect(stats).toBeDefined();
-      expect(stats?.date).toBe('2024-03-15');
-      expect(stats?.totalReviews).toBe(2);
-      expect(stats?.newCards).toBe(1);
-      expect(stats?.reviewedCards).toBe(1);
-    });
-
-    it('should always return current day stats', async () => {
-      // Create stats for multiple days
-      vi.setSystemTime(new Date('2024-03-14T10:00:00'));
-      await updateStats(Rating.Good, false);
-
-      vi.setSystemTime(new Date('2024-03-15T10:00:00'));
-      await updateStats(Rating.Easy, false);
-
-      vi.setSystemTime(new Date('2024-03-16T10:00:00'));
-      await updateStats(Rating.Hard, false);
-
-      // Check today's stats returns March 16
-      const stats = await getTodayStats();
-      expect(stats?.date).toBe('2024-03-16');
-      expect(stats?.gradeBreakdown[Rating.Hard]).toBe(1);
+    vi.setSystemTime(new Date('2024-03-16T10:00:00'));
+    expect(await getTodayStats()).toBeNull();
+    await updateStats(Rating.Hard, false);
+    expect(await getTodayStats()).toMatchObject({
+      date: '2024-03-16',
+      totalReviews: 1,
+      gradeBreakdown: { [Rating.Hard]: 1 },
     });
   });
 
@@ -265,25 +160,6 @@ describe('Stats management', () => {
       expect(stats[6].totalReviews).toBe(1);
       expect(stats[6].gradeBreakdown[Rating.Hard]).toBe(1);
     });
-
-    it('should include all grade breakdowns for each day', async () => {
-      vi.setSystemTime(new Date('2024-03-15T10:00:00'));
-      await updateStats(Rating.Again, false);
-      await updateStats(Rating.Hard, false);
-      await updateStats(Rating.Good, false);
-      await updateStats(Rating.Easy, false);
-
-      const stats = await getLastNDaysStats(1);
-
-      expect(stats).toHaveLength(1);
-      const todayStats = stats[0];
-      expect(todayStats.date).toBe('2024-03-15');
-      expect(todayStats.totalReviews).toBe(4);
-      expect(todayStats.gradeBreakdown[Rating.Again]).toBe(1);
-      expect(todayStats.gradeBreakdown[Rating.Hard]).toBe(1);
-      expect(todayStats.gradeBreakdown[Rating.Good]).toBe(1);
-      expect(todayStats.gradeBreakdown[Rating.Easy]).toBe(1);
-    });
   });
 
   describe('getCardStateStats', () => {
@@ -314,125 +190,26 @@ describe('Stats management', () => {
   });
 
   describe('getNextNDaysStats', () => {
-    beforeEach(() => {
-      fakeBrowser.reset();
-      vi.setSystemTime(new Date('2024-03-15T10:00:00'));
-    });
-
-    it('should return empty counts when no cards exist', async () => {
-      const stats = await getNextNDaysStats(7);
-
-      expect(stats).toHaveLength(7);
-      expect(stats[0].date).toBe('2024-03-15');
-      expect(stats[6].date).toBe('2024-03-21');
-      stats.forEach((stat) => {
-        expect(stat.count).toBe(0);
+    it('buckets stored active cards, folding overdue cards into today and excluding the window end', async () => {
+      const cards = [
+        ['overdue', '2024-03-14T12:00:00', false],
+        ['today', '2024-03-15T12:00:00', false],
+        ['tomorrow-early', '2024-03-16T00:00:00', false],
+        ['tomorrow-late', '2024-03-16T23:59:59.999', false],
+        ['paused', '2024-03-16T12:00:00', true],
+        ['outside', '2024-03-17T00:00:00', false],
+      ] as const;
+      const storedCards = cards.map(([slug, due, paused]) => {
+        const card = createMockCard(FsrsState.Review, { slug, paused });
+        card.fsrs.due = new Date(due).getTime();
+        return card;
       });
-    });
+      await storage.setItem(STORAGE_KEYS.cards, Object.fromEntries(storedCards.map((card) => [card.slug, card])));
 
-    it('should count cards due today', async () => {
-      // Add a card that's due today
-      await addCard(buildProblem({ slug: 'problem-1' }));
-      const cards = (await storage.getItem(STORAGE_KEYS.cards)) as Record<string, Card>;
-
-      // Manually set the card to be due today
-      cards['problem-1'].fsrs.due = new Date('2024-03-15T12:00:00').getTime();
-      await storage.setItem(STORAGE_KEYS.cards, cards);
-
-      const stats = await getNextNDaysStats(7);
-
-      expect(stats[0].date).toBe('2024-03-15');
-      expect(stats[0].count).toBe(1);
-      expect(stats[1].count).toBe(0); // Not counted again tomorrow
-    });
-
-    it('should count cards due in the future', async () => {
-      // Add cards with different due dates
-      await addCard(buildProblem({ slug: 'problem-1' }));
-      await addCard(buildProblem({ slug: 'problem-2' }));
-      await addCard(buildProblem({ slug: 'problem-3' }));
-
-      const cards = (await storage.getItem(STORAGE_KEYS.cards)) as Record<string, Card>;
-
-      // Set different due dates
-      cards['problem-1'].fsrs.due = new Date('2024-03-15T12:00:00').getTime(); // Today
-      cards['problem-2'].fsrs.due = new Date('2024-03-17T12:00:00').getTime(); // In 2 days
-      cards['problem-3'].fsrs.due = new Date('2024-03-20T12:00:00').getTime(); // In 5 days
-      await storage.setItem(STORAGE_KEYS.cards, cards);
-
-      const stats = await getNextNDaysStats(7);
-
-      expect(stats[0].count).toBe(1); // problem-1 due today
-      expect(stats[1].count).toBe(0);
-      expect(stats[2].count).toBe(1); // problem-2 due in 2 days
-      expect(stats[3].count).toBe(0);
-      expect(stats[4].count).toBe(0);
-      expect(stats[5].count).toBe(1); // problem-3 due in 5 days
-      expect(stats[6].count).toBe(0);
-    });
-
-    it('should not count paused cards', async () => {
-      // Add cards
-      await addCard(buildProblem({ slug: 'problem-1' }));
-      await addCard(buildProblem({ slug: 'problem-2' }));
-
-      const cards = (await storage.getItem(STORAGE_KEYS.cards)) as Record<string, Card>;
-
-      // Both due today, but one is paused
-      cards['problem-1'].fsrs.due = new Date('2024-03-15T12:00:00').getTime();
-      cards['problem-1'].paused = true;
-      cards['problem-2'].fsrs.due = new Date('2024-03-15T12:00:00').getTime();
-      cards['problem-2'].paused = false;
-      await storage.setItem(STORAGE_KEYS.cards, cards);
-
-      const stats = await getNextNDaysStats(7);
-
-      expect(stats[0].count).toBe(1); // Only the non-paused card
-    });
-
-    it('should handle cards due in the past', async () => {
-      // Add cards due in the past
-      await addCard(buildProblem({ slug: 'problem-1' }));
-      await addCard(buildProblem({ slug: 'problem-2' }));
-
-      const cards = (await storage.getItem(STORAGE_KEYS.cards)) as Record<string, Card>;
-
-      cards['problem-1'].fsrs.due = new Date('2024-03-10T12:00:00').getTime(); // 5 days ago
-      cards['problem-2'].fsrs.due = new Date('2024-03-14T12:00:00').getTime(); // Yesterday
-      await storage.setItem(STORAGE_KEYS.cards, cards);
-
-      const stats = await getNextNDaysStats(7);
-
-      // Both cards are overdue, so they should be counted on the first day (today)
-      expect(stats[0].count).toBe(2);
-      expect(stats[1].count).toBe(0);
-    });
-
-    it('should handle large number of days', async () => {
-      const stats = await getNextNDaysStats(30);
-
-      expect(stats).toHaveLength(30);
-      expect(stats[0].date).toBe('2024-03-15');
-      expect(stats[29].date).toBe('2024-04-13');
-    });
-
-    it('should exclude cards due immediately after the requested window', async () => {
-      await addCard(buildProblem({ slug: 'problem-1' }));
-      const cards = (await storage.getItem(STORAGE_KEYS.cards)) as Record<string, Card>;
-
-      cards['problem-1'].fsrs.due = new Date('2024-03-22T12:00:00').getTime();
-      await storage.setItem(STORAGE_KEYS.cards, cards);
-
-      const stats = await getNextNDaysStats(7);
-
-      expect(stats).toHaveLength(7);
-      expect(stats[0].date).toBe('2024-03-15');
-      expect(stats[6].date).toBe('2024-03-21');
-      expect(stats.every((stat) => stat.count === 0)).toBe(true);
-    });
-
-    it('should return an empty array when zero days are requested', async () => {
-      await expect(getNextNDaysStats(0)).resolves.toEqual([]);
+      expect(await getNextNDaysStats(2)).toEqual([
+        { date: '2024-03-15', count: 2 },
+        { date: '2024-03-16', count: 2 },
+      ]);
     });
 
     it('ignores a legacy day start hour when bucketing upcoming reviews', async () => {
@@ -449,20 +226,6 @@ describe('Stats management', () => {
         { date: '2024-03-15', count: 0 },
         { date: '2024-03-16', count: 1 },
       ]);
-    });
-
-    it('should accumulate active cards due on the same review day', async () => {
-      await addCard(buildProblem({ slug: 'problem-1' }));
-      await addCard(buildProblem({ slug: 'problem-2' }));
-      const cards = (await storage.getItem(STORAGE_KEYS.cards)) as Record<string, Card>;
-
-      cards['problem-1'].fsrs.due = new Date('2024-03-17T09:00:00').getTime();
-      cards['problem-2'].fsrs.due = new Date('2024-03-17T18:00:00').getTime();
-      await storage.setItem(STORAGE_KEYS.cards, cards);
-
-      const stats = await getNextNDaysStats(7);
-
-      expect(stats[2]).toEqual({ date: '2024-03-17', count: 2 });
     });
   });
 });


### PR DESCRIPTION
- Consolidate card and note persistence round trips and remove repeated queue and statistics cases.
- Combine query message checks with result and cache-invalidation coverage.
- Remove duplicate UI rendering, rating, confirmation, and CSS-class assertions while retaining interactions, failure paths, and concurrency tests.
- Preserve the note storage-key compatibility assertion.

Closes #325
