### PR TITLE
test: remove redundant mock clears

### DIFF
--- a/entrypoints/popup/queries/__tests__/cards.test.tsx
+++ b/entrypoints/popup/queries/__tests__/cards.test.tsx
@@ -86,10 +86,6 @@ describe('card mutation invalidation', () => {
 });
 
 describe('usePauseCardMutation', () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
-
   it.each([
     ['pausing', 'two-sum', true],
     ['unpausing', 'three-sum', false],

--- a/entrypoints/popup/queries/__tests__/notes.test.tsx
+++ b/entrypoints/popup/queries/__tests__/notes.test.tsx
@@ -3,7 +3,7 @@
  */
 
 import { renderHook, waitFor } from '@testing-library/react';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { sendMessage } from '@/infrastructure/browser/messages';
 import { createTestWrapper } from '@/test/utils/test-wrapper';
 import { noteQueryKeys, useDeleteNoteMutation, useSaveNoteMutation } from '../notes';
@@ -13,10 +13,6 @@ vi.mock('@/infrastructure/browser/messages', () => ({
 }));
 
 describe('useSaveNoteMutation', () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
-
   it('sends note edits and invalidates the saved card note', async () => {
     const cardId = 'test-card-cache';
     const noteText = '  Solution with whitespace  ';
@@ -45,10 +41,6 @@ describe('useSaveNoteMutation', () => {
 });
 
 describe('useDeleteNoteMutation', () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
-
   it('sends deletion and invalidates the deleted card note', async () => {
     const cardId = 'test-card-delete';
     const { wrapper, queryClient } = createTestWrapper();

--- a/entrypoints/popup/views/home/__tests__/ActionsSection.test.tsx
+++ b/entrypoints/popup/views/home/__tests__/ActionsSection.test.tsx
@@ -3,17 +3,13 @@
  */
 
 import { fireEvent, render, screen } from '@testing-library/react';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { ActionsSection } from '../ActionsSection';
 
 describe('ActionsSection', () => {
   const mockOnDelete = vi.fn();
   const mockOnDelay = vi.fn();
   const mockOnPause = vi.fn();
-
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
 
   const defaultProps = {
     onDelete: mockOnDelete,

--- a/entrypoints/popup/views/home/__tests__/ReviewCard.test.tsx
+++ b/entrypoints/popup/views/home/__tests__/ReviewCard.test.tsx
@@ -31,7 +31,6 @@ describe('ReviewCard', () => {
   };
 
   beforeEach(() => {
-    vi.clearAllMocks();
     vi.mocked(useI18n).mockReturnValue(translations.en);
   });
 

--- a/services/__tests__/cards.test.ts
+++ b/services/__tests__/cards.test.ts
@@ -30,7 +30,6 @@ beforeEach(() => {
 describe('card mutations', () => {
   beforeEach(() => {
     fakeBrowser.reset();
-    vi.clearAllMocks();
   });
 
   it.each(['add', 'rate new', 'rate existing', 'delay', 'pause', 'resume', 'remove'])(
@@ -184,9 +183,6 @@ describe('removeCard', () => {
   });
 
   it('should not call deleteNote when removing non-existent card', async () => {
-    // Clear any previous mock calls
-    vi.clearAllMocks();
-
     // Try to remove a card that doesn't exist
     await removeCard('non-existent-card');
 


### PR DESCRIPTION
- Remove seven mock clears already covered by the shared Vitest configuration, plus four empty hooks and unused imports.
- Preserve the mid-test clear that separates background startup from unrelated-alarm assertions.
- Verified with `npm run check` (858 tests pass).
