### PR TITLE
refactor: remove redundant sync concurrency rejection

### DIFF
--- a/entrypoints/background/__tests__/message-handlers.test.ts
+++ b/entrypoints/background/__tests__/message-handlers.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import { ZodError } from 'zod';
+import type { SyncResult } from '@/domain/gist-sync';
 import { type MessageData, type MessageName, onMessage } from '@/infrastructure/browser/messages';
 import { createNewGist, getGistSyncConfig, setGistSyncConfig, validateGistId } from '@/services/gist-setup';
 import { validatePat } from '@/services/github-auth';
@@ -22,6 +23,37 @@ vi.mock('@/services/github-auth', () => ({ validatePat: vi.fn() }));
 vi.mock('@/services/github-sync', () => ({ getGistSyncStatus: vi.fn(), triggerGistSync: vi.fn() }));
 
 describe('GitHub message contracts', () => {
+  it.each([true, false])('queues a second sync until the first settles (success: %s)', async (success) => {
+    const started = Promise.withResolvers<void>();
+    const release = Promise.withResolvers<void>();
+    const firstResult: SyncResult = success
+      ? { success: true, action: 'no-change', timestamp: 'now' }
+      : { success: false, error: 'Gist not found' };
+    const secondResult: SyncResult = { success: true, action: 'pushed', timestamp: 'later' };
+    vi.mocked(triggerGistSync)
+      .mockImplementationOnce(async () => {
+        started.resolve();
+        await release.promise;
+        return firstResult;
+      })
+      .mockResolvedValueOnce(secondResult);
+    const runner = registerBackgroundMessages(messages, {
+      ready: Promise.resolve(),
+      markDataUpdated: vi.fn(),
+      refreshBadge: vi.fn(),
+    });
+
+    const first = runner.execute(messages.triggerGistSync, undefined);
+    const second = runner.execute(messages.triggerGistSync, undefined);
+    await started.promise;
+    expect(triggerGistSync).toHaveBeenCalledOnce();
+
+    release.resolve();
+    expect(await first).toEqual(firstResult);
+    expect(await second).toEqual(secondResult);
+    expect(triggerGistSync).toHaveBeenCalledTimes(2);
+  });
+
   it('returns combined configuration and forwards partial updates unchanged', async () => {
     const config = { pat: ' token ', gistId: 'gist', enabled: false };
     vi.mocked(getGistSyncConfig).mockResolvedValue(config);

--- a/services/__tests__/github-sync.test.ts
+++ b/services/__tests__/github-sync.test.ts
@@ -119,27 +119,6 @@ describe('github-sync', () => {
       mockGistsGet.mockRejectedValue(new Error(message));
       expect(await triggerGistSync()).toEqual({ success: false, error });
     });
-
-    describe('concurrent sync prevention', () => {
-      it('prevents concurrent syncs and permits another after completion', async () => {
-        const request = Promise.withResolvers<{ data: { files: Record<string, never> } }>();
-        mockGistsGet.mockReturnValue(request.promise);
-        mockExportData.mockResolvedValue('{}');
-        mockGistsUpdate.mockResolvedValue({});
-
-        // Start first sync
-        const firstSync = triggerGistSync();
-
-        // Immediately try second sync
-        const secondSync = await triggerGistSync();
-
-        expect(secondSync).toEqual({ success: false, error: 'Sync already in progress' });
-
-        request.resolve({ data: { files: {} } });
-        expect(await firstSync).toMatchObject({ success: true, action: 'pushed' });
-        expect(await triggerGistSync()).toMatchObject({ success: true, action: 'pushed' });
-      });
-    });
   });
 
   describe('extraction characterization', () => {
@@ -430,7 +409,6 @@ describe('github-sync', () => {
       await started.promise;
 
       expect((await getGistSyncStatus()).syncInProgress).toBe(true);
-      expect(await triggerGistSync()).toEqual({ success: false, error: 'Sync already in progress' });
       request.reject('request failed');
       expect(await syncing).toEqual({ success: false, error: 'Unknown sync error' });
       expect(await getGistSyncStatus()).toMatchObject({ syncInProgress: false, lastError: 'Unknown sync error' });
@@ -443,6 +421,7 @@ describe('github-sync', () => {
       mockExportData.mockResolvedValue('{}');
       mockGistsUpdate.mockResolvedValue({});
       expect(await triggerGistSync()).toMatchObject({ success: true, action: 'pushed' });
+      expect((await getGistSyncStatus()).syncInProgress).toBe(false);
     });
   });
 });

--- a/services/github-sync.ts
+++ b/services/github-sync.ts
@@ -22,10 +22,6 @@ export async function getGistSyncStatus(): Promise<GistSyncStatus> {
 }
 
 export async function triggerGistSync(): Promise<SyncResult> {
-  if (syncInProgress) {
-    return { success: false, error: 'Sync already in progress' };
-  }
-
   syncInProgress = true;
   lastError = null;
 


### PR DESCRIPTION
- Remove the redundant sync concurrency rejection while preserving busy status cleanup.
- Verify queued sync ordering after success and failure; retain shared queue execution.
- Checks: `npm run check` (859 tests passed).

Closes #323
