### PR TITLE
refactor: embed notes in their owning cards

### DIFF
--- a/docs/agents/architecture.md
+++ b/docs/agents/architecture.md
@@ -30,9 +30,9 @@ Before changing background commands or sync execution, read [ADR-0001](../adr/00
 
 ## Storage, backup, and sync
 
-- Cards are slug-keyed, notes reference card UUIDs, and stored card dates are numeric.
+- Cards are slug-keyed with an optional `note` string; absent and empty notes are distinct. Stored card dates are numeric. Note commands still accept card UUIDs and resolve their owners from the cards.
 - Preserve supported card fields, FSRS schedules, notes, stats, settings, and Gist configuration. Unrecognized fields may be discarded; unrelated undecodable records need not survive mutations.
-- Schema changes require a new sequential migration in `infrastructure/storage/migrations.ts`.
+- Schema changes require a new sequential migration in `infrastructure/storage/migrations.ts`. Schema 4 embeds legacy UUID-keyed notes, saves cards before removing legacy keys, and preserves embedded notes on retry. Legacy backups use the same conversion. Keep each winning card and its own note together when resolving duplicates.
 - Infrastructure owns card date codecs, stored-record validation, migrations, and card/note/stat persistence. Persistence adapters do not mark local edits.
 - Domain owns import envelope/configuration validation, settings compatibility, and relationship checks without depending on storage types.
 - Services migrate and validate imports before replacement, then orchestrate reset/restore through shared persistence adapters. Preserve the local PAT and apply imported timestamps after settings writes.

--- a/domain/backup-import.ts
+++ b/domain/backup-import.ts
@@ -60,7 +60,7 @@ export function normalizeImportData(data: BackupImportEnvelope, currentSchema: n
     schemaVersion: importedSchema,
     cards: objectMapSchema.parse(data.data.cards),
     stats: objectMapSchema.parse(data.data.stats),
-    notes: objectMapSchema.parse(data.data.notes),
+    notes: importedSchema < 4 ? objectMapSchema.parse(data.data.notes) : undefined,
     settings: getImportedSettings(data.data.settings),
     gistSync: gistSyncBackupSchema.optional().parse(data.data.gistSync),
     dataUpdatedAt,
@@ -70,7 +70,6 @@ export function normalizeImportData(data: BackupImportEnvelope, currentSchema: n
 export function validateImportRelationships(records: {
   cards: Record<string, Pick<Card, 'id' | 'slug'>>;
   stats: Record<string, Pick<DailyStats, 'date'>>;
-  notes: Record<string, unknown>;
 }): void {
   const cardIds = new Set<string>();
   for (const [slug, card] of Object.entries(records.cards)) {
@@ -80,8 +79,5 @@ export function validateImportRelationships(records: {
   }
   for (const [date, stats] of Object.entries(records.stats)) {
     if (stats.date !== date) throw new Error(`Stats date does not match key: ${date}`);
-  }
-  for (const id of Object.keys(records.notes)) {
-    if (!cardIds.has(id)) throw new Error(`Note has no owning card: ${id}`);
   }
 }

--- a/domain/cards.ts
+++ b/domain/cards.ts
@@ -1,5 +1,6 @@
 import { type CardInput, State } from 'ts-fsrs';
 import { z } from 'zod';
+import { noteSchema } from './notes';
 import { ratingSchema } from './ratings';
 
 const nonemptyString = z.string().refine((value) => value.trim().length > 0, {
@@ -45,5 +46,6 @@ export const cardSchema = problemDescriptorSchema.extend({
   createdAt: epochMilliseconds,
   fsrs: fsrsCardSchema,
   paused: z.boolean(),
+  note: noteSchema.shape.text.optional(),
 });
 export type Card = z.infer<typeof cardSchema>;

--- a/entrypoints/background/__tests__/execution.test.ts
+++ b/entrypoints/background/__tests__/execution.test.ts
@@ -271,6 +271,7 @@ it.each(invalidPayloads)('rejects invalid %s input before mutation and recovers 
   await expect(dispatch(name, invalid)).rejects.toBeInstanceOf(ZodError);
   expect(writes).not.toHaveBeenCalled();
   expect(badge).not.toHaveBeenCalled();
-  await dispatch('saveNote', { cardId: 'card', text: 'after failure', extra: true });
-  expect(await dispatch('getNote', { cardId: 'card' })).toEqual({ text: 'after failure' });
+  const card = await cards.addCard(problem);
+  await dispatch('saveNote', { cardId: card.id, text: 'after failure', extra: true });
+  expect(await dispatch('getNote', { cardId: card.id })).toEqual({ text: 'after failure' });
 });

--- a/infrastructure/storage/__tests__/migrations.test.ts
+++ b/infrastructure/storage/__tests__/migrations.test.ts
@@ -41,7 +41,7 @@ describe('migrations', () => {
       expect(migrateBackupData(data, schemaVersion)).toEqual(data);
     });
 
-    it.each([-1, 0.5, 4])('rejects unsupported schema %s', (schemaVersion) => {
+    it.each([-1, 0.5, 5])('rejects unsupported schema %s', (schemaVersion) => {
       expect(() => migrateBackupData({ cards: {} }, schemaVersion)).toThrow('Unsupported schema version');
     });
   });
@@ -219,6 +219,59 @@ describe('migrations', () => {
     });
   });
 
+  describe('migration v4: embed notes', () => {
+    it.each(['cards', 'cleanup', 'version', 'none'])(
+      'preserves configured learning data and retries after %s failure',
+      async (failure) => {
+        await setSchemaVersion(3);
+        const card = createMockCard(State.Review, { id: 'owner', slug: 'two-sum', paused: true });
+        const empty = createMockCard(State.Learning, { id: 'empty', slug: 'empty', domain: 'leetcode.cn' });
+        const absent = createMockCard(State.New, { id: 'absent', slug: 'absent' });
+        await storage.setItem(STORAGE_KEYS.cards, { 'two-sum': card, empty, absent });
+        await storage.setItem('local:leetsrs:notes:owner', { text: 'Keep the full schedule' });
+        await storage.setItem('local:leetsrs:notes:empty', { text: '' });
+        await storage.setItem('local:leetsrs:notes:orphan', { text: 'Obsolete' });
+        await storage.setItem(STORAGE_KEYS.theme, 'dark');
+        await storage.setItem(STORAGE_KEYS.gistId, 'configured-gist');
+        await storage.setItem(STORAGE_KEYS.dataUpdatedAt, '2024-01-01T00:00:00.000Z');
+        const settings = await fakeBrowser.storage.sync.get(null);
+        const write = storage.setItem.bind(storage);
+        const writes = vi.spyOn(storage, 'setItem').mockImplementation(async (key, value) => {
+          if (
+            (failure === 'cards' && key === STORAGE_KEYS.cards) ||
+            (failure === 'version' && key === STORAGE_KEYS.schemaVersion)
+          )
+            throw new Error('write failed');
+          await write(key, value);
+        });
+        const cleanup = vi.spyOn(storage, 'removeItems');
+        if (failure === 'cleanup') cleanup.mockRejectedValueOnce(new Error('cleanup failed'));
+        try {
+          if (failure !== 'none') {
+            await expect(runStartupMigrations()).rejects.toThrow('Failed to run migration 4');
+            expect(await getCurrentSchemaVersion()).toBe(3);
+          }
+        } finally {
+          writes.mockRestore();
+          cleanup.mockRestore();
+        }
+        await runStartupMigrations();
+        await runStartupMigrations();
+        expect(await getAllCards()).toEqual([
+          { ...card, note: 'Keep the full schedule' },
+          { ...empty, note: '' },
+          absent,
+        ]);
+        expect(await getCurrentSchemaVersion()).toBe(4);
+        expect(await fakeBrowser.storage.sync.get(null)).toEqual(settings);
+        expect(await storage.getItem(STORAGE_KEYS.dataUpdatedAt)).toBe('2024-01-01T00:00:00.000Z');
+        expect(
+          Object.keys(await fakeBrowser.storage.local.get(null)).filter((key) => key.startsWith('leetsrs:notes'))
+        ).toEqual([]);
+      }
+    );
+  });
+
   describe('migration v1: add domain to cards', () => {
     it('changes only missing domains while preserving schedules, pause state, notes, and unrelated storage', async () => {
       const { domain: _domain, ...legacyCard } = createMockCard(State.Review, {
@@ -235,22 +288,25 @@ describe('migrations', () => {
         }),
       };
       await storage.setItem(STORAGE_KEYS.cards, cards);
-      await storage.setItem(`${STORAGE_KEYS.notes}:legacy-id`, { text: 'Keep this note' });
-      await storage.setItem(`${STORAGE_KEYS.notes}:cn-id`, { text: 'Keep this too' });
+      await storage.setItem(`local:leetsrs:notes:legacy-id`, { text: 'Keep this note' });
+      await storage.setItem(`local:leetsrs:notes:cn-id`, { text: 'Keep this too' });
       await storage.setItem(STORAGE_KEYS.theme, 'dark');
       await storage.setItem(STORAGE_KEYS.dataUpdatedAt, '2024-01-01T00:00:00.000Z');
       const before = await fakeBrowser.storage.local.get(null);
 
       await runStartupMigrations();
 
-      expect(await getAllCards()).toEqual([{ ...legacyCard, domain: 'leetcode.com' }, cards['add-two-numbers']]);
+      expect(await getAllCards()).toEqual([
+        { ...legacyCard, domain: 'leetcode.com', note: 'Keep this note' },
+        { ...cards['add-two-numbers'], note: 'Keep this too' },
+      ]);
       expect(await fakeBrowser.storage.local.get(null)).toEqual({
-        ...before,
+        [STORAGE_KEYS.dataUpdatedAt.slice('local:'.length)]: before['leetsrs:dataUpdatedAt'],
         [STORAGE_KEYS.cards.slice('local:'.length)]: {
-          ...cards,
-          'two-sum': { ...cards['two-sum'], domain: 'leetcode.com' },
+          'two-sum': { ...cards['two-sum'], domain: 'leetcode.com', note: 'Keep this note' },
+          'add-two-numbers': { ...cards['add-two-numbers'], note: 'Keep this too' },
         },
-        [STORAGE_KEYS.schemaVersion.slice('local:'.length)]: 3,
+        [STORAGE_KEYS.schemaVersion.slice('local:'.length)]: 4,
       });
     });
 
@@ -286,8 +342,8 @@ describe('migrations', () => {
         }),
       };
       await storage.setItem(STORAGE_KEYS.cards, cards);
-      await storage.setItem(`${STORAGE_KEYS.notes}:legacy-id`, { text: 'Keep this note' });
-      await storage.setItem(`${STORAGE_KEYS.notes}:cn-id`, { text: 'Keep this too' });
+      await storage.setItem(`local:leetsrs:notes:legacy-id`, { text: 'Keep this note' });
+      await storage.setItem(`local:leetsrs:notes:cn-id`, { text: 'Keep this too' });
       await storage.setItem(STORAGE_KEYS.theme, 'dark');
       await storage.setItem(STORAGE_KEYS.dataUpdatedAt, '2024-01-01T00:00:00.000Z');
       const before = await fakeBrowser.storage.local.get(null);
@@ -315,15 +371,19 @@ describe('migrations', () => {
       await runStartupMigrations();
 
       expect(await fakeBrowser.storage.local.get(null)).toEqual({
-        ...expectedAfterCardWrite,
-        [STORAGE_KEYS.schemaVersion.slice('local:'.length)]: 3,
+        'leetsrs:dataUpdatedAt': before['leetsrs:dataUpdatedAt'],
+        'leetsrs:cards': {
+          'two-sum': { ...cards['two-sum'], domain: 'leetcode.com', note: 'Keep this note' },
+          'add-two-numbers': { ...cards['add-two-numbers'], note: 'Keep this too' },
+        },
+        [STORAGE_KEYS.schemaVersion.slice('local:'.length)]: 4,
       });
     });
 
     it('should handle empty or missing cards storage', async () => {
       await runStartupMigrations();
 
-      expect(await getCurrentSchemaVersion()).toBe(3);
+      expect(await getCurrentSchemaVersion()).toBe(4);
     });
   });
 
@@ -342,11 +402,11 @@ describe('migrations', () => {
       await runStartupMigrations();
       await runStartupMigrations();
 
-      expect(await getCurrentSchemaVersion()).toBe(3);
+      expect(await getCurrentSchemaVersion()).toBe(4);
       expect(await fakeBrowser.storage.sync.get(null)).toEqual(remainingSettings);
       expect(await fakeBrowser.storage.local.get(null)).toEqual({
         ...localBefore,
-        'leetsrs:schemaVersion': 3,
+        'leetsrs:schemaVersion': 4,
       });
     });
 
@@ -359,7 +419,7 @@ describe('migrations', () => {
         expect(await getCurrentSchemaVersion()).toBe(2);
         await runStartupMigrations();
         expect(await storage.getItem('sync:leetsrs:dayStartHour')).toBeNull();
-        expect(await getCurrentSchemaVersion()).toBe(3);
+        expect(await getCurrentSchemaVersion()).toBe(4);
       } finally {
         remove.mockRestore();
       }
@@ -373,7 +433,7 @@ describe('migrations', () => {
 
       await runStartupMigrations();
 
-      expect(await getCurrentSchemaVersion()).toBe(3);
+      expect(await getCurrentSchemaVersion()).toBe(4);
       expect(await storage.getItem(STORAGE_KEYS.theme)).toBe('dark');
     });
   });

--- a/infrastructure/storage/__tests__/notes.test.ts
+++ b/infrastructure/storage/__tests__/notes.test.ts
@@ -1,9 +1,12 @@
+import { State } from 'ts-fsrs';
 import { beforeEach, describe, expect, it } from 'vitest';
 import { fakeBrowser } from 'wxt/testing/fake-browser';
 import { storage } from 'wxt/utils/storage';
 import { ZodError } from 'zod';
 import { NOTES_MAX_LENGTH } from '@/domain/notes';
-import { getNoteStorageKey } from '@/infrastructure/storage/storage-keys';
+import { STORAGE_KEYS } from '@/infrastructure/storage/storage-keys';
+import { createMockCard } from '@/test/utils/card-mocks';
+import { getAllCards, saveCards } from '../cards';
 import { deleteNote, getNote, saveNote } from '../notes';
 
 describe('Note persistence', () => {
@@ -12,20 +15,25 @@ describe('Note persistence', () => {
     fakeBrowser.reset();
   });
 
-  it.each([{ text: 'a'.repeat(NOTES_MAX_LENGTH + 1) }, { text: 42 }, {}, [], false])(
+  it.each(['a'.repeat(NOTES_MAX_LENGTH + 1), 42, {}, [], false, null].map((note) => ({ note })))(
     'rejects invalid stored note %j',
-    async (note) => {
-      await storage.setItem(getNoteStorageKey('invalid'), note);
+    async ({ note }) => {
+      await storage.setItem(STORAGE_KEYS.cards, {
+        invalid: { ...createMockCard(State.New, { id: 'invalid', slug: 'invalid' }), note },
+      });
       await expect(getNote('invalid')).rejects.toBeInstanceOf(ZodError);
     }
   );
 
   it('strips unknown stored fields without trimming text', async () => {
-    await storage.setItem(getNoteStorageKey('extra'), { text: '  note  ', extra: true });
+    await storage.setItem(STORAGE_KEYS.cards, {
+      extra: { ...createMockCard(State.New, { id: 'extra', slug: 'extra' }), note: '  note  ', extra: true },
+    });
     expect(await getNote('extra')).toEqual({ text: '  note  ' });
   });
 
   it.each([false, true])('rejects overlong writes without changing storage (existing note: %s)', async (existing) => {
+    await saveCards([createMockCard(State.New, { id: 'card' })]);
     const text = 'a'.repeat(NOTES_MAX_LENGTH);
     if (existing) await saveNote('card', text);
     await expect(saveNote('card', 'b'.repeat(NOTES_MAX_LENGTH + 1))).rejects.toThrow(
@@ -34,20 +42,32 @@ describe('Note persistence', () => {
     expect(await getNote('card')).toEqual(existing ? { text } : null);
   });
 
+  it('does not create notes for missing cards', async () => {
+    await expect(saveNote('missing', 'note')).rejects.toThrow('not found');
+    await deleteNote('missing');
+    expect(await getNote('missing')).toBeNull();
+    expect(await getAllCards()).toEqual([]);
+  });
+
   it('round-trips notes independently through creation, replacement, and deletion', async () => {
+    const first = createMockCard(State.Review, { id: 'first-card', slug: 'first' });
+    const second = createMockCard(State.New, { id: 'second-card', slug: 'second' });
+    await saveCards([first, second]);
     expect(await getNote('first-card')).toBeNull();
     await saveNote('first-card', 'Original solution');
     await saveNote('second-card', 'Other solution');
     expect(await getNote('first-card')).toEqual({ text: 'Original solution' });
     expect(await getNote('second-card')).toEqual({ text: 'Other solution' });
 
+    await saveNote('first-card', '');
+    expect(await getNote('first-card')).toEqual({ text: '' });
     await saveNote('first-card', 'Revised solution');
     expect(await getNote('first-card')).toEqual({ text: 'Revised solution' });
     expect(await getNote('second-card')).toEqual({ text: 'Other solution' });
 
     await deleteNote('first-card');
     expect(await getNote('first-card')).toBeNull();
-    expect(await storage.getItem(getNoteStorageKey('first-card'))).toBeNull();
+    expect(await getAllCards()).toEqual([first, { ...second, note: 'Other solution' }]);
     expect(await getNote('second-card')).toEqual({ text: 'Other solution' });
 
     await expect(deleteNote('first-card')).resolves.toBeUndefined();

--- a/infrastructure/storage/__tests__/storage-keys.test.ts
+++ b/infrastructure/storage/__tests__/storage-keys.test.ts
@@ -1,8 +1,0 @@
-import { expect, it } from 'vitest';
-import { getNoteStorageKey } from '../storage-keys';
-
-it('preserves the persisted note key format', () => {
-  expect(getNoteStorageKey('a1b2c3d4-e5f6-7890-abcd-ef1234567890')).toBe(
-    'local:leetsrs:notes:a1b2c3d4-e5f6-7890-abcd-ef1234567890'
-  );
-});

--- a/infrastructure/storage/backup.ts
+++ b/infrastructure/storage/backup.ts
@@ -2,14 +2,12 @@ import { z } from 'zod';
 import { backupMetadataSchema } from '@/domain/backup-import';
 import { cardSchema } from '@/domain/cards';
 import { gistSyncBackupSchema } from '@/domain/gist-sync';
-import { noteSchema } from '@/domain/notes';
 import { settingsUpdateSchema } from '@/domain/settings';
 import { dailyStatsSchema } from '@/domain/statistics';
 
 const backupRecordsSchema = z.object({
   cards: z.record(z.string(), cardSchema),
   stats: z.record(z.string(), dailyStatsSchema),
-  notes: z.record(z.string(), noteSchema),
 });
 
 export const exportDataSchema = backupMetadataSchema.extend({

--- a/infrastructure/storage/migrations.ts
+++ b/infrastructure/storage/migrations.ts
@@ -1,14 +1,17 @@
 import type { StorageItemKey } from 'wxt/utils/storage';
 import { storage } from '#imports';
+import { noteSchema } from '@/domain/notes';
 import { STORAGE_KEYS } from './storage-keys';
 
 // Cards may be absent in storage, and legacy records have not yet been validated.
 interface MigrationData {
   cards?: Record<string, unknown>;
+  notes?: Record<string, unknown>;
 }
 
 export interface Migration {
   description: string;
+  migrateStorage?: () => Promise<void>;
   removeKeys?: readonly StorageItemKey[];
   migrate: (data: MigrationData) => MigrationData;
 }
@@ -35,7 +38,7 @@ const migrations: readonly Migration[] = [
           return [slug, { ...card, domain: 'leetcode.com' }];
         })
       );
-      return { cards };
+      return { ...data, cards };
     },
   },
   {
@@ -47,7 +50,39 @@ const migrations: readonly Migration[] = [
     migrate: (data: MigrationData): MigrationData => data,
     removeKeys: ['sync:leetsrs:dayStartHour'],
   },
+  {
+    description: 'Embed notes in their owning cards',
+    migrate: embedNotes,
+    migrateStorage: async () => {
+      const snapshot = await storage.snapshot('local');
+      const noteKeys = Object.keys(snapshot).filter((key) => key.startsWith('leetsrs:notes:'));
+      const cards = await storage.getItem<Record<string, unknown>>(STORAGE_KEYS.cards);
+      const migrated = embedNotes({
+        cards: cards ?? undefined,
+        notes: Object.fromEntries(noteKeys.map((key) => [key.slice('leetsrs:notes:'.length), snapshot[key]])),
+      });
+      // Keep legacy notes until their owners are saved. Retrying after cleanup
+      // preserves embedded notes even when some or all legacy keys are gone.
+      if (migrated.cards !== undefined) await storage.setItem(STORAGE_KEYS.cards, migrated.cards);
+      await storage.removeItems([...noteKeys.map((key): StorageItemKey => `local:${key}`), 'local:leetsrs:notes']);
+    },
+  },
 ];
+
+export const CURRENT_SCHEMA_VERSION = migrations.length;
+
+function embedNotes(data: MigrationData): MigrationData {
+  if (!data.cards) return data;
+  const cards = Object.fromEntries(
+    Object.entries(data.cards).map(([slug, card]) => {
+      if (typeof card !== 'object' || card === null || Array.isArray(card)) return [slug, card];
+      if ('note' in card || !('id' in card) || typeof card.id !== 'string') return [slug, card];
+      const note = data.notes && Object.hasOwn(data.notes, card.id) ? data.notes[card.id] : undefined;
+      return [slug, note == null ? card : { ...card, note: noteSchema.parse(note).text }];
+    })
+  );
+  return { cards };
+}
 
 export function migrateBackupData(data: MigrationData, schemaVersion: number): MigrationData {
   if (!Number.isInteger(schemaVersion) || schemaVersion < 0 || schemaVersion > migrations.length) {
@@ -65,14 +100,18 @@ export async function runStartupMigrations(steps: readonly Migration[] = migrati
   for (const [index, migration] of steps.slice(currentVersion).entries()) {
     const version = currentVersion + index + 1;
     try {
-      const cards = await storage.getItem<Record<string, unknown>>(STORAGE_KEYS.cards);
-      const data = { cards: cards ?? undefined };
-      const migrated = migration.migrate(data);
-      if (migrated.cards !== undefined) {
-        await storage.setItem(STORAGE_KEYS.cards, migrated.cards);
-      }
-      if (migration.removeKeys) {
-        await storage.removeItems([...migration.removeKeys]);
+      if (migration.migrateStorage) {
+        await migration.migrateStorage();
+      } else {
+        const cards = await storage.getItem<Record<string, unknown>>(STORAGE_KEYS.cards);
+        const data = { cards: cards ?? undefined };
+        const migrated = migration.migrate(data);
+        if (migrated.cards !== undefined) {
+          await storage.setItem(STORAGE_KEYS.cards, migrated.cards);
+        }
+        if (migration.removeKeys) {
+          await storage.removeItems([...migration.removeKeys]);
+        }
       }
       await setSchemaVersion(version);
     } catch (error) {

--- a/infrastructure/storage/notes.ts
+++ b/infrastructure/storage/notes.ts
@@ -1,30 +1,24 @@
-import { storage } from '#imports';
-import type { Card } from '@/domain/cards';
 import { type Note, noteSchema } from '@/domain/notes';
-import { getNoteStorageKey } from './storage-keys';
+import { getAllCards, saveCards } from './cards';
 
 export async function getNote(cardId: string): Promise<Note | null> {
-  const key = getNoteStorageKey(cardId);
-  const note = await storage.getItem<unknown>(key);
-  return note == null ? null : noteSchema.parse(note);
+  const card = (await getAllCards()).find((card) => card.id === cardId);
+  return card?.note === undefined ? null : { text: card.note };
 }
 
 export async function saveNote(cardId: string, text: string): Promise<void> {
-  const key = getNoteStorageKey(cardId);
   const note = noteSchema.parse({ text });
-  await storage.setItem(key, note);
+  const cards = await getAllCards();
+  const card = cards.find((card) => card.id === cardId);
+  if (!card) throw new Error(`Card with ID "${cardId}" not found`);
+  card.note = note.text;
+  await saveCards(cards);
 }
 
 export async function deleteNote(cardId: string): Promise<void> {
-  const key = getNoteStorageKey(cardId);
-  await storage.removeItem(key);
-}
-
-export async function getNotesForCards(cards: Pick<Card, 'id'>[]): Promise<Record<string, Note>> {
-  const notes: Record<string, Note> = {};
-  for (const card of cards) {
-    const note = await getNote(card.id);
-    if (note) notes[card.id] = note;
-  }
-  return notes;
+  const cards = await getAllCards();
+  const card = cards.find((card) => card.id === cardId);
+  if (!card || card.note === undefined) return;
+  delete card.note;
+  await saveCards(cards);
 }

--- a/infrastructure/storage/storage-keys.ts
+++ b/infrastructure/storage/storage-keys.ts
@@ -1,7 +1,6 @@
 export const STORAGE_KEYS = {
   cards: 'local:leetsrs:cards',
   stats: 'local:leetsrs:stats',
-  notes: 'local:leetsrs:notes',
   maxNewCardsPerDay: 'sync:leetsrs:maxNewCardsPerDay',
   theme: 'sync:leetsrs:theme',
   resetEditorOnEveryProblem: 'sync:leetsrs:autoClearLeetcode',
@@ -20,7 +19,3 @@ export const STORAGE_KEYS = {
 } as const;
 
 export type StorageKey = (typeof STORAGE_KEYS)[keyof typeof STORAGE_KEYS];
-
-export function getNoteStorageKey(cardId: string): `local:leetsrs:notes:${string}` {
-  return `${STORAGE_KEYS.notes}:${cardId}`;
-}

--- a/services/__tests__/cards.test.ts
+++ b/services/__tests__/cards.test.ts
@@ -4,7 +4,6 @@ import { fakeBrowser } from 'wxt/testing/fake-browser';
 import { storage } from 'wxt/utils/storage';
 import type { Card } from '@/domain/cards';
 import type { DailyStats } from '@/domain/statistics';
-import * as notesModule from '@/infrastructure/storage/notes';
 import { STORAGE_KEYS } from '@/infrastructure/storage/storage-keys';
 import { requireDefined } from '@/test/utils/assertions';
 import { buildProblem, createMockCard } from '@/test/utils/card-mocks';
@@ -12,11 +11,6 @@ import { buildSettings } from '@/test/utils/settings-mocks';
 import { addCard, delayCard, getAllCards, getReviewQueue, rateCard, removeCard, setPauseStatus } from '../cards';
 
 const { mockGetSettings } = vi.hoisted(() => ({ mockGetSettings: vi.fn() }));
-
-// Mock the notes module
-vi.mock('@/infrastructure/storage/notes', () => ({
-  deleteNote: vi.fn(),
-}));
 
 // Mock the settings module
 vi.mock('../settings', () => ({
@@ -36,11 +30,20 @@ describe('card mutations', () => {
     '%s retains other supported cards and their learning data',
     async (operation) => {
       const others = [
-        createMockCard(FsrsState.Review, { slug: 'reviewed', domain: 'leetcode.cn', paused: true }),
-        createMockCard(FsrsState.Relearning, { slug: 'relearning' }),
+        createMockCard(FsrsState.Review, {
+          slug: 'reviewed',
+          domain: 'leetcode.cn',
+          paused: true,
+          note: 'Keep this note',
+        }),
+        createMockCard(FsrsState.Relearning, { slug: 'relearning', note: '' }),
       ];
       const problem = buildProblem();
-      const target = createMockCard(FsrsState.Review, { ...problem, paused: operation === 'resume' });
+      const target = createMockCard(FsrsState.Review, {
+        ...problem,
+        paused: operation === 'resume',
+        note: 'Target solution',
+      });
       const initial = operation === 'add' || operation === 'rate new' ? others : [...others, target];
       await storage.setItem(STORAGE_KEYS.cards, Object.fromEntries(initial.map((card) => [card.slug, card])));
 
@@ -67,10 +70,8 @@ describe('card mutations', () => {
       const reloaded = await getAllCards();
       expect(reloaded.filter((card) => card.slug !== problem.slug)).toEqual(others);
       expect(reloaded).toHaveLength(operation === 'remove' ? 2 : 3);
-      if (operation === 'remove') {
-        expect(notesModule.deleteNote).toHaveBeenCalledExactlyOnceWith(target.id);
-      } else {
-        expect(notesModule.deleteNote).not.toHaveBeenCalled();
+      if (['rate existing', 'delay', 'pause', 'resume'].includes(operation)) {
+        expect(reloaded.find((card) => card.slug === problem.slug)?.note).toBe('Target solution');
       }
     }
   );
@@ -180,14 +181,6 @@ describe('removeCard', () => {
     // Verify storage is still empty/unchanged
     const cards = await storage.getItem<Record<string, Card>>(STORAGE_KEYS.cards);
     expect(cards || {}).toEqual({});
-  });
-
-  it('should not call deleteNote when removing non-existent card', async () => {
-    // Try to remove a card that doesn't exist
-    await removeCard('non-existent-card');
-
-    // Verify deleteNote was NOT called
-    expect(notesModule.deleteNote).not.toHaveBeenCalled();
   });
 });
 

--- a/services/__tests__/github-sync.test.ts
+++ b/services/__tests__/github-sync.test.ts
@@ -58,8 +58,32 @@ describe('github-sync', () => {
   });
 
   describe('triggerGistSync', () => {
+    it('pushes and restores schema 4 cards with their own embedded notes', async () => {
+      await setSchemaVersion(4);
+      const actual = await vi.importActual<typeof import('../import-export')>('../import-export');
+      const { payload, accepted } = mixedRecordBackup();
+      await actual.importData(JSON.stringify({ ...payload, data: accepted }));
+      await storage.setItem(STORAGE_KEYS.gistId, 'gist123');
+      mockExportData.mockImplementation(actual.exportData);
+      mockImportData.mockImplementation(actual.importData);
+      mockGistsGet.mockResolvedValue({ data: { files: {} } });
+      expect(await triggerGistSync()).toMatchObject({ success: true, action: 'pushed' });
+      const content = mockGistsUpdate.mock.calls[0][0].files['leetsrs-backup.json'].content;
+      const backup = JSON.parse(content);
+      expect(backup.schemaVersion).toBe(4);
+      expect(backup.data).not.toHaveProperty('notes');
+      expect(backup.data.cards['two-sum'].note).toBe('Keep this note');
+      expect(backup.data.cards['cn-problem'].note).toBe('');
+      expect(backup.data.cards['bad-note']).not.toHaveProperty('note');
+      await storage.removeItem(STORAGE_KEYS.cards);
+      await storage.setItem(STORAGE_KEYS.dataUpdatedAt, '2023-01-01T00:00:00.000Z');
+      mockGistsGet.mockResolvedValue({ data: { files: { 'leetsrs-backup.json': { content } } } });
+      expect(await triggerGistSync()).toMatchObject({ success: true, action: 'pulled' });
+      expect(JSON.parse(await actual.exportData()).data.cards).toEqual(backup.data.cards);
+    });
+
     it('rejects an invalid pull without changing local data or sync metadata', async () => {
-      await setSchemaVersion(2);
+      await setSchemaVersion(4);
       const { payload, accepted } = mixedRecordBackup();
       const actual = await vi.importActual<typeof import('../import-export')>('../import-export');
       await actual.importData(JSON.stringify({ ...payload, data: accepted }));

--- a/services/__tests__/import-export.test.ts
+++ b/services/__tests__/import-export.test.ts
@@ -543,7 +543,7 @@ describe('import-export', () => {
         await storage.setItem(STORAGE_KEYS.cards, currentCards);
         await storage.setItem(STORAGE_KEYS.stats, validExportData.data.stats);
         for (const [id, note] of Object.entries(notes)) {
-          await storage.setItem(`local:leetsrs:notes:${id}`, note);
+          await saveNote(id, note.text);
         }
         await storage.setItem(STORAGE_KEYS.theme, 'dark');
         await storage.setItem(STORAGE_KEYS.githubPat, 'existing-pat');
@@ -567,7 +567,9 @@ describe('import-export', () => {
 
     it('rejects notes over 500 characters before replacing any local data', async () => {
       await storage.setItem(STORAGE_KEYS.theme, 'dark');
-      await storage.setItem(`local:leetsrs:notes:${cardUuid}`, { text: 'existing note' });
+      await storage.setItem(STORAGE_KEYS.cards, {
+        'two-sum': { ...validExportData.data.cards['two-sum'], note: 'existing note' },
+      });
       const before = await fakeBrowser.storage.local.get(null);
       const json = JSON.stringify({
         ...validExportData,
@@ -590,7 +592,9 @@ describe('import-export', () => {
       await setSchemaVersion(4);
       await storage.setItem(STORAGE_KEYS.cards, validExportData.data.cards);
       await storage.setItem(STORAGE_KEYS.stats, validExportData.data.stats);
-      await storage.setItem(`local:leetsrs:notes:${cardUuid}`, { text: 'existing note' });
+      await storage.setItem(STORAGE_KEYS.cards, {
+        'two-sum': { ...validExportData.data.cards['two-sum'], note: 'existing note' },
+      });
       for (const [key, value] of Object.entries(validExportData.data.settings)) {
         await storage.setItem(STORAGE_KEYS[key as keyof typeof validExportData.data.settings], value);
       }

--- a/services/__tests__/import-export.test.ts
+++ b/services/__tests__/import-export.test.ts
@@ -3,9 +3,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { fakeBrowser } from 'wxt/testing/fake-browser';
 import { storage } from 'wxt/utils/storage';
 import type { Card } from '@/domain/cards';
-import type { Note } from '@/domain/notes';
 import type { DailyStats } from '@/domain/statistics';
 import { runStartupMigrations, setSchemaVersion } from '@/infrastructure/storage/migrations';
+import { getNote, saveNote } from '@/infrastructure/storage/notes';
 import { STORAGE_KEYS } from '@/infrastructure/storage/storage-keys';
 import { malformedBackupCases, mixedRecordBackup } from '@/test/utils/backup-mocks';
 import { createMockCard } from '@/test/utils/card-mocks';
@@ -15,9 +15,10 @@ import { exportData, importData, prepareImportData, resetAllData } from '../impo
 describe('import-export', () => {
   const legacyMonthlyStatsKey = 'local:leetsrs:monthlyStats';
 
-  beforeEach(() => {
+  beforeEach(async () => {
     fakeBrowser.reset();
     fakeBrowser.runtime.id = 'test';
+    await runStartupMigrations();
   });
 
   afterEach(() => {
@@ -26,12 +27,60 @@ describe('import-export', () => {
     fakeBrowser.reset();
   });
 
+  it('round-trips embedded notes without a separate collection', async () => {
+    await setSchemaVersion(4);
+    const cards = {
+      present: createMockCard(State.Review, { id: 'present', slug: 'present', note: 'solution', paused: true }),
+      empty: createMockCard(State.Learning, { id: 'empty', slug: 'empty', note: '' }),
+      absent: createMockCard(State.New, { id: 'absent', slug: 'absent' }),
+    };
+    await storage.setItem(STORAGE_KEYS.cards, cards);
+    const backup = await exportData();
+    const parsed = JSON.parse(backup);
+    expect(parsed.schemaVersion).toBe(4);
+    expect(parsed.data).not.toHaveProperty('notes');
+    expect(parsed.data.cards).toEqual(cards);
+    await resetAllData();
+    await importData(backup);
+    expect(await storage.getItem(STORAGE_KEYS.cards)).toEqual(cards);
+  });
+
+  it.each(['a'.repeat(501), null, 42])('rejects invalid embedded note %j before replacement', async (note) => {
+    const existing = createMockCard(State.New, { slug: 'existing', note: 'keep' });
+    await storage.setItem(STORAGE_KEYS.cards, { existing });
+    const before = await fakeBrowser.storage.local.get(null);
+    await expect(
+      importData(
+        JSON.stringify({
+          schemaVersion: 4,
+          exportDate: '2024-01-01T00:00:00.000Z',
+          data: { cards: { existing: { ...existing, note } }, stats: {} },
+        })
+      )
+    ).rejects.toThrow();
+    expect(await fakeBrowser.storage.local.get(null)).toEqual(before);
+  });
+
+  it('replaces an existing note with absence and ignores obsolete sidecar notes in schema 4', async () => {
+    const card = createMockCard(State.Review, { slug: 'two-sum', id: 'winner' });
+    await storage.setItem(STORAGE_KEYS.cards, { 'two-sum': { ...card, note: 'old note' } });
+    await importData(
+      JSON.stringify({
+        schemaVersion: 4,
+        exportDate: '2024-01-01T00:00:00.000Z',
+        data: { cards: { 'two-sum': card }, stats: {}, notes: { winner: { text: 'obsolete' } } },
+      })
+    );
+    expect(await storage.getItem(STORAGE_KEYS.cards)).toEqual({ 'two-sum': card });
+  });
+
   describe('exportData', () => {
     it('should export all data with correct structure', async () => {
       const cardUuid = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890';
       const mockCards: Record<string, Card> = {
         'two-sum': {
           id: cardUuid,
+          note: 'Use hash map for O(n) solution',
           slug: 'two-sum',
           name: 'Two Sum',
           leetcodeId: '1',
@@ -62,10 +111,6 @@ describe('import-export', () => {
         },
       };
 
-      const mockNotes: Record<string, Note> = {
-        [cardUuid]: { text: 'Use hash map for O(n) solution' },
-      };
-
       const mockSettings = buildSettings({
         maxNewCardsPerDay: 5,
         theme: 'dark',
@@ -78,7 +123,6 @@ describe('import-export', () => {
       // Set up storage with mock data
       await storage.setItem(STORAGE_KEYS.cards, mockCards);
       await storage.setItem(STORAGE_KEYS.stats, mockStats);
-      await storage.setItem(`${STORAGE_KEYS.notes}:${cardUuid}` as const, mockNotes[cardUuid]);
       await storage.setItem(STORAGE_KEYS.maxNewCardsPerDay, mockSettings.maxNewCardsPerDay);
       await storage.setItem('sync:leetsrs:dayStartHour', 4);
       await storage.setItem(STORAGE_KEYS.theme, mockSettings.theme);
@@ -87,7 +131,6 @@ describe('import-export', () => {
       await storage.setItem(STORAGE_KEYS.badgeEnabled, mockSettings.badgeEnabled);
       await storage.setItem(STORAGE_KEYS.language, mockSettings.language);
 
-      await storage.setItem(`${STORAGE_KEYS.notes}:orphan`, { text: 'orphan note' });
       await storage.setItem(STORAGE_KEYS.githubPat, 'private-pat');
       await storage.setItem(STORAGE_KEYS.gistId, 'exported-gist');
       await storage.setItem(STORAGE_KEYS.gistSyncEnabled, false);
@@ -97,10 +140,10 @@ describe('import-export', () => {
       const result = await exportData();
       const parsed = JSON.parse(result);
 
-      expect(parsed.schemaVersion).toBe(0);
+      expect(parsed.schemaVersion).toBe(4);
       expect(parsed.exportDate).toMatch(/^\d{4}-\d{2}-\d{2}T/);
       expect(parsed.data.stats).toEqual(mockStats);
-      expect(parsed.data.notes).toEqual(mockNotes);
+      expect(parsed.data).not.toHaveProperty('notes');
       expect(parsed.data.settings).toEqual(mockSettings);
       expect(parsed.data.gistSync).toEqual({ gistId: 'exported-gist', enabled: false });
       expect(parsed.dataUpdatedAt).toBe('2024-01-01T00:00:00.000Z');
@@ -116,22 +159,21 @@ describe('import-export', () => {
       const parsed = JSON.parse(result);
 
       expect(parsed).toMatchObject({
-        schemaVersion: 0,
+        schemaVersion: 4,
         exportDate: expect.any(String),
         data: {
           cards: {},
           stats: {},
-          notes: {},
           settings: {},
         },
       });
       expect(parsed.data.monthlyStats).toBeUndefined();
     });
 
-    it('should export schema version 3 after migrations run', async () => {
+    it('should export schema version 4 after migrations run', async () => {
       await runStartupMigrations();
       const parsed = JSON.parse(await exportData());
-      expect(parsed.schemaVersion).toBe(3);
+      expect(parsed.schemaVersion).toBe(4);
     });
 
     it('does not export legacy monthly stats', async () => {
@@ -147,7 +189,7 @@ describe('import-export', () => {
     it.each(['cards', 'stats', 'notes'] as const)(
       'rejects mixed invalid %s during preparation and import without changing storage',
       async (collection) => {
-        await setSchemaVersion(2);
+        await setSchemaVersion(4);
         const { payload, accepted } = mixedRecordBackup();
         await importData(JSON.stringify({ ...payload, data: accepted }));
         await storage.setItem(STORAGE_KEYS.githubPat, 'existing-pat');
@@ -162,7 +204,7 @@ describe('import-export', () => {
     );
 
     it.each([0, undefined])('rejects invalid legacy schema %s records after migration', async (schemaVersion) => {
-      await setSchemaVersion(2);
+      await setSchemaVersion(4);
       const { payload, accepted } = mixedRecordBackup();
       await importData(JSON.stringify({ ...payload, data: accepted }));
       const before = await fakeBrowser.storage.local.get(null);
@@ -176,17 +218,16 @@ describe('import-export', () => {
       expect(await fakeBrowser.storage.local.get(null)).toEqual(before);
     });
 
-    it.each(['slug', 'duplicate', 'date', 'orphan'] as const)(
+    it.each(['slug', 'duplicate', 'date'] as const)(
       'rejects invalid %s relationships before replacement',
       async (kind) => {
-        await setSchemaVersion(2);
+        await setSchemaVersion(4);
         const { payload, accepted } = mixedRecordBackup();
         await importData(JSON.stringify({ ...payload, data: accepted }));
         const before = await fakeBrowser.storage.local.get(null);
         if (kind === 'slug') accepted.cards['two-sum'].slug = 'different';
         if (kind === 'duplicate') accepted.cards['cn-problem'].id = 'valid-com';
         if (kind === 'date') accepted.stats['2024-01-01'].date = '2024-01-02';
-        if (kind === 'orphan') delete (accepted.cards as Record<string, unknown>)['two-sum'];
         await expect(importData(JSON.stringify({ ...payload, data: accepted }))).rejects.toThrow();
         expect(await fakeBrowser.storage.local.get(null)).toEqual(before);
       }
@@ -195,7 +236,7 @@ describe('import-export', () => {
     it.each([undefined, 0, 1705222800000])(
       'round-trips supported records with numeric dates and last_review %s',
       async (lastReview) => {
-        await setSchemaVersion(2);
+        await setSchemaVersion(4);
         const { payload, accepted } = mixedRecordBackup();
         const originalCard = accepted.cards['two-sum'];
         const data = {
@@ -214,10 +255,19 @@ describe('import-export', () => {
         await resetAllData();
         await importData(exported);
         const restored = JSON.parse(await exportData());
-        expect(restored.data).toMatchObject(JSON.parse(JSON.stringify(data)));
-        expect(restored.data.cards).toEqual(JSON.parse(JSON.stringify(data.cards)));
+        expect(restored.data.stats).toEqual(data.stats);
+        expect(restored.data).not.toHaveProperty('notes');
+        expect(restored.data.cards).toEqual(
+          JSON.parse(
+            JSON.stringify({
+              ...data.cards,
+              'two-sum': { ...data.cards['two-sum'], note: 'Keep this note' },
+              'cn-problem': { ...data.cards['cn-problem'], note: '' },
+            })
+          )
+        );
         expect(restored.dataUpdatedAt).toBe(payload.dataUpdatedAt);
-        expect(restored.schemaVersion).toBe(2);
+        expect(restored.schemaVersion).toBe(4);
       }
     );
 
@@ -276,11 +326,11 @@ describe('import-export', () => {
         old: createMockCard(State.New, { id: 'old', slug: 'old' }),
       });
       await storage.setItem(STORAGE_KEYS.stats, { '2023-12-31': { totalReviews: 7 } });
-      await storage.setItem(`${STORAGE_KEYS.notes}:old`, { text: 'old note' });
+      await saveNote('old', 'old note');
       await storage.setItem(STORAGE_KEYS.githubPat, 'existing-pat');
       await storage.setItem(STORAGE_KEYS.gistId, 'old-gist');
       await storage.setItem(STORAGE_KEYS.dataUpdatedAt, '2023-12-31T00:00:00.000Z');
-      await setSchemaVersion(2);
+      await setSchemaVersion(4);
     }
 
     it('propagates schema-read failures without changing existing data', async () => {
@@ -320,7 +370,9 @@ describe('import-export', () => {
         expect(await storage.getItem(STORAGE_KEYS.gistId)).toBe(gistSync?.gistId ?? null);
         expect(await storage.getItem(STORAGE_KEYS.gistSyncEnabled)).toBe(gistSync?.enabled ?? null);
         expect(await storage.getItem(STORAGE_KEYS.githubPat)).toBe('existing-pat');
-        expect(await storage.getItem(STORAGE_KEYS.cards)).toEqual(validExportData.data.cards);
+        expect(await storage.getItem(STORAGE_KEYS.cards)).toEqual({
+          'two-sum': { ...validExportData.data.cards['two-sum'], note: 'Use hash map' },
+        });
       }
     );
 
@@ -350,19 +402,23 @@ describe('import-export', () => {
         })
       );
 
-      expect(await storage.getItem(STORAGE_KEYS.cards)).toEqual(validExportData.data.cards);
+      expect(await storage.getItem(STORAGE_KEYS.cards)).toEqual({
+        'two-sum': { ...validExportData.data.cards['two-sum'], note: 'Use hash map' },
+      });
       expect(await storage.getItem(STORAGE_KEYS.stats)).toEqual(validExportData.data.stats);
-      expect(await storage.getItem(`${STORAGE_KEYS.notes}:${cardUuid}`)).toEqual(validExportData.data.notes[cardUuid]);
-      expect(await storage.getItem(`${STORAGE_KEYS.notes}:old`)).toBeNull();
+      expect(await getNote(cardUuid)).toEqual(validExportData.data.notes[cardUuid]);
+      expect(await getNote('old')).toBeNull();
       expect(await storage.getItem(STORAGE_KEYS.theme)).toBe(validExportData.data.settings.theme);
       expect(await storage.getItem(STORAGE_KEYS.maxNewCardsPerDay)).toBe(
         validExportData.data.settings.maxNewCardsPerDay
       );
       expect(await storage.getItem(STORAGE_KEYS.dataUpdatedAt)).toBe('2024-01-01T00:00:00.000Z');
       expect(await storage.getItem(STORAGE_KEYS.githubPat)).toBe('existing-pat');
-      expect(await storage.getItem(STORAGE_KEYS.schemaVersion)).toBe(2);
+      expect(await storage.getItem(STORAGE_KEYS.schemaVersion)).toBe(4);
       expect(JSON.parse(await exportData()).data).toEqual({
-        ...validExportData.data,
+        cards: { 'two-sum': { ...validExportData.data.cards['two-sum'], note: 'Use hash map' } },
+        stats: validExportData.data.stats,
+        settings: validExportData.data.settings,
         gistSync: { gistId: 'incoming-gist', enabled: false },
       });
     });
@@ -378,22 +434,19 @@ describe('import-export', () => {
       await expect(importData(JSON.stringify(validExportData))).rejects.toBe(failure);
     });
 
-    it.each([
-      STORAGE_KEYS.cards,
-      STORAGE_KEYS.stats,
-      `${STORAGE_KEYS.notes}:${cardUuid}`,
-      STORAGE_KEYS.theme,
-      STORAGE_KEYS.dataUpdatedAt,
-    ])('reports a failed import write to %s', async (failedKey) => {
-      await seedExistingData();
-      const failure = new Error('import write failed');
-      const write = storage.setItem.bind(storage);
-      vi.spyOn(storage, 'setItem').mockImplementation((key, value) =>
-        key === failedKey ? Promise.reject(failure) : write(key, value)
-      );
+    it.each([STORAGE_KEYS.cards, STORAGE_KEYS.stats, STORAGE_KEYS.theme, STORAGE_KEYS.dataUpdatedAt])(
+      'reports a failed import write to %s',
+      async (failedKey) => {
+        await seedExistingData();
+        const failure = new Error('import write failed');
+        const write = storage.setItem.bind(storage);
+        vi.spyOn(storage, 'setItem').mockImplementation((key, value) =>
+          key === failedKey ? Promise.reject(failure) : write(key, value)
+        );
 
-      await expect(importData(JSON.stringify(validExportData))).rejects.toBe(failure);
-    });
+        await expect(importData(JSON.stringify(validExportData))).rejects.toBe(failure);
+      }
+    );
 
     it.each([null, 'existing-pat'])('ignores imported credentials when the local PAT is %s', async (pat) => {
       if (pat !== null) await storage.setItem(STORAGE_KEYS.githubPat, pat);
@@ -433,16 +486,20 @@ describe('import-export', () => {
       it.each([0, undefined, 2, 3])(
         'prepares and imports schema %s cards identically to startup migration',
         async (schemaVersion) => {
+          await setSchemaVersion(0);
           await storage.setItem(STORAGE_KEYS.cards, legacyCards);
           await storage.setItem(STORAGE_KEYS.stats, validExportData.data.stats);
           for (const [id, note] of Object.entries(notes)) {
-            await storage.setItem(`${STORAGE_KEYS.notes}:${id}`, note);
+            await storage.setItem(`local:leetsrs:notes:${id}`, note);
           }
           await storage.setItem(STORAGE_KEYS.theme, 'light');
           await storage.setItem(STORAGE_KEYS.githubPat, 'existing-pat');
           await runStartupMigrations();
           const startupCards = await storage.getItem(STORAGE_KEYS.cards);
-          expect(startupCards).toEqual(currentCards);
+          expect(startupCards).toEqual({
+            'two-sum': { ...currentCards['two-sum'], note: 'Use hash map' },
+            'add-two-numbers': { ...currentCards['add-two-numbers'], note: 'Keep the carry' },
+          });
           const before = await fakeBrowser.storage.local.get(null);
           const json = JSON.stringify({
             ...validExportData,
@@ -459,7 +516,7 @@ describe('import-export', () => {
           const prepared = await prepareImportData(json);
 
           expect.soft(prepared.cards).toEqual(startupCards);
-          expect(prepared.notes).toEqual(notes);
+          expect(prepared).not.toHaveProperty('notes');
           expect(prepared.stats).toEqual(validExportData.data.stats);
           expect(prepared.settings).toEqual(validExportData.data.settings);
           expect(prepared.dataUpdatedAt).toBe(dataUpdatedAt);
@@ -470,23 +527,23 @@ describe('import-export', () => {
           expect.soft(await storage.getItem(STORAGE_KEYS.cards)).toEqual(startupCards);
           expect(await storage.getItem(STORAGE_KEYS.stats)).toEqual(validExportData.data.stats);
           for (const [id, note] of Object.entries(notes)) {
-            expect(await storage.getItem(`${STORAGE_KEYS.notes}:${id}`)).toEqual(note);
+            expect(await getNote(id)).toEqual(note);
           }
           expect(await storage.getItem(STORAGE_KEYS.theme)).toBe('light');
           expect(await storage.getItem(STORAGE_KEYS.githubPat)).toBe('existing-pat');
           expect(await storage.getItem(STORAGE_KEYS.dataUpdatedAt)).toBe(dataUpdatedAt);
-          expect(await storage.getItem(STORAGE_KEYS.schemaVersion)).toBe(3);
+          expect(await storage.getItem(STORAGE_KEYS.schemaVersion)).toBe(4);
           expect(await storage.getItem('sync:leetsrs:dayStartHour')).toBeNull();
           expect(JSON.parse(await exportData()).data.settings).toEqual(validExportData.data.settings);
         }
       );
 
       it('leaves storage untouched when preparing a legacy import fails', async () => {
-        await setSchemaVersion(2);
+        await setSchemaVersion(4);
         await storage.setItem(STORAGE_KEYS.cards, currentCards);
         await storage.setItem(STORAGE_KEYS.stats, validExportData.data.stats);
         for (const [id, note] of Object.entries(notes)) {
-          await storage.setItem(`${STORAGE_KEYS.notes}:${id}`, note);
+          await storage.setItem(`local:leetsrs:notes:${id}`, note);
         }
         await storage.setItem(STORAGE_KEYS.theme, 'dark');
         await storage.setItem(STORAGE_KEYS.githubPat, 'existing-pat');
@@ -510,7 +567,7 @@ describe('import-export', () => {
 
     it('rejects notes over 500 characters before replacing any local data', async () => {
       await storage.setItem(STORAGE_KEYS.theme, 'dark');
-      await storage.setItem(`${STORAGE_KEYS.notes}:${cardUuid}`, { text: 'existing note' });
+      await storage.setItem(`local:leetsrs:notes:${cardUuid}`, { text: 'existing note' });
       const before = await fakeBrowser.storage.local.get(null);
       const json = JSON.stringify({
         ...validExportData,
@@ -530,10 +587,10 @@ describe('import-export', () => {
         JSON.stringify({ ...validExportData, data: { ...validExportData.data, [key]: null } }),
       ]),
     ])('rejects %s during preparation and import without changing storage', async (_name, json) => {
-      await setSchemaVersion(2);
+      await setSchemaVersion(4);
       await storage.setItem(STORAGE_KEYS.cards, validExportData.data.cards);
       await storage.setItem(STORAGE_KEYS.stats, validExportData.data.stats);
-      await storage.setItem(`${STORAGE_KEYS.notes}:${cardUuid}`, { text: 'existing note' });
+      await storage.setItem(`local:leetsrs:notes:${cardUuid}`, { text: 'existing note' });
       for (const [key, value] of Object.entries(validExportData.data.settings)) {
         await storage.setItem(STORAGE_KEYS[key as keyof typeof validExportData.data.settings], value);
       }
@@ -572,7 +629,6 @@ describe('import-export', () => {
         expect(preparedData).toMatchObject({
           cards: parsedLegacyData.data.cards,
           stats: parsedLegacyData.data.stats,
-          notes: parsedLegacyData.data.notes,
           settings: { ...legacySettings, resetEditorOnEveryProblem: true },
           dataUpdatedAt: '2024-01-15T10:00:00.000Z',
         });
@@ -678,18 +734,18 @@ describe('import-export', () => {
       await storage.setItem(STORAGE_KEYS.resetEditorOnDueReview, true);
       await storage.setItem(STORAGE_KEYS.badgeEnabled, true);
       await storage.setItem(STORAGE_KEYS.language, 'en');
-      await storage.setItem(`${STORAGE_KEYS.notes}:${uuid1}` as const, { text: 'note 1' });
-      await storage.setItem(`${STORAGE_KEYS.notes}:${uuid2}` as const, { text: 'note 2' });
+      await saveNote(uuid1, 'note 1');
+      await saveNote(uuid2, 'note 2');
 
       await storage.setItem(STORAGE_KEYS.githubPat, 'existing-pat');
       await storage.setItem(STORAGE_KEYS.dataUpdatedAt, '2024-01-01T00:00:00.000Z');
-      await setSchemaVersion(2);
+      await setSchemaVersion(4);
 
       await resetAllData();
 
       expect(await storage.getItem(STORAGE_KEYS.githubPat)).toBeNull();
       expect(await storage.getItem(STORAGE_KEYS.dataUpdatedAt)).toBeNull();
-      expect(await storage.getItem(STORAGE_KEYS.schemaVersion)).toBe(2);
+      expect(await storage.getItem(STORAGE_KEYS.schemaVersion)).toBe(4);
 
       // Verify all data was removed
       expect(await storage.getItem(STORAGE_KEYS.cards)).toBeNull();
@@ -701,8 +757,8 @@ describe('import-export', () => {
       expect(await storage.getItem(STORAGE_KEYS.resetEditorOnDueReview)).toBeNull();
       expect(await storage.getItem(STORAGE_KEYS.badgeEnabled)).toBeNull();
       expect(await storage.getItem(STORAGE_KEYS.language)).toBeNull();
-      expect(await storage.getItem(`${STORAGE_KEYS.notes}:${uuid1}` as const)).toBeNull();
-      expect(await storage.getItem(`${STORAGE_KEYS.notes}:${uuid2}` as const)).toBeNull();
+      expect(await getNote(uuid1)).toBeNull();
+      expect(await getNote(uuid2)).toBeNull();
     });
   });
 });

--- a/services/__tests__/learning-persistence.test.ts
+++ b/services/__tests__/learning-persistence.test.ts
@@ -3,7 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { fakeBrowser } from 'wxt/testing/fake-browser';
 import { storage } from 'wxt/utils/storage';
 import { getNote, saveNote } from '@/infrastructure/storage/notes';
-import { getNoteStorageKey, STORAGE_KEYS } from '@/infrastructure/storage/storage-keys';
+import { STORAGE_KEYS } from '@/infrastructure/storage/storage-keys';
 import { buildProblem } from '@/test/utils/card-mocks';
 import { buildSettings } from '@/test/utils/settings-mocks';
 import { addCard, getAllCards, rateCard, removeCard } from '../cards';
@@ -85,43 +85,17 @@ describe('learning persistence sequencing', () => {
     }
   );
 
-  it('awaits note deletion before writing the card removal', async () => {
+  it('removes the card and its note together, preserving both when the write fails', async () => {
     const card = await addCard(buildProblem());
     await saveNote(card.id, 'solution');
-    const started = Promise.withResolvers<void>();
-    const deleted = Promise.withResolvers<void>();
-    const removeItem = storage.removeItem.bind(storage);
-    const removal = vi.spyOn(storage, 'removeItem').mockImplementation(async (key) => {
-      started.resolve();
-      await deleted.promise;
-      await removeItem(key);
-    });
-    const writes = vi.spyOn(storage, 'setItem');
-
-    const removing = removeCard(card.slug);
-    await started.promise;
-    expect(removal).toHaveBeenCalledWith(getNoteStorageKey(card.id));
-    expect(writes).not.toHaveBeenCalled();
-    expect(await getAllCards()).toEqual([card]);
-    deleted.resolve();
-    await removing;
-    expect(writes).toHaveBeenCalledExactlyOnceWith(STORAGE_KEYS.cards, {});
+    const write = vi.spyOn(storage, 'setItem').mockRejectedValueOnce(new Error('removal failed'));
+    await expect(removeCard(card.slug)).rejects.toThrow('removal failed');
+    expect(await getAllCards()).toEqual([{ ...card, note: 'solution' }]);
+    expect(await getNote(card.id)).toEqual({ text: 'solution' });
+    write.mockRestore();
+    await removeCard(card.slug);
+    expect(await getAllCards()).toEqual([]);
     expect(await getNote(card.id)).toBeNull();
-  });
-
-  it.each(['note', 'card'])('preserves partial removal state when the %s operation fails', async (failedOperation) => {
-    const card = await addCard(buildProblem());
-    await saveNote(card.id, 'solution');
-    const failure = new Error('removal failed');
-    if (failedOperation === 'note') vi.spyOn(storage, 'removeItem').mockRejectedValueOnce(failure);
-    const writes = vi.spyOn(storage, 'setItem');
-    if (failedOperation === 'card') writes.mockRejectedValueOnce(failure);
-
-    await expect(removeCard(card.slug)).rejects.toBe(failure);
-
-    expect(await getAllCards()).toEqual([card]);
-    expect(await getNote(card.id)).toEqual(failedOperation === 'note' ? { text: 'solution' } : null);
-    expect(writes).toHaveBeenCalledTimes(failedOperation === 'note' ? 0 : 1);
     expect(await storage.getItem(STORAGE_KEYS.dataUpdatedAt)).toBeNull();
   });
 });

--- a/services/cards.ts
+++ b/services/cards.ts
@@ -3,7 +3,6 @@ import { formatLocalDate } from '@/domain/calendar';
 import type { Card, ProblemDescriptor, RateCardInput } from '@/domain/cards';
 import { buildReviewQueue, calculateDelayedDueDate, isDue } from '@/domain/review';
 import { getAllCards, saveCards } from '@/infrastructure/storage/cards';
-import { deleteNote } from '@/infrastructure/storage/notes';
 import { getStatsForDate } from '@/infrastructure/storage/stats';
 import { getSettings } from './settings';
 import { updateStats } from './stats';
@@ -39,11 +38,6 @@ export async function addCard(problem: ProblemDescriptor): Promise<Card> {
 
 export async function removeCard(slug: string): Promise<void> {
   const cards = await getAllCards();
-
-  const card = cards.find((card) => card.slug === slug);
-  if (card) {
-    await deleteNote(card.id);
-  }
 
   await saveCards(cards.filter((card) => card.slug !== slug));
 }

--- a/services/import-export.ts
+++ b/services/import-export.ts
@@ -2,34 +2,33 @@ import { normalizeImportData, validateImportRelationships, validateImportStructu
 import type { ExportData, PreparedImportData } from '@/infrastructure/storage/backup';
 import { validateBackupRecords } from '@/infrastructure/storage/backup';
 import { getAllCards, removeCards, saveCards } from '@/infrastructure/storage/cards';
-import { getCurrentSchemaVersion, migrateBackupData } from '@/infrastructure/storage/migrations';
-import { deleteNote, getNotesForCards, saveNote } from '@/infrastructure/storage/notes';
+import {
+  CURRENT_SCHEMA_VERSION,
+  getCurrentSchemaVersion,
+  migrateBackupData,
+} from '@/infrastructure/storage/migrations';
 import { getStats, removeStats, saveStats } from '@/infrastructure/storage/stats';
 import { readSyncMetadata, removeSyncMetadata, writeSyncMetadata } from '@/infrastructure/storage/sync-metadata';
 import { getGitHubPat, removeGitHubPat, setGitHubPat } from './github-auth';
 import { exportSettings, resetSettings, updateSettings } from './settings';
 
 export async function exportData(): Promise<string> {
-  const cardsPromise = getAllCards();
-  const [cards, stats, notes, settings, gistId, gistSyncEnabled, dataUpdatedAt, schemaVersion] = await Promise.all([
-    cardsPromise,
+  const [cards, stats, settings, gistId, gistSyncEnabled, dataUpdatedAt] = await Promise.all([
+    getAllCards(),
     getStats(),
-    cardsPromise.then((cards) => getNotesForCards(cards)),
     exportSettings(),
     readSyncMetadata('gistId'),
     readSyncMetadata('gistSyncEnabled'),
     readSyncMetadata('dataUpdatedAt'),
-    getCurrentSchemaVersion(),
   ]);
 
   const exportData: ExportData = {
-    schemaVersion,
+    schemaVersion: CURRENT_SCHEMA_VERSION,
     exportDate: new Date().toISOString(),
     dataUpdatedAt: dataUpdatedAt ?? undefined,
     data: {
       cards: Object.fromEntries(cards.map((card) => [card.slug, card])),
       stats,
-      notes,
       settings,
       gistSync: {
         ...(gistId != null && { gistId }),
@@ -52,11 +51,10 @@ export async function prepareImportData(jsonData: string): Promise<PreparedImpor
   validateImportStructure(data);
   const currentSchema = await getCurrentSchemaVersion();
   const { schemaVersion, ...normalizedData } = normalizeImportData(data, currentSchema);
-  const migrated = migrateBackupData({ cards: normalizedData.cards }, schemaVersion);
+  const migrated = migrateBackupData({ cards: normalizedData.cards, notes: normalizedData.notes }, schemaVersion);
   const validRecords = validateBackupRecords({
     cards: migrated.cards,
     stats: normalizedData.stats,
-    notes: normalizedData.notes,
   });
   validateImportRelationships(validRecords);
 
@@ -79,9 +77,6 @@ export async function applyImportData(preparedData: PreparedImportData): Promise
 
   await saveCards(Object.values(preparedData.cards));
   await saveStats(preparedData.stats);
-  for (const [cardId, note] of Object.entries(preparedData.notes)) {
-    await saveNote(cardId, note.text);
-  }
   await updateSettings(preparedData.settings);
 
   if (preparedData.gistSync) {
@@ -102,7 +97,6 @@ export async function importData(jsonData: string): Promise<void> {
 }
 
 export async function resetAllData(): Promise<void> {
-  const cards = await getAllCards();
   await removeCards();
   await removeStats();
   await resetSettings();
@@ -112,8 +106,4 @@ export async function resetAllData(): Promise<void> {
   await removeSyncMetadata('lastSyncTime');
   await removeSyncMetadata('lastSyncDirection');
   await removeSyncMetadata('dataUpdatedAt');
-
-  for (const card of cards) {
-    await deleteNote(card.id);
-  }
 }


### PR DESCRIPTION
- Embed optional note text in cards and remove separate note storage and cleanup.
- Add retryable schema-4 migration, compatible legacy imports, and embedded-note Gist round trips.
- Preserve note editing and full scheduling state; `npm run check` passes (875 tests).

Closes #327
