### PR TITLE
fix: preserve migration data and split definitions

### DIFF
--- a/docs/agents/architecture.md
+++ b/docs/agents/architecture.md
@@ -32,7 +32,7 @@ Before changing background commands or sync execution, read [ADR-0001](../adr/00
 
 - Cards are slug-keyed, notes reference card UUIDs, and stored card dates are numeric.
 - Preserve supported card fields, FSRS schedules, notes, stats, settings, and Gist configuration. Unrecognized fields may be discarded; unrelated undecodable records need not survive mutations.
-- Schema changes require a new sequential migration in `infrastructure/storage/migrations.ts`.
+- Schema changes require a new numbered file in `infrastructure/storage/migrations/`, appended to the ordered list in `infrastructure/storage/migrations.ts`. Each migration defines one pure, idempotent `migrate` transformation shared by startup and backup import; loading, persistence, obsolete-key cleanup, and schema-version advancement stay in the runner.
 - Infrastructure owns card date codecs, stored-record validation, migrations, and card/note/stat persistence. Persistence adapters do not mark local edits.
 - Domain owns import envelope/configuration validation, settings compatibility, and relationship checks without depending on storage types.
 - Services migrate and validate imports before replacement, then orchestrate reset/restore through shared persistence adapters. Preserve the local PAT and apply imported timestamps after settings writes.

--- a/infrastructure/storage/__tests__/migrations.test.ts
+++ b/infrastructure/storage/__tests__/migrations.test.ts
@@ -4,13 +4,8 @@ import { fakeBrowser } from 'wxt/testing/fake-browser';
 import { storage } from 'wxt/utils/storage';
 import { createMockCard } from '@/test/utils/card-mocks';
 import { getAllCards } from '../cards';
-import {
-  getCurrentSchemaVersion,
-  type Migration,
-  migrateBackupData,
-  runStartupMigrations,
-  setSchemaVersion,
-} from '../migrations';
+import { getCurrentSchemaVersion, migrateBackupData, runStartupMigrations, setSchemaVersion } from '../migrations';
+import type { Migration } from '../migrations/types';
 import { STORAGE_KEYS } from '../storage-keys';
 
 describe('migrations', () => {

--- a/infrastructure/storage/__tests__/migrations.test.ts
+++ b/infrastructure/storage/__tests__/migrations.test.ts
@@ -19,11 +19,13 @@ describe('migrations', () => {
   });
 
   describe('migrateBackupData', () => {
-    it('migrates frozen input without changing the input or writing storage', async () => {
+    it('preserves unrelated fields and migrates frozen input without changing it or writing storage', async () => {
       const { domain: _domain, ...legacyCard } = createMockCard(State.Review, { slug: 'two-sum', paused: true });
       const card = Object.freeze(legacyCard);
       const data = Object.freeze({
         cards: Object.freeze({ 'two-sum': card }),
+        notes: Object.freeze({ [card.id]: Object.freeze({ text: 'Keep this note' }) }),
+        settings: Object.freeze({ theme: 'dark' }),
       });
       const before = await fakeBrowser.storage.local.get(null);
       const migrated = migrateBackupData(data, 0);
@@ -39,6 +41,29 @@ describe('migrations', () => {
     it.each([1, 2, 3])('does not reapply the domain migration to schema %s', (schemaVersion) => {
       const data = { cards: { 'two-sum': createMockCard(State.Review, { slug: 'two-sum' }) } };
       expect(migrateBackupData(data, schemaVersion)).toEqual(data);
+    });
+
+    it.each([0, 1, 2])('is idempotent and matches startup for schema %s', async (schemaVersion) => {
+      const cards = {
+        legacy: { domain: '', paused: true },
+        regional: { domain: 'leetcode.cn', extra: 'preserved' },
+        malformed: null,
+      };
+      const expectedCards = {
+        ...cards,
+        legacy: { domain: schemaVersion === 0 ? 'leetcode.com' : '', paused: true },
+      };
+      const migrated = migrateBackupData({ cards }, schemaVersion);
+
+      expect(migrated).toEqual({ cards: expectedCards });
+      expect(migrateBackupData(migrated, schemaVersion)).toEqual(migrated);
+
+      await storage.setItem(STORAGE_KEYS.cards, cards);
+      await setSchemaVersion(schemaVersion);
+      await runStartupMigrations();
+
+      expect(await storage.getItem(STORAGE_KEYS.cards)).toEqual(migrated.cards);
+      expect(await getCurrentSchemaVersion()).toBe(3);
     });
 
     it.each([-1, 0.5, 4])('rejects unsupported schema %s', (schemaVersion) => {
@@ -180,7 +205,7 @@ describe('migrations', () => {
       expect(await getCurrentSchemaVersion()).toBe(1); // Only first migration succeeded
     });
 
-    it('persists each step before advancing its version and starting the next step', async () => {
+    it('persists each step before cleanup, version advancement, and the next step', async () => {
       const versions: number[] = [];
       const first = createMockCard(State.New, { slug: 'first' });
       const second = createMockCard(State.New, { slug: 'second' });
@@ -188,6 +213,7 @@ describe('migrations', () => {
         {
           description: 'First',
           migrate: () => ({ cards: { first } }),
+          removeKeys: ['sync:leetsrs:dayStartHour'],
         },
         {
           description: 'Second',
@@ -202,6 +228,12 @@ describe('migrations', () => {
         if (key === STORAGE_KEYS.cards) versions.push(await getCurrentSchemaVersion());
         return write(key, value);
       });
+      const remove = storage.removeItems.bind(storage);
+      const removals = vi.spyOn(storage, 'removeItems').mockImplementation(async (keys) => {
+        expect(await storage.getItem(STORAGE_KEYS.cards)).toEqual({ first });
+        expect(await getCurrentSchemaVersion()).toBe(0);
+        return remove(keys);
+      });
       try {
         await runStartupMigrations(steps);
 
@@ -213,8 +245,10 @@ describe('migrations', () => {
           STORAGE_KEYS.schemaVersion,
         ]);
         expect(await getCurrentSchemaVersion()).toBe(2);
+        expect(removals).toHaveBeenCalledOnce();
       } finally {
         writes.mockRestore();
+        removals.mockRestore();
       }
     });
   });
@@ -269,6 +303,11 @@ describe('migrations', () => {
       } finally {
         writes.mockRestore();
       }
+
+      await runStartupMigrations();
+
+      expect(await storage.getItem(STORAGE_KEYS.cards)).toEqual(cards);
+      expect(await getCurrentSchemaVersion()).toBe(3);
     });
 
     it('safely retries startup after cards are saved but the schema version write fails', async () => {
@@ -350,19 +389,37 @@ describe('migrations', () => {
       });
     });
 
-    it('retries legacy setting removal before advancing the schema after a storage failure', async () => {
+    it.each(['cleanup', 'version'])('safely retries after a %s failure', async (failedStep) => {
       await setSchemaVersion(2);
+      const cards = { 'two-sum': createMockCard(State.Review, { slug: 'two-sum' }) };
+      await storage.setItem(STORAGE_KEYS.cards, cards);
       await storage.setItem('sync:leetsrs:dayStartHour', 4);
-      const remove = vi.spyOn(storage, 'removeItems').mockRejectedValueOnce(new Error('storage unavailable'));
+      const remove = vi.spyOn(storage, 'removeItems');
+      const write = storage.setItem.bind(storage);
+      const writes = vi.spyOn(storage, 'setItem');
+      if (failedStep === 'cleanup') {
+        remove.mockRejectedValueOnce(new Error('storage unavailable'));
+      } else {
+        writes.mockImplementation(async (key, value) => {
+          if (key === STORAGE_KEYS.schemaVersion) throw new Error('storage unavailable');
+          return write(key, value);
+        });
+      }
       try {
         await expect(runStartupMigrations()).rejects.toThrow('Failed to run migration 3');
         expect(await getCurrentSchemaVersion()).toBe(2);
-        await runStartupMigrations();
-        expect(await storage.getItem('sync:leetsrs:dayStartHour')).toBeNull();
-        expect(await getCurrentSchemaVersion()).toBe(3);
+        expect(await storage.getItem(STORAGE_KEYS.cards)).toEqual(cards);
+        expect(await storage.getItem('sync:leetsrs:dayStartHour')).toBe(failedStep === 'cleanup' ? 4 : null);
       } finally {
         remove.mockRestore();
+        writes.mockRestore();
       }
+
+      await runStartupMigrations();
+
+      expect(await storage.getItem('sync:leetsrs:dayStartHour')).toBeNull();
+      expect(await storage.getItem(STORAGE_KEYS.cards)).toEqual(cards);
+      expect(await getCurrentSchemaVersion()).toBe(3);
     });
   });
 

--- a/infrastructure/storage/migrations.ts
+++ b/infrastructure/storage/migrations.ts
@@ -1,17 +1,11 @@
-import type { StorageItemKey } from 'wxt/utils/storage';
 import { storage } from '#imports';
+import { addCardDomainMigration } from './migrations/001-add-card-domain';
+import { addSystemThemeMigration } from './migrations/002-add-system-theme';
+import { removeDayStartMigration } from './migrations/003-remove-day-start';
+import type { Migration, MigrationData } from './migrations/types';
 import { STORAGE_KEYS } from './storage-keys';
 
-// Cards may be absent in storage, and legacy records have not yet been validated.
-interface MigrationData {
-  cards?: Record<string, unknown>;
-}
-
-export interface Migration {
-  description: string;
-  removeKeys?: readonly StorageItemKey[];
-  migrate: (data: MigrationData) => MigrationData;
-}
+export type { Migration } from './migrations/types';
 
 export async function getCurrentSchemaVersion(): Promise<number> {
   return (await storage.getItem<number>(STORAGE_KEYS.schemaVersion)) ?? 0;
@@ -22,32 +16,7 @@ export async function setSchemaVersion(version: number): Promise<void> {
 }
 
 // Append only: index + 1 is the schema version. Never reorder or remove entries.
-const migrations: readonly Migration[] = [
-  {
-    description: 'Add domain field to existing cards, defaulting to leetcode.com',
-    migrate: (data: MigrationData): MigrationData => {
-      if (!data.cards) return data;
-      const cards = Object.fromEntries(
-        Object.entries(data.cards).map(([slug, card]) => {
-          // Leave malformed records for record validation after migration.
-          if (typeof card !== 'object' || card === null || Array.isArray(card)) return [slug, card];
-          if ('domain' in card && card.domain) return [slug, card];
-          return [slug, { ...card, domain: 'leetcode.com' }];
-        })
-      );
-      return { cards };
-    },
-  },
-  {
-    description: 'Add system theme preference',
-    migrate: (data: MigrationData): MigrationData => data,
-  },
-  {
-    description: 'Remove configurable day start',
-    migrate: (data: MigrationData): MigrationData => data,
-    removeKeys: ['sync:leetsrs:dayStartHour'],
-  },
-];
+const migrations: readonly Migration[] = [addCardDomainMigration, addSystemThemeMigration, removeDayStartMigration];
 
 export function migrateBackupData(data: MigrationData, schemaVersion: number): MigrationData {
   if (!Number.isInteger(schemaVersion) || schemaVersion < 0 || schemaVersion > migrations.length) {

--- a/infrastructure/storage/migrations.ts
+++ b/infrastructure/storage/migrations.ts
@@ -5,8 +5,6 @@ import { removeDayStartMigration } from './migrations/003-remove-day-start';
 import type { Migration, MigrationData } from './migrations/types';
 import { STORAGE_KEYS } from './storage-keys';
 
-export type { Migration } from './migrations/types';
-
 export async function getCurrentSchemaVersion(): Promise<number> {
   return (await storage.getItem<number>(STORAGE_KEYS.schemaVersion)) ?? 0;
 }

--- a/infrastructure/storage/migrations/001-add-card-domain.ts
+++ b/infrastructure/storage/migrations/001-add-card-domain.ts
@@ -1,0 +1,19 @@
+import type { Migration, MigrationData } from './types';
+
+function addCardDomain(data: MigrationData): MigrationData {
+  if (!data.cards) return data;
+  const cards = Object.fromEntries(
+    Object.entries(data.cards).map(([slug, card]) => {
+      // Leave malformed records for record validation after migration.
+      if (typeof card !== 'object' || card === null || Array.isArray(card)) return [slug, card];
+      if ('domain' in card && card.domain) return [slug, card];
+      return [slug, { ...card, domain: 'leetcode.com' }];
+    })
+  );
+  return { ...data, cards };
+}
+
+export const addCardDomainMigration: Migration = {
+  description: 'Add domain field to existing cards, defaulting to leetcode.com',
+  migrate: addCardDomain,
+};

--- a/infrastructure/storage/migrations/002-add-system-theme.ts
+++ b/infrastructure/storage/migrations/002-add-system-theme.ts
@@ -1,0 +1,6 @@
+import type { Migration } from './types';
+
+export const addSystemThemeMigration: Migration = {
+  description: 'Add system theme preference',
+  migrate: (data) => data,
+};

--- a/infrastructure/storage/migrations/003-remove-day-start.ts
+++ b/infrastructure/storage/migrations/003-remove-day-start.ts
@@ -1,0 +1,7 @@
+import type { Migration } from './types';
+
+export const removeDayStartMigration: Migration = {
+  description: 'Remove configurable day start',
+  migrate: (data) => data,
+  removeKeys: ['sync:leetsrs:dayStartHour'],
+};

--- a/infrastructure/storage/migrations/types.ts
+++ b/infrastructure/storage/migrations/types.ts
@@ -1,0 +1,12 @@
+import type { StorageItemKey } from 'wxt/utils/storage';
+
+// Cards may be absent in storage, and legacy records have not yet been validated.
+export interface MigrationData {
+  cards?: Record<string, unknown>;
+}
+
+export interface Migration {
+  description: string;
+  removeKeys?: readonly StorageItemKey[];
+  migrate: (data: MigrationData) => MigrationData;
+}


### PR DESCRIPTION
- Split migrations into numbered files while retaining one ordered list and shared startup/import transformations.
- Preserve unrelated input fields and cover idempotency, ordering, and safe retries.
- Verified with `npm run check` (873 tests); standards and spec reviews passed.

Closes #344
