### PR TITLE
refactor: add snapshot-based migration recovery

### DIFF
--- a/docs/adr/0003-snapshot-migration-input.md
+++ b/docs/adr/0003-snapshot-migration-input.md
@@ -1,0 +1,15 @@
+---
+status: accepted
+---
+
+# Recover startup migrations from saved input
+
+Startup and backup import share numbered, pure, deterministic transformations of complete versioned datasets. Each migration owns its historical shape checks; the runner does not depend on today's application models. Separate migration-specific loading, destination writes, and source cleanup allow storage layouts and backends to change without moving I/O into transformations.
+
+Persist one original-input snapshot per startup migration before changing destination storage, including all inputs needed to repeat the transformation. Retry from that snapshot after interruption instead of rereading partially changed sources. Finish destination writes, clean obsolete source data, record the completed version, then retire the snapshot; writes and cleanup must be repeatable. A snapshot left after version advancement is retired without replay. Preserve recovery data and block normal data operations until recovery succeeds, including when snapshot creation fails.
+
+This costs temporary storage but avoids requiring transformations to accept partially migrated data or their own output. Keep recovery metadata available throughout storage moves and complete each migration before starting the next. Startup recovery is separate from backup replacement and its failure-restoration policy; imports migrate raw data before current normalization and validation, without writing startup snapshots.
+
+Each migration explicitly defines and tests which historical records it repairs, discards, or rejects; the runner supplies no blanket record policy. Use one version sequence: the code-supported version governs backup compatibility and exports, while the device's completed version tracks startup progress. Recovery snapshots reference that sequence rather than introducing another version system.
+
+The implementation and downstream ownership are specified in [#344](https://github.com/mattcdrake/LeetSRS/issues/344), under [#329](https://github.com/mattcdrake/LeetSRS/issues/329). PRs #343 and #345 are abandoned experiments; their code is not the implementation base.

--- a/docs/agents/architecture.md
+++ b/docs/agents/architecture.md
@@ -45,6 +45,8 @@ Before changing background commands or sync execution, read [ADR-0001](../adr/00
 
 Append each schema change as a numbered file in `infrastructure/storage/migrations/` and append it to the ordered list in `infrastructure/storage/migrations.ts`. Array position plus one is its version. `LATEST_SCHEMA_VERSION` governs exports and backup compatibility; the stored device version records completed startup steps. Keep historical checks independent of current application models. Versions 1–3 retain the existing learning-data backend.
 
+Keep each migration's historical schema and validation helpers, when needed, in its numbered file. Small, similar validation wrappers are intentional and should remain local so historical validation can evolve independently.
+
 Each `Migration` supplies:
 
 - `load()`: read the complete historical logical dataset and any additional inputs as lossless JSON data. Keep historical storage layouts in migration adapters such as `legacy-storage.ts`.

--- a/docs/agents/architecture.md
+++ b/docs/agents/architecture.md
@@ -32,11 +32,26 @@ Before changing background commands or sync execution, read [ADR-0001](../adr/00
 
 - Cards are slug-keyed, notes reference card UUIDs, and stored card dates are numeric.
 - Preserve supported card fields, FSRS schedules, notes, stats, settings, and Gist configuration. Unrecognized fields may be discarded; unrelated undecodable records need not survive mutations.
-- Schema changes require a new sequential migration in `infrastructure/storage/migrations.ts`.
+- Before changing schema migrations or startup recovery, read [ADR-0003](../adr/0003-snapshot-migration-input.md) and the migration contract below.
 - Infrastructure owns card date codecs, stored-record validation, migrations, and card/note/stat persistence. Persistence adapters do not mark local edits.
 - Domain owns import envelope/configuration validation, settings compatibility, and relationship checks without depending on storage types.
-- Services migrate and validate imports before replacement, then orchestrate reset/restore through shared persistence adapters. Preserve the local PAT and apply imported timestamps after settings writes.
+- Services parse the import envelope and source version, migrate the raw logical dataset, then normalize and validate current records and relationships before replacement. Preserve historical fields until transformation. Reset/restore uses shared persistence adapters, preserves the local PAT, and applies imported timestamps after settings writes.
 - Imports discard extra record and configuration fields while validating supported fields and relationships. Legacy imports default missing card domains to `leetcode.com` and map `autoClearLeetcode` to `resetEditorOnEveryProblem`, with the current setting taking precedence.
 - Sync, backup/reset, and local-edit tracking share `infrastructure/storage/sync-metadata.ts`.
 - Before changing Gist sync conflict resolution, read [ADR-0002](../adr/0002-whole-dataset-gist-sync.md). Restore pulls through backup import.
 - Sync payloads include settings and Gist configuration, exclude the PAT, and need new synchronized fields added to `ExportData`.
+
+### Migration contract and recovery
+
+Append each schema change as a numbered file in `infrastructure/storage/migrations/` and append it to the ordered list in `infrastructure/storage/migrations.ts`. Array position plus one is its version. `LATEST_SCHEMA_VERSION` governs exports and backup compatibility; the stored device version records completed startup steps. Keep historical checks independent of current application models. Versions 1–3 retain the existing learning-data backend.
+
+Each `Migration` supplies:
+
+- `load()`: read the complete historical logical dataset and any additional inputs as lossless JSON data. Keep historical storage layouts in migration adapters such as `legacy-storage.ts`.
+- `migrate(input)`: perform the pure, deterministic transformation shared by startup and imports. Validate historical input/output here, preserve unrelated fields, and explicitly define and test repair, discard, and rejection policies.
+- `save(output)`: persist the transformed result. Validate and calculate writes first, batching each storage area where practical.
+- Optional `cleanup(input)`: remove obsolete sources using the saved original input when needed. Both saving and cleanup must tolerate repeats.
+
+Startup saves `{ version, input }` at `local:leetsrs:migrationSnapshot` before transformation or destination writes. It then transforms, saves destinations, cleans sources, records completion, and retires the snapshot before starting another step. Retry uses the snapshot without calling `load()` again. Transformations need not accept their own output. Keep this recovery key and the completed-version key available in local storage when learning data moves.
+
+A snapshot for the device's completed version is retired without replay. A pending snapshot must identify the next version; malformed metadata, version gaps, older snapshots, and unsupported future versions block startup without changing recovery data. Failures report the step and phase. Background messages and alarms stay behind startup readiness, including after snapshot creation or retirement fails; reload after resolving the failure to retry. Import preparation runs only transformations and current validation; startup snapshots do not provide import replacement rollback.

--- a/domain/backup-import.ts
+++ b/domain/backup-import.ts
@@ -9,15 +9,8 @@ const structureSchema = z.object({
   schemaVersion: z.unknown().optional(),
   exportDate: z.unknown().refine(Boolean),
   dataUpdatedAt: z.unknown().optional(),
-  data: z.object({
-    cards: z.unknown().optional(),
-    stats: z.unknown().optional(),
-    notes: z.unknown().optional(),
-    settings: z.unknown().optional(),
-    gistSync: z.unknown().optional(),
-  }),
+  data: z.unknown().refine((value) => value !== undefined, 'Missing backup data'),
 });
-type BackupImportEnvelope = z.infer<typeof structureSchema>;
 
 const schemaVersionSchema = z.number().refine((value) => Number.isInteger(value) && value >= 0);
 // Preserve legacy timestamp formats accepted by Date.parse.
@@ -28,10 +21,6 @@ export const backupMetadataSchema = z.object({
   exportDate: timestampSchema,
   dataUpdatedAt: timestampSchema.optional(),
 });
-
-export function validateImportStructure(data: unknown): asserts data is BackupImportEnvelope {
-  structureSchema.parse(data);
-}
 
 function getImportedSettings(settings: unknown): Partial<Settings> {
   if (settings === undefined) return {};
@@ -48,7 +37,23 @@ function getImportedSettings(settings: unknown): Partial<Settings> {
   return settingsUpdateSchema.parse(importedSettings);
 }
 
-export function normalizeImportData(data: BackupImportEnvelope, currentSchema: number) {
+export function normalizeImportData(data: unknown, currentSchema: number) {
+  const envelope = parseImportEnvelope(data, currentSchema);
+  const dataset = objectMapSchema.parse(envelope.data);
+
+  return {
+    schemaVersion: envelope.schemaVersion,
+    cards: objectMapSchema.parse(dataset.cards),
+    stats: objectMapSchema.parse(dataset.stats),
+    notes: objectMapSchema.parse(dataset.notes),
+    settings: getImportedSettings(dataset.settings),
+    gistSync: gistSyncBackupSchema.optional().parse(dataset.gistSync),
+    dataUpdatedAt: envelope.dataUpdatedAt,
+  };
+}
+
+export function parseImportEnvelope(input: unknown, currentSchema: number) {
+  const data = structureSchema.parse(input);
   const importedSchema = schemaVersionSchema.optional().parse(data.schemaVersion) ?? 0;
   if (importedSchema > currentSchema) {
     throw new Error(`Export is from a newer version (schema ${importedSchema}). Please update the extension.`);
@@ -58,12 +63,9 @@ export function normalizeImportData(data: BackupImportEnvelope, currentSchema: n
 
   return {
     schemaVersion: importedSchema,
-    cards: objectMapSchema.parse(data.data.cards),
-    stats: objectMapSchema.parse(data.data.stats),
-    notes: objectMapSchema.parse(data.data.notes),
-    settings: getImportedSettings(data.data.settings),
-    gistSync: gistSyncBackupSchema.optional().parse(data.data.gistSync),
+    exportDate: data.exportDate,
     dataUpdatedAt,
+    data: data.data,
   };
 }
 

--- a/entrypoints/background/__tests__/execution.test.ts
+++ b/entrypoints/background/__tests__/execution.test.ts
@@ -1,3 +1,4 @@
+import { State } from 'ts-fsrs';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { browser } from 'wxt/browser';
 import { fakeBrowser } from 'wxt/testing/fake-browser';
@@ -15,7 +16,7 @@ import { STORAGE_KEYS } from '@/infrastructure/storage/storage-keys';
 import * as cards from '@/services/cards';
 import * as setup from '@/services/gist-setup';
 import * as sync from '@/services/github-sync';
-import { buildProblem } from '@/test/utils/card-mocks';
+import { buildProblem, createMockCard } from '@/test/utils/card-mocks';
 import background from '../index';
 
 vi.mock('@/infrastructure/browser/messages', async (importOriginal) => ({
@@ -49,6 +50,59 @@ beforeEach(async () => {
 const problem = buildProblem();
 
 describe('registered background execution', () => {
+  it.each([STORAGE_KEYS.migrationSnapshot, STORAGE_KEYS.cards])(
+    'blocks data commands and alarms after a real migration write fails at %s, then recovers on restart',
+    async (failedKey) => {
+      fakeBrowser.reset();
+      fakeBrowser.runtime.id = 'test';
+      const { domain: _domain, ...card } = createMockCard(State.New, { id: 'one', slug: 'two-sum' });
+      const legacy = { 'two-sum': card };
+      await storage.setItem(STORAGE_KEYS.cards, legacy);
+      await storage.setItem(STORAGE_KEYS.githubPat, 'pat');
+      await storage.setItem(STORAGE_KEYS.gistId, 'gist');
+      await storage.setItem(STORAGE_KEYS.gistSyncEnabled, true);
+      const before = await storage.snapshot('local');
+      const syncBefore = await storage.snapshot('sync');
+      const report = vi.spyOn(console, 'error').mockImplementation(() => {});
+      const write = storage.setItem.bind(storage);
+      const writes = vi.spyOn(storage, 'setItem').mockImplementation(async (key, value) => {
+        if (key === failedKey) throw new Error('storage unavailable');
+        return write(key, value);
+      });
+      vi.mocked(onMessage).mockClear();
+      const alarms = vi.spyOn(browser.alarms.onAlarm, 'addListener');
+      background.main();
+      const alarm = alarms.mock.calls[0]?.[0];
+      if (!alarm) throw new Error('Alarm listener not registered');
+
+      await expect(dispatch('getAllCards')).rejects.toThrow('storage unavailable');
+      await expect(dispatch('saveNote', { cardId: 'one', text: 'must not save' })).rejects.toThrow(
+        'storage unavailable'
+      );
+      await expect(dispatch('resetAllData')).rejects.toThrow('storage unavailable');
+      await expect(dispatch('exportData')).rejects.toThrow('storage unavailable');
+      await alarm({ name: 'gist-sync', scheduledTime: 0, persistAcrossSessions: true });
+
+      expect(sync.triggerGistSync).not.toHaveBeenCalled();
+      expect(report).toHaveBeenCalledOnce();
+      const recovery = await storage.getItem(STORAGE_KEYS.migrationSnapshot);
+      expect(await storage.snapshot('local')).toEqual({
+        ...before,
+        ...(failedKey === STORAGE_KEYS.cards ? { 'leetsrs:migrationSnapshot': recovery } : {}),
+      });
+      expect(await storage.snapshot('sync')).toEqual(syncBefore);
+      writes.mockRestore();
+      vi.mocked(onMessage).mockClear();
+      background.main();
+
+      await expect(dispatch('getSettings')).resolves.toBeDefined();
+      await dispatch('saveNote', { cardId: 'one', text: 'recovered' });
+      await expect(dispatch('getNote', { cardId: 'one' })).resolves.toEqual({ text: 'recovered' });
+      expect(await storage.getItem(STORAGE_KEYS.schemaVersion)).toBe(3);
+      expect(await storage.getItem(STORAGE_KEYS.migrationSnapshot)).toBeNull();
+    }
+  );
+
   it('registers every message synchronously', () => {
     expect(
       vi

--- a/infrastructure/storage/__tests__/migration-recovery.test.ts
+++ b/infrastructure/storage/__tests__/migration-recovery.test.ts
@@ -1,0 +1,254 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fakeBrowser } from 'wxt/testing/fake-browser';
+import { storage } from 'wxt/utils/storage';
+import { z } from 'zod';
+import { getCurrentSchemaVersion, type Migration, migrateBackupData, runStartupMigrations } from '../migrations';
+
+const snapshotKey = 'local:leetsrs:migrationSnapshot';
+const sourceSchema = z.looseObject({
+  cards: z.array(z.object({ id: z.string(), title: z.string() })),
+  notes: z.record(z.string(), z.object({ text: z.string() })),
+  generation: z.number(),
+});
+const destinationSchema = z.looseObject({
+  entries: z.array(z.object({ id: z.string(), title: z.string(), note: z.string() })),
+  generation: z.number(),
+});
+const original = {
+  cards: [{ id: 'one', title: 'Two Sum' }],
+  notes: { one: { text: 'Use a map' } },
+  generation: 7,
+  settings: { theme: 'dark' },
+};
+const expected = {
+  entries: [{ id: 'one', title: 'Two Sum', note: 'Use a map' }],
+  generation: 8,
+  settings: { theme: 'dark' },
+};
+
+// A synthetic cross-area move with a shape change; the transformation cannot accept its own output.
+const move: Migration = {
+  description: 'Move cards and embed notes',
+  load: async () => ({
+    ...z.record(z.string(), z.unknown()).parse(await storage.getItem('local:test:remaining')),
+    cards: await storage.getItem('local:test:cards'),
+    notes: await storage.getItem('local:test:notes'),
+  }),
+  migrate: (input) => {
+    const { cards, notes, generation, ...rest } = sourceSchema.parse(input);
+    return destinationSchema.parse({
+      ...rest,
+      generation: generation + 1,
+      entries: cards.map((card) => ({ ...card, note: notes[card.id]?.text ?? '' })),
+    });
+  },
+  save: async (output) => {
+    const { entries, ...rest } = destinationSchema.parse(output);
+    await storage.setItem('local:test:remaining', rest);
+    await storage.setItem('sync:test:entries', entries);
+  },
+  cleanup: async (input) => {
+    // Cleanup can use original identifiers even after some sources have been removed.
+    sourceSchema.parse(input);
+    await storage.removeItems(['local:test:cards', 'local:test:notes']);
+  },
+};
+
+async function readDestination() {
+  return {
+    ...z.record(z.string(), z.unknown()).parse(await storage.getItem('local:test:remaining')),
+    entries: await storage.getItem('sync:test:entries'),
+  };
+}
+
+beforeEach(async () => {
+  fakeBrowser.reset();
+  const { cards, notes, ...rest } = original;
+  await storage.setItems([
+    { key: 'local:test:cards', value: cards },
+    { key: 'local:test:notes', value: notes },
+    { key: 'local:test:remaining', value: rest },
+  ]);
+});
+
+describe('startup snapshot recovery', () => {
+  it.each(['snapshot', 'destination', 'cleanup', 'version', 'retirement'] as const)(
+    'recovers an interrupted %s phase from its original input',
+    async (phase) => {
+      const before = await storage.snapshot('local');
+      const write = storage.setItem.bind(storage);
+      vi.spyOn(storage, 'setItem').mockImplementation(async (key, value) => {
+        if (
+          (phase === 'snapshot' && key === snapshotKey) ||
+          (phase === 'destination' && key === 'sync:test:entries') ||
+          (phase === 'version' && key === 'local:leetsrs:schemaVersion')
+        ) {
+          throw new Error(`${phase} unavailable`);
+        }
+        return write(key, value);
+      });
+      if (phase === 'cleanup') {
+        vi.spyOn(storage, 'removeItems').mockImplementationOnce(async () => {
+          await storage.removeItem('local:test:cards');
+          throw new Error('cleanup unavailable');
+        });
+      }
+      if (phase === 'retirement') {
+        vi.spyOn(storage, 'removeItem').mockRejectedValueOnce(new Error('retirement unavailable'));
+      }
+
+      await expect(runStartupMigrations([move])).rejects.toThrow(`${phase} unavailable`);
+      expect(await getCurrentSchemaVersion()).toBe(phase === 'retirement' ? 1 : 0);
+      if (phase === 'snapshot') {
+        expect(await storage.snapshot('local')).toEqual(before);
+        expect(await storage.snapshot('sync')).toEqual({});
+      } else {
+        expect(await storage.getItem(snapshotKey)).toEqual({ version: 1, input: original });
+        expect(await storage.getItem('local:test:remaining')).toEqual({ generation: 8, settings: { theme: 'dark' } });
+      }
+      if (phase === 'cleanup') {
+        expect(await storage.getItem('local:test:cards')).toBeNull();
+        expect(await storage.getItem('local:test:notes')).toEqual(original.notes);
+      }
+      vi.restoreAllMocks();
+      const mustNotRun = () => {
+        throw new Error('Completed work was replayed');
+      };
+      const resume: Migration =
+        phase === 'snapshot'
+          ? move
+          : {
+              ...move,
+              load: mustNotRun,
+              ...(phase === 'retirement' ? { migrate: mustNotRun, save: mustNotRun, cleanup: mustNotRun } : {}),
+            };
+
+      await runStartupMigrations([resume]);
+
+      expect(await readDestination()).toEqual(expected);
+      expect(await readDestination()).toEqual(migrateBackupData(original, 0, [move]));
+      expect(await storage.getItem('local:test:cards')).toBeNull();
+      expect(await storage.getItem('local:test:notes')).toBeNull();
+      expect(await getCurrentSchemaVersion()).toBe(1);
+      expect(await storage.getItem(snapshotKey)).toBeNull();
+    }
+  );
+
+  it('finishes and retires each step before loading the next logical shape', async () => {
+    const titles: Migration = {
+      description: 'Reduce the dataset to a title list',
+      load: async () => {
+        expect(await getCurrentSchemaVersion()).toBe(1);
+        expect(await storage.getItem(snapshotKey)).toBeNull();
+        expect(await storage.getItem('local:test:notes')).toBeNull();
+        return readDestination();
+      },
+      migrate: (data) => destinationSchema.parse(data).entries.map((entry) => entry.title),
+      save: async (data) => {
+        const parsed = z.array(z.string()).parse(data);
+        expect(await getCurrentSchemaVersion()).toBe(1);
+        expect(await storage.getItem(snapshotKey)).toEqual({ version: 2, input: expected });
+        await storage.setItem('sync:test:titles', parsed);
+      },
+    };
+    const steps = [move, titles];
+    const frozen = Object.freeze({
+      ...original,
+      cards: Object.freeze(original.cards.map((card) => Object.freeze({ ...card }))),
+      notes: Object.freeze({ one: Object.freeze({ text: 'Use a map' }) }),
+      settings: Object.freeze({ theme: 'dark' }),
+    });
+    const before = await storage.snapshot('local');
+    expect(migrateBackupData(frozen, 0, steps)).toEqual(['Two Sum']);
+    expect(migrateBackupData(frozen, 0, steps)).toEqual(['Two Sum']);
+    expect(await storage.snapshot('local')).toEqual(before);
+    expect(await storage.snapshot('sync')).toEqual({});
+
+    await runStartupMigrations(steps);
+    await runStartupMigrations(steps);
+
+    expect(await storage.getItem('sync:test:titles')).toEqual(['Two Sum']);
+    expect(await getCurrentSchemaVersion()).toBe(2);
+    expect(await storage.getItem(snapshotKey)).toBeNull();
+    expect(migrateBackupData(expected, 1, steps)).toEqual(['Two Sum']);
+    expect(migrateBackupData(['Two Sum'], 2, steps)).toEqual(['Two Sum']);
+  });
+
+  it('retains rejected historical input without touching destinations or later steps', async () => {
+    await storage.setItem('local:test:cards', 'malformed');
+    const before = await storage.snapshot('local');
+    const next: Migration = {
+      ...move,
+      load: async () => {
+        throw new Error('Next step must not start');
+      },
+    };
+
+    await expect(runStartupMigrations([move, next])).rejects.toThrow('transform and validate');
+    expect(await storage.snapshot('local')).toEqual({
+      ...before,
+      'leetsrs:migrationSnapshot': { version: 1, input: { ...original, cards: 'malformed' } },
+    });
+    expect(await storage.snapshot('sync')).toEqual({});
+    await expect(runStartupMigrations([move, next])).rejects.toThrow('transform and validate');
+  });
+
+  it.each([
+    { version: -1, snapshot: undefined },
+    { version: 0.5, snapshot: undefined },
+    { version: '0', snapshot: undefined },
+    { version: 4, snapshot: { version: 1, input: original } },
+    { version: 0, snapshot: { version: 2, input: original } },
+    { version: 0, snapshot: { version: 4, input: original } },
+    { version: 0, snapshot: { version: 0, input: original } },
+    { version: 0, snapshot: { version: 0.5, input: original } },
+    { version: 0, snapshot: { version: 1 } },
+    { version: 0, snapshot: [] },
+    { version: 0, snapshot: 'corrupt' },
+    { version: 2, snapshot: { version: 1, input: original } },
+  ])('blocks inconsistent metadata without changing recovery data: %j', async ({ version, snapshot }) => {
+    await storage.setItem('local:leetsrs:schemaVersion', version);
+    if (snapshot !== undefined) await storage.setItem(snapshotKey, snapshot);
+    const before = await storage.snapshot('local');
+
+    await expect(runStartupMigrations([move, move, move])).rejects.toThrow(/schema version|recovery metadata/);
+
+    expect(await storage.snapshot('local')).toEqual(before);
+    expect(await storage.snapshot('sync')).toEqual({});
+  });
+
+  it('supports an empty version sequence', async () => {
+    const before = await storage.snapshot('local');
+    await runStartupMigrations([]);
+    expect(await storage.snapshot('local')).toEqual(before);
+    expect(migrateBackupData(['unchanged'], 0, [])).toEqual(['unchanged']);
+  });
+
+  it('reports retirement failures after completion and leaves the snapshot available', async () => {
+    await storage.setItem('local:leetsrs:schemaVersion', 1);
+    await storage.setItem(snapshotKey, { version: 1, input: original });
+    vi.spyOn(storage, 'removeItem').mockRejectedValueOnce(new Error('storage unavailable'));
+
+    await expect(runStartupMigrations([move])).rejects.toThrow('retire recovery snapshot');
+
+    expect(await storage.getItem(snapshotKey)).toEqual({ version: 1, input: original });
+    expect(await getCurrentSchemaVersion()).toBe(1);
+  });
+
+  it.each([undefined, { requiredInput: undefined }, { requiredInput: Number.NaN }])(
+    'rejects input that cannot be saved losslessly as JSON: %j',
+    async (input) => {
+      const before = await storage.snapshot('local');
+      const migration: Migration = {
+        ...move,
+        load: async () => input,
+        migrate: () => expected,
+      };
+
+      await expect(runStartupMigrations([migration])).rejects.toThrow('save recovery snapshot');
+
+      expect(await storage.snapshot('local')).toEqual(before);
+      expect(await storage.snapshot('sync')).toEqual({});
+    }
+  );
+});

--- a/infrastructure/storage/__tests__/migration-recovery.test.ts
+++ b/infrastructure/storage/__tests__/migration-recovery.test.ts
@@ -72,6 +72,28 @@ beforeEach(async () => {
 });
 
 describe('startup snapshot recovery', () => {
+  it('validates snapshots without rewriting historical JSON keys', async () => {
+    const input: unknown = JSON.parse('{"records":{"__proto__":{"text":"preserve"}}}');
+    const copy: Migration = {
+      description: 'Preserve historical JSON',
+      load: async () => input,
+      migrate: (data) => data,
+      save: (data) => storage.setItem('sync:test:copy', data),
+    };
+    const write = storage.setItem.bind(storage);
+    const failure = vi.spyOn(storage, 'setItem').mockImplementation(async (key, value) => {
+      if (key === 'local:leetsrs:schemaVersion') throw new Error('version unavailable');
+      return write(key, value);
+    });
+
+    await expect(runStartupMigrations([copy])).rejects.toThrow('version unavailable');
+    expect(await storage.getItem(snapshotKey)).toEqual({ version: 1, input });
+    failure.mockRestore();
+    await runStartupMigrations([copy]);
+
+    expect(await storage.getItem('sync:test:copy')).toEqual(input);
+  });
+
   it.each(['snapshot', 'destination', 'cleanup', 'version', 'retirement'] as const)(
     'recovers an interrupted %s phase from its original input',
     async (phase) => {

--- a/infrastructure/storage/__tests__/migration-recovery.test.ts
+++ b/infrastructure/storage/__tests__/migration-recovery.test.ts
@@ -257,20 +257,28 @@ describe('startup snapshot recovery', () => {
     expect(await getCurrentSchemaVersion()).toBe(1);
   });
 
-  it.each([undefined, { requiredInput: undefined }, { requiredInput: Number.NaN }])(
-    'rejects input that cannot be saved losslessly as JSON: %j',
-    async (input) => {
-      const before = await storage.snapshot('local');
-      const migration: Migration = {
-        ...move,
-        load: async () => input,
-        migrate: () => expected,
-      };
+  it.each([
+    undefined,
+    { requiredInput: undefined },
+    { requiredInput: Number.NaN },
+    Object.fromEntries([['__proto__', { requiredInput: undefined }]]),
+    Object.fromEntries([['__proto__', { requiredInput: Number.NaN }]]),
+    new Date(0),
+    Array(1),
+    Object.assign([], { requiredInput: true }),
+    Object.defineProperty({}, 'requiredInput', { value: true }),
+    Object.defineProperty({}, 'requiredInput', { enumerable: true, get: () => true }),
+  ])('rejects input that cannot be saved losslessly as JSON: %j', async (input) => {
+    const before = await storage.snapshot('local');
+    const migration: Migration = {
+      ...move,
+      load: async () => input,
+      migrate: () => expected,
+    };
 
-      await expect(runStartupMigrations([migration])).rejects.toThrow('save recovery snapshot');
+    await expect(runStartupMigrations([migration])).rejects.toThrow('save recovery snapshot');
 
-      expect(await storage.snapshot('local')).toEqual(before);
-      expect(await storage.snapshot('sync')).toEqual({});
-    }
-  );
+    expect(await storage.snapshot('local')).toEqual(before);
+    expect(await storage.snapshot('sync')).toEqual({});
+  });
 });

--- a/infrastructure/storage/__tests__/migrations.test.ts
+++ b/infrastructure/storage/__tests__/migrations.test.ts
@@ -13,6 +13,17 @@ describe('migrations', () => {
   });
 
   describe('migrateBackupData', () => {
+    it('preserves legal JSON keys while validating historical datasets and collections', () => {
+      const data: unknown = JSON.parse(
+        '{"__proto__":{"text":"unrelated"},"cards":{"__proto__":{"domain":"leetcode.com"}},"settings":{"__proto__":{"text":"setting"},"dayStartHour":4}}'
+      );
+      expect(migrateBackupData(data, 0)).toEqual(
+        JSON.parse(
+          '{"__proto__":{"text":"unrelated"},"cards":{"__proto__":{"domain":"leetcode.com"}},"settings":{"__proto__":{"text":"setting"}}}'
+        )
+      );
+    });
+
     it('migrates frozen input without changing the input or writing storage', async () => {
       const { domain: _domain, ...legacyCard } = createMockCard(State.Review, { slug: 'two-sum', paused: true });
       const card = Object.freeze(legacyCard);

--- a/infrastructure/storage/__tests__/migrations.test.ts
+++ b/infrastructure/storage/__tests__/migrations.test.ts
@@ -15,7 +15,7 @@ describe('migrations', () => {
   describe('migrateBackupData', () => {
     it('preserves legal JSON keys while validating historical datasets and collections', () => {
       const data: unknown = JSON.parse(
-        '{"__proto__":{"text":"unrelated"},"cards":{"__proto__":{"domain":"leetcode.com"}},"settings":{"__proto__":{"text":"setting"},"dayStartHour":4}}'
+        '{"__proto__":{"text":"unrelated"},"cards":{"__proto__":{}},"settings":{"__proto__":{"text":"setting"},"dayStartHour":4}}'
       );
       expect(migrateBackupData(data, 0)).toEqual(
         JSON.parse(
@@ -66,10 +66,16 @@ describe('migrations', () => {
         zeroDomain: { domain: 0 },
         cn: { domain: 'leetcode.cn' },
         invalidDomain: { domain: 'example.com' },
+        objectDomain: { domain: { historical: true } },
+        arrayDomain: { domain: [] },
+        booleanDomain: { domain: true },
+        numberDomain: { domain: 42 },
         invalidField: { domain: 'leetcode.com', paused: 'invalid' },
         nullCard: null,
         arrayCard: [],
         primitiveCard: 'invalid',
+        booleanCard: false,
+        numberCard: 0,
       };
       expect(migrateBackupData({ cards, historical: 'keep' }, 0)).toEqual({
         historical: 'keep',
@@ -225,14 +231,23 @@ describe('migrations', () => {
   });
 
   describe('migration v2: add system theme preference', () => {
-    it('should advance the schema without changing an existing theme', async () => {
+    it('upgrades version 1 to 3 while preserving learning data and unrelated settings', async () => {
       await setSchemaVersion(1);
+      const card = createMockCard(State.Review, { paused: true });
+      await storage.setItem(STORAGE_KEYS.cards, { [card.slug]: card });
+      await storage.setItem(`${STORAGE_KEYS.notes}:${card.id}`, { text: 'Keep this note' });
+      await storage.setItem(STORAGE_KEYS.stats, { '2024-03-14': { streak: 7 } });
       await storage.setItem(STORAGE_KEYS.theme, 'dark');
+      await storage.setItem('sync:leetsrs:dayStartHour', 4);
+      const localBefore = await fakeBrowser.storage.local.get(null);
+      const syncBefore = await fakeBrowser.storage.sync.get(null);
+      const { 'leetsrs:dayStartHour': _legacy, ...remainingSettings } = syncBefore;
 
       await runStartupMigrations();
 
       expect(await getCurrentSchemaVersion()).toBe(3);
-      expect(await storage.getItem(STORAGE_KEYS.theme)).toBe('dark');
+      expect(await fakeBrowser.storage.local.get(null)).toEqual({ ...localBefore, 'leetsrs:schemaVersion': 3 });
+      expect(await fakeBrowser.storage.sync.get(null)).toEqual(remainingSettings);
     });
   });
 });

--- a/infrastructure/storage/__tests__/migrations.test.ts
+++ b/infrastructure/storage/__tests__/migrations.test.ts
@@ -4,13 +4,7 @@ import { fakeBrowser } from 'wxt/testing/fake-browser';
 import { storage } from 'wxt/utils/storage';
 import { createMockCard } from '@/test/utils/card-mocks';
 import { getAllCards } from '../cards';
-import {
-  getCurrentSchemaVersion,
-  type Migration,
-  migrateBackupData,
-  runStartupMigrations,
-  setSchemaVersion,
-} from '../migrations';
+import { getCurrentSchemaVersion, migrateBackupData, runStartupMigrations, setSchemaVersion } from '../migrations';
 import { STORAGE_KEYS } from '../storage-keys';
 
 describe('migrations', () => {
@@ -24,6 +18,11 @@ describe('migrations', () => {
       const card = Object.freeze(legacyCard);
       const data = Object.freeze({
         cards: Object.freeze({ 'two-sum': card }),
+        notes: Object.freeze({ [card.id]: Object.freeze({ text: 'Keep this note' }) }),
+        stats: Object.freeze({ historical: Object.freeze({ reviews: 2 }) }),
+        settings: Object.freeze({ theme: 'dark', dayStartHour: 4 }),
+        gistSync: Object.freeze({ gistId: 'saved-gist', enabled: false }),
+        historicalField: Object.freeze({ value: 42 }),
       });
       const before = await fakeBrowser.storage.local.get(null);
       const migrated = migrateBackupData(data, 0);
@@ -31,7 +30,9 @@ describe('migrations', () => {
       expect(migrated).toEqual({
         ...data,
         cards: { 'two-sum': { ...card, domain: 'leetcode.com' } },
+        settings: { theme: 'dark' },
       });
+      expect(migrateBackupData(data, 0)).toEqual(migrated);
       expect(data.cards['two-sum']).not.toHaveProperty('domain');
       expect(await fakeBrowser.storage.local.get(null)).toEqual(before);
     });
@@ -43,6 +44,53 @@ describe('migrations', () => {
 
     it.each([-1, 0.5, 4])('rejects unsupported schema %s', (schemaVersion) => {
       expect(() => migrateBackupData({ cards: {} }, schemaVersion)).toThrow('Unsupported schema version');
+    });
+
+    it('repairs only falsy card domains and preserves malformed records for later validation', () => {
+      const cards = {
+        missing: { id: 'one', historical: true },
+        empty: { domain: '' },
+        nullDomain: { domain: null },
+        falseDomain: { domain: false },
+        zeroDomain: { domain: 0 },
+        cn: { domain: 'leetcode.cn' },
+        invalidDomain: { domain: 'example.com' },
+        invalidField: { domain: 'leetcode.com', paused: 'invalid' },
+        nullCard: null,
+        arrayCard: [],
+        primitiveCard: 'invalid',
+      };
+      expect(migrateBackupData({ cards, historical: 'keep' }, 0)).toEqual({
+        historical: 'keep',
+        cards: {
+          ...cards,
+          missing: { id: 'one', historical: true, domain: 'leetcode.com' },
+          empty: { domain: 'leetcode.com' },
+          nullDomain: { domain: 'leetcode.com' },
+          falseDomain: { domain: 'leetcode.com' },
+          zeroDomain: { domain: 'leetcode.com' },
+        },
+      });
+    });
+
+    it.each([[], 'invalid', 42])('rejects malformed historical card collections: %j', (cards) => {
+      expect(() => migrateBackupData({ cards }, 0)).toThrow();
+    });
+
+    it.each([{}, { cards: null }])('preserves absent card collections: %j', (data) => {
+      expect(migrateBackupData(data, 0)).toEqual(data);
+    });
+
+    it.each([4, 'invalid', null, { historical: true }])('discards retired day start values: %j', (dayStartHour) => {
+      const data = { cards: { malformed: null }, settings: { dayStartHour, theme: 'unknown' }, extra: true };
+      expect(migrateBackupData(data, 1)).toEqual({
+        ...data,
+        settings: { theme: 'unknown' },
+      });
+    });
+
+    it.each([[], null, 'invalid'])('rejects malformed historical settings: %j', (settings) => {
+      expect(() => migrateBackupData({ settings }, 2)).toThrow();
     });
   });
 
@@ -64,158 +112,6 @@ describe('migrations', () => {
       await setSchemaVersion(3);
       const stored = await storage.getItem(STORAGE_KEYS.schemaVersion);
       expect(stored).toBe(3);
-    });
-  });
-
-  describe('runStartupMigrations', () => {
-    it('runs migrations in array order', async () => {
-      const executionOrder: string[] = [];
-      const steps: Migration[] = ['add domain', 'add theme', 'next migration'].map((description) => ({
-        description,
-        migrate: (data) => {
-          executionOrder.push(description);
-          return data;
-        },
-      }));
-
-      await runStartupMigrations(steps);
-
-      expect(executionOrder).toEqual(['add domain', 'add theme', 'next migration']);
-      expect(await getCurrentSchemaVersion()).toBe(3);
-    });
-
-    it('should only run migrations newer than current version', async () => {
-      await setSchemaVersion(2);
-
-      const executionOrder: number[] = [];
-      const migrations: Migration[] = [
-        {
-          description: 'Old migration',
-          migrate: (data) => {
-            executionOrder.push(1);
-            return data;
-          },
-        },
-        {
-          description: 'Current migration',
-          migrate: (data) => {
-            executionOrder.push(2);
-            return data;
-          },
-        },
-        {
-          description: 'New migration',
-          migrate: (data) => {
-            executionOrder.push(3);
-            return data;
-          },
-        },
-        {
-          description: 'Newer migration',
-          migrate: (data) => {
-            executionOrder.push(4);
-            return data;
-          },
-        },
-      ];
-
-      await runStartupMigrations(migrations);
-
-      expect(executionOrder).toEqual([3, 4]);
-      expect(await getCurrentSchemaVersion()).toBe(4);
-    });
-
-    it('should handle empty migrations array', async () => {
-      await runStartupMigrations([]);
-      expect(await getCurrentSchemaVersion()).toBe(0);
-    });
-
-    it('derives persisted versions from array positions after skipping completed steps', async () => {
-      await setSchemaVersion(1);
-      const step: Migration = { description: 'No-op', migrate: (data) => data };
-      const writes = vi.spyOn(storage, 'setItem');
-      try {
-        await runStartupMigrations([step, step, step]);
-
-        expect(writes.mock.calls.filter(([key]) => key === STORAGE_KEYS.schemaVersion)).toEqual([
-          [STORAGE_KEYS.schemaVersion, 2],
-          [STORAGE_KEYS.schemaVersion, 3],
-        ]);
-        expect(await getCurrentSchemaVersion()).toBe(3);
-      } finally {
-        writes.mockRestore();
-      }
-    });
-
-    it('should stop and throw error if migration fails', async () => {
-      const executionOrder: number[] = [];
-
-      const migrations: Migration[] = [
-        {
-          description: 'Success migration',
-          migrate: (data) => {
-            executionOrder.push(1);
-            return data;
-          },
-        },
-        {
-          description: 'Failing migration',
-          migrate: () => {
-            executionOrder.push(2);
-            throw new Error('Migration failed');
-          },
-        },
-        {
-          description: 'Should not run',
-          migrate: (data) => {
-            executionOrder.push(3);
-            return data;
-          },
-        },
-      ];
-
-      await expect(runStartupMigrations(migrations)).rejects.toThrow('Failed to run migration 2');
-
-      expect(executionOrder).toEqual([1, 2]);
-      expect(await getCurrentSchemaVersion()).toBe(1); // Only first migration succeeded
-    });
-
-    it('persists each step before advancing its version and starting the next step', async () => {
-      const versions: number[] = [];
-      const first = createMockCard(State.New, { slug: 'first' });
-      const second = createMockCard(State.New, { slug: 'second' });
-      const steps: Migration[] = [
-        {
-          description: 'First',
-          migrate: () => ({ cards: { first } }),
-        },
-        {
-          description: 'Second',
-          migrate: (data) => {
-            expect(data.cards).toEqual({ first });
-            return { cards: { ...data.cards, second } };
-          },
-        },
-      ];
-      const write = storage.setItem.bind(storage);
-      const writes = vi.spyOn(storage, 'setItem').mockImplementation(async (key, value) => {
-        if (key === STORAGE_KEYS.cards) versions.push(await getCurrentSchemaVersion());
-        return write(key, value);
-      });
-      try {
-        await runStartupMigrations(steps);
-
-        expect(versions).toEqual([0, 1]);
-        expect(writes.mock.calls.map(([key]) => key)).toEqual([
-          STORAGE_KEYS.cards,
-          STORAGE_KEYS.schemaVersion,
-          STORAGE_KEYS.cards,
-          STORAGE_KEYS.schemaVersion,
-        ]);
-        expect(await getCurrentSchemaVersion()).toBe(2);
-      } finally {
-        writes.mockRestore();
-      }
     });
   });
 
@@ -269,55 +165,6 @@ describe('migrations', () => {
       } finally {
         writes.mockRestore();
       }
-    });
-
-    it('safely retries startup after cards are saved but the schema version write fails', async () => {
-      const { domain: _domain, ...legacyCard } = createMockCard(State.Review, {
-        id: 'legacy-id',
-        slug: 'two-sum',
-        paused: true,
-      });
-      const cards = {
-        'two-sum': legacyCard,
-        'add-two-numbers': createMockCard(State.Learning, {
-          id: 'cn-id',
-          slug: 'add-two-numbers',
-          domain: 'leetcode.cn',
-        }),
-      };
-      await storage.setItem(STORAGE_KEYS.cards, cards);
-      await storage.setItem(`${STORAGE_KEYS.notes}:legacy-id`, { text: 'Keep this note' });
-      await storage.setItem(`${STORAGE_KEYS.notes}:cn-id`, { text: 'Keep this too' });
-      await storage.setItem(STORAGE_KEYS.theme, 'dark');
-      await storage.setItem(STORAGE_KEYS.dataUpdatedAt, '2024-01-01T00:00:00.000Z');
-      const before = await fakeBrowser.storage.local.get(null);
-      const expectedAfterCardWrite = {
-        ...before,
-        [STORAGE_KEYS.cards.slice('local:'.length)]: {
-          ...cards,
-          'two-sum': { ...cards['two-sum'], domain: 'leetcode.com' },
-        },
-      };
-      const write = storage.setItem.bind(storage);
-      const writes = vi.spyOn(storage, 'setItem').mockImplementation(async (key, value) => {
-        if (key === STORAGE_KEYS.schemaVersion) throw new Error('schema persistence failed');
-        return write(key, value);
-      });
-      try {
-        await expect(runStartupMigrations()).rejects.toThrow('schema persistence failed');
-        expect(await getCurrentSchemaVersion()).toBe(0);
-        expect(await fakeBrowser.storage.local.get(null)).toEqual(expectedAfterCardWrite);
-      } finally {
-        writes.mockRestore();
-      }
-
-      // A new startup sees the persisted cards and the old schema version.
-      await runStartupMigrations();
-
-      expect(await fakeBrowser.storage.local.get(null)).toEqual({
-        ...expectedAfterCardWrite,
-        [STORAGE_KEYS.schemaVersion.slice('local:'.length)]: 3,
-      });
     });
 
     it('should handle empty or missing cards storage', async () => {

--- a/infrastructure/storage/migrations.ts
+++ b/infrastructure/storage/migrations.ts
@@ -14,9 +14,32 @@ export const LATEST_SCHEMA_VERSION = migrations.length;
 
 const snapshotSchema = z.object({
   version: z.number().int().positive(),
-  // Validate JSON compatibility without using Zod's parsed copy, which strips keys such as __proto__.
-  input: z.unknown().refine((input) => z.json().safeParse(input).success, 'Migration input must be lossless JSON data'),
+  input: z.unknown().refine(isJsonInput, 'Migration input must be lossless JSON data'),
 });
+
+// Visit every own JSON key. Schema parsers may skip __proto__, losing data or overlooking invalid values.
+function isJsonInput(value: unknown): boolean {
+  if (value === null || typeof value === 'string' || typeof value === 'boolean') return true;
+  if (typeof value === 'number') return Number.isFinite(value);
+  if (typeof value !== 'object') return false;
+  const properties = Object.getOwnPropertyDescriptors(value);
+  if (Array.isArray(value)) {
+    return (
+      Reflect.ownKeys(value).length === value.length + 1 &&
+      Array.from({ length: value.length }, (_, index) => properties[index]).every(
+        (property) => property !== undefined && 'value' in property && isJsonInput(property.value)
+      )
+    );
+  }
+  const prototype = Object.getPrototypeOf(value);
+  return (
+    (prototype === Object.prototype || prototype === null) &&
+    Object.getOwnPropertySymbols(value).length === 0 &&
+    Object.values(properties).every(
+      (property) => property.enumerable && 'value' in property && isJsonInput(property.value)
+    )
+  );
+}
 
 function checkVersion(version: number, latest: number): void {
   if (!Number.isInteger(version) || version < 0 || version > latest) {

--- a/infrastructure/storage/migrations.ts
+++ b/infrastructure/storage/migrations.ts
@@ -1,16 +1,26 @@
-import type { StorageItemKey } from 'wxt/utils/storage';
+import { z } from 'zod';
 import { storage } from '#imports';
+import { cardDomainMigration } from './migrations/001-card-domain';
+import { systemThemeMigration } from './migrations/002-system-theme';
+import { removeDayStartMigration } from './migrations/003-remove-day-start';
+import type { Migration } from './migrations/contract';
 import { STORAGE_KEYS } from './storage-keys';
 
-// Cards may be absent in storage, and legacy records have not yet been validated.
-interface MigrationData {
-  cards?: Record<string, unknown>;
-}
+export type { Migration } from './migrations/contract';
 
-export interface Migration {
-  description: string;
-  removeKeys?: readonly StorageItemKey[];
-  migrate: (data: MigrationData) => MigrationData;
+// Append only: index + 1 is the schema version. Never reorder or remove entries.
+const migrations: readonly Migration[] = [cardDomainMigration, systemThemeMigration, removeDayStartMigration];
+export const LATEST_SCHEMA_VERSION = migrations.length;
+
+const snapshotSchema = z.object({
+  version: z.number().int().positive(),
+  input: z.json(),
+});
+
+function checkVersion(version: number, latest: number): void {
+  if (!Number.isInteger(version) || version < 0 || version > latest) {
+    throw new Error(`Unsupported schema version: ${version}. Please update the extension before retrying.`);
+  }
 }
 
 export async function getCurrentSchemaVersion(): Promise<number> {
@@ -21,62 +31,73 @@ export async function setSchemaVersion(version: number): Promise<void> {
   await storage.setItem(STORAGE_KEYS.schemaVersion, version);
 }
 
-// Append only: index + 1 is the schema version. Never reorder or remove entries.
-const migrations: readonly Migration[] = [
-  {
-    description: 'Add domain field to existing cards, defaulting to leetcode.com',
-    migrate: (data: MigrationData): MigrationData => {
-      if (!data.cards) return data;
-      const cards = Object.fromEntries(
-        Object.entries(data.cards).map(([slug, card]) => {
-          // Leave malformed records for record validation after migration.
-          if (typeof card !== 'object' || card === null || Array.isArray(card)) return [slug, card];
-          if ('domain' in card && card.domain) return [slug, card];
-          return [slug, { ...card, domain: 'leetcode.com' }];
-        })
-      );
-      return { cards };
-    },
-  },
-  {
-    description: 'Add system theme preference',
-    migrate: (data: MigrationData): MigrationData => data,
-  },
-  {
-    description: 'Remove configurable day start',
-    migrate: (data: MigrationData): MigrationData => data,
-    removeKeys: ['sync:leetsrs:dayStartHour'],
-  },
-];
-
-export function migrateBackupData(data: MigrationData, schemaVersion: number): MigrationData {
-  if (!Number.isInteger(schemaVersion) || schemaVersion < 0 || schemaVersion > migrations.length) {
-    throw new Error(`Unsupported schema version: ${schemaVersion}`);
-  }
+export function migrateBackupData(
+  data: unknown,
+  schemaVersion: number,
+  steps: readonly Migration[] = migrations
+): unknown {
+  checkVersion(schemaVersion, steps.length);
   let migrated = data;
-  for (const migration of migrations.slice(schemaVersion)) {
+  for (const migration of steps.slice(schemaVersion)) {
     migrated = migration.migrate(migrated);
   }
   return migrated;
 }
 
 export async function runStartupMigrations(steps: readonly Migration[] = migrations): Promise<void> {
-  const currentVersion = await getCurrentSchemaVersion();
-  for (const [index, migration] of steps.slice(currentVersion).entries()) {
-    const version = currentVersion + index + 1;
-    try {
-      const cards = await storage.getItem<Record<string, unknown>>(STORAGE_KEYS.cards);
-      const data = { cards: cards ?? undefined };
-      const migrated = migration.migrate(data);
-      if (migrated.cards !== undefined) {
-        await storage.setItem(STORAGE_KEYS.cards, migrated.cards);
+  let phase = 'read recovery metadata';
+  let step = 'startup recovery';
+  try {
+    const currentVersion = await getCurrentSchemaVersion();
+    checkVersion(currentVersion, steps.length);
+    const saved = await storage.getItem<unknown>(STORAGE_KEYS.migrationSnapshot);
+    let snapshot: z.infer<typeof snapshotSchema> | undefined;
+    if (saved !== null) {
+      const parsed = snapshotSchema.safeParse(saved);
+      if (
+        !parsed.success ||
+        parsed.data.version > steps.length ||
+        (parsed.data.version !== currentVersion && parsed.data.version !== currentVersion + 1)
+      ) {
+        throw new Error(
+          'Inconsistent migration recovery metadata. Preserve the snapshot and restore compatible recovery metadata before retrying.'
+        );
       }
-      if (migration.removeKeys) {
-        await storage.removeItems([...migration.removeKeys]);
+      snapshot = parsed.data;
+      if (snapshot.version === currentVersion) {
+        // Destination writes, cleanup, and version advancement already succeeded.
+        phase = 'retire recovery snapshot';
+        await storage.removeItem(STORAGE_KEYS.migrationSnapshot);
+        snapshot = undefined;
       }
-      await setSchemaVersion(version);
-    } catch (error) {
-      throw new Error(`Failed to run migration ${version}: ${error}`);
     }
+    for (const [index, migration] of steps.slice(currentVersion).entries()) {
+      const version = currentVersion + index + 1;
+      step = `migration ${version} (${migration.description})`;
+      phase = 'load original input';
+      if (!snapshot) {
+        const input = await migration.load();
+        phase = 'save recovery snapshot';
+        snapshot = snapshotSchema.parse({ version, input });
+        await storage.setItem(STORAGE_KEYS.migrationSnapshot, snapshot);
+      }
+      phase = 'transform and validate';
+      const migrated = migration.migrate(snapshot.input);
+      phase = 'save destination';
+      await migration.save(migrated);
+      phase = 'clean obsolete sources';
+      await migration.cleanup?.(snapshot.input);
+      phase = 'record completed version';
+      await setSchemaVersion(version);
+      phase = 'retire recovery snapshot';
+      await storage.removeItem(STORAGE_KEYS.migrationSnapshot);
+      snapshot = undefined;
+    }
+  } catch (error) {
+    throw new Error(
+      `Failed to run ${step} during ${phase}: ${error}. ` +
+        'Startup is blocked. Resolve the error and reload the extension to retry; keep any saved recovery snapshot.',
+      { cause: error }
+    );
   }
 }

--- a/infrastructure/storage/migrations.ts
+++ b/infrastructure/storage/migrations.ts
@@ -14,7 +14,8 @@ export const LATEST_SCHEMA_VERSION = migrations.length;
 
 const snapshotSchema = z.object({
   version: z.number().int().positive(),
-  input: z.json(),
+  // Validate JSON compatibility without using Zod's parsed copy, which strips keys such as __proto__.
+  input: z.unknown().refine((input) => z.json().safeParse(input).success, 'Migration input must be lossless JSON data'),
 });
 
 function checkVersion(version: number, latest: number): void {

--- a/infrastructure/storage/migrations/001-card-domain.ts
+++ b/infrastructure/storage/migrations/001-card-domain.ts
@@ -11,7 +11,7 @@ function validateDataset(data: unknown): asserts data is z.infer<typeof datasetS
   datasetSchema.parse(data);
 }
 
-export function migrate(data: unknown): unknown {
+function migrate(data: unknown): unknown {
   validateDataset(data);
   if (!data.cards) return data;
   return {

--- a/infrastructure/storage/migrations/001-card-domain.ts
+++ b/infrastructure/storage/migrations/001-card-domain.ts
@@ -6,13 +6,18 @@ import { loadLegacyData } from './legacy-storage';
 // This is the v0 shape, deliberately independent of today's Card schema.
 const datasetSchema = z.looseObject({ cards: z.record(z.string(), z.unknown()).nullish() });
 
+function validateDataset(data: unknown): asserts data is z.infer<typeof datasetSchema> {
+  // Use validation without the parsed copy so historical JSON keys remain intact.
+  datasetSchema.parse(data);
+}
+
 export function migrate(data: unknown): unknown {
-  const dataset = datasetSchema.parse(data);
-  if (!dataset.cards) return dataset;
+  validateDataset(data);
+  if (!data.cards) return data;
   return {
-    ...dataset,
+    ...data,
     cards: Object.fromEntries(
-      Object.entries(dataset.cards).map(([slug, card]) => {
+      Object.entries(data.cards).map(([slug, card]) => {
         // Preserve malformed records for later validation. Repair only falsy/missing domains.
         if (typeof card !== 'object' || card === null || Array.isArray(card)) return [slug, card];
         if ('domain' in card && card.domain) return [slug, card];
@@ -27,7 +32,8 @@ export const cardDomainMigration: Migration = {
   load: loadLegacyData,
   migrate,
   save: async (data) => {
-    const { cards } = datasetSchema.parse(data);
+    validateDataset(data);
+    const { cards } = data;
     if (cards != null) await storage.setItem('local:leetsrs:cards', cards);
   },
 };

--- a/infrastructure/storage/migrations/001-card-domain.ts
+++ b/infrastructure/storage/migrations/001-card-domain.ts
@@ -1,0 +1,33 @@
+import { z } from 'zod';
+import { storage } from '#imports';
+import type { Migration } from './contract';
+import { loadLegacyData } from './legacy-storage';
+
+// This is the v0 shape, deliberately independent of today's Card schema.
+const datasetSchema = z.looseObject({ cards: z.record(z.string(), z.unknown()).nullish() });
+
+export function migrate(data: unknown): unknown {
+  const dataset = datasetSchema.parse(data);
+  if (!dataset.cards) return dataset;
+  return {
+    ...dataset,
+    cards: Object.fromEntries(
+      Object.entries(dataset.cards).map(([slug, card]) => {
+        // Preserve malformed records for later validation. Repair only falsy/missing domains.
+        if (typeof card !== 'object' || card === null || Array.isArray(card)) return [slug, card];
+        if ('domain' in card && card.domain) return [slug, card];
+        return [slug, { ...card, domain: 'leetcode.com' }];
+      })
+    ),
+  };
+}
+
+export const cardDomainMigration: Migration = {
+  description: 'Add domain field to existing cards, defaulting to leetcode.com',
+  load: loadLegacyData,
+  migrate,
+  save: async (data) => {
+    const { cards } = datasetSchema.parse(data);
+    if (cards != null) await storage.setItem('local:leetsrs:cards', cards);
+  },
+};

--- a/infrastructure/storage/migrations/001-card-domain.ts
+++ b/infrastructure/storage/migrations/001-card-domain.ts
@@ -5,35 +5,59 @@ import { loadLegacyData } from './legacy-storage';
 
 // This is the v0 shape, deliberately independent of today's Card schema.
 const datasetSchema = z.looseObject({ cards: z.record(z.string(), z.unknown()).nullish() });
+// Only object cards gain a domain. Other JSON records and truthy historical domains remain unchanged.
+const migratedCardSchema = z.union([
+  z.looseObject({ domain: z.custom<NonNullable<unknown>>((domain) => Boolean(domain)) }),
+  z.string(),
+  z.number(),
+  z.boolean(),
+  z.null(),
+  z.array(z.unknown()),
+]);
 
-function validateDataset(data: unknown): asserts data is z.infer<typeof datasetSchema> {
+type InputDataset = z.infer<typeof datasetSchema>;
+type OutputDataset = InputDataset & {
+  cards?: Record<string, z.infer<typeof migratedCardSchema>> | null;
+};
+
+function validateDataset(data: unknown): asserts data is InputDataset {
   // Use validation without the parsed copy so historical JSON keys remain intact.
   datasetSchema.parse(data);
 }
 
-function migrate(data: unknown): unknown {
+function validateOutput(data: unknown): asserts data is OutputDataset {
   validateDataset(data);
-  if (!data.cards) return data;
-  return {
-    ...data,
-    cards: Object.fromEntries(
-      Object.entries(data.cards).map(([slug, card]) => {
-        // Preserve malformed records for later validation. Repair only falsy/missing domains.
-        if (typeof card !== 'object' || card === null || Array.isArray(card)) return [slug, card];
-        if ('domain' in card && card.domain) return [slug, card];
-        return [slug, { ...card, domain: 'leetcode.com' }];
-      })
-    ),
-  };
+  // Visit the original values: record parsing can omit legal JSON keys such as __proto__.
+  for (const card of Object.values(data.cards ?? {})) migratedCardSchema.parse(card);
 }
 
-export const cardDomainMigration: Migration = {
+function migrate(data: unknown): OutputDataset {
+  validateDataset(data);
+  let output = data;
+  if (data.cards) {
+    output = {
+      ...data,
+      cards: Object.fromEntries(
+        Object.entries(data.cards).map(([slug, card]) => {
+          // Preserve malformed records for later validation. Repair only falsy/missing domains.
+          if (typeof card !== 'object' || card === null || Array.isArray(card)) return [slug, card];
+          if ('domain' in card && card.domain) return [slug, card];
+          return [slug, { ...card, domain: 'leetcode.com' }];
+        })
+      ),
+    };
+  }
+  validateOutput(output);
+  return output;
+}
+
+export const cardDomainMigration = {
   description: 'Add domain field to existing cards, defaulting to leetcode.com',
   load: loadLegacyData,
   migrate,
   save: async (data) => {
-    validateDataset(data);
+    validateOutput(data);
     const { cards } = data;
     if (cards != null) await storage.setItem('local:leetsrs:cards', cards);
   },
-};
+} satisfies Migration;

--- a/infrastructure/storage/migrations/002-system-theme.ts
+++ b/infrastructure/storage/migrations/002-system-theme.ts
@@ -2,13 +2,13 @@ import type { Migration } from './contract';
 import { loadLegacyData } from './legacy-storage';
 
 // Adding the system preference changed no stored values. Preserve all input, including malformed records.
-function migrate(data: unknown): unknown {
+function migrate<Dataset>(data: Dataset): Dataset {
   return data;
 }
 
-export const systemThemeMigration: Migration = {
+export const systemThemeMigration = {
   description: 'Add system theme preference',
   load: loadLegacyData,
   migrate,
   save: async () => {},
-};
+} satisfies Migration;

--- a/infrastructure/storage/migrations/002-system-theme.ts
+++ b/infrastructure/storage/migrations/002-system-theme.ts
@@ -1,7 +1,8 @@
 import type { Migration } from './contract';
 import { loadLegacyData } from './legacy-storage';
+
 // Adding the system preference changed no stored values. Preserve all input, including malformed records.
-export function migrate(data: unknown): unknown {
+function migrate(data: unknown): unknown {
   return data;
 }
 

--- a/infrastructure/storage/migrations/002-system-theme.ts
+++ b/infrastructure/storage/migrations/002-system-theme.ts
@@ -1,0 +1,13 @@
+import type { Migration } from './contract';
+import { loadLegacyData } from './legacy-storage';
+// Adding the system preference changed no stored values. Preserve all input, including malformed records.
+export function migrate(data: unknown): unknown {
+  return data;
+}
+
+export const systemThemeMigration: Migration = {
+  description: 'Add system theme preference',
+  load: loadLegacyData,
+  migrate,
+  save: async () => {},
+};

--- a/infrastructure/storage/migrations/003-remove-day-start.ts
+++ b/infrastructure/storage/migrations/003-remove-day-start.ts
@@ -1,0 +1,22 @@
+import { z } from 'zod';
+import { storage } from '#imports';
+import type { Migration } from './contract';
+import { loadLegacyData } from './legacy-storage';
+
+const datasetSchema = z.looseObject({ settings: z.record(z.string(), z.unknown()).optional() });
+
+export function migrate(data: unknown): unknown {
+  const dataset = datasetSchema.parse(data);
+  if (!dataset.settings) return dataset;
+  // Discard only the retired setting, regardless of its value. Preserve other historical fields.
+  const { dayStartHour: _removed, ...settings } = dataset.settings;
+  return { ...dataset, settings };
+}
+
+export const removeDayStartMigration: Migration = {
+  description: 'Remove configurable day start',
+  load: loadLegacyData,
+  migrate,
+  save: async () => {},
+  cleanup: () => storage.removeItems(['sync:leetsrs:dayStartHour']),
+};

--- a/infrastructure/storage/migrations/003-remove-day-start.ts
+++ b/infrastructure/storage/migrations/003-remove-day-start.ts
@@ -6,11 +6,16 @@ import { loadLegacyData } from './legacy-storage';
 const datasetSchema = z.looseObject({ settings: z.record(z.string(), z.unknown()).optional() });
 
 export function migrate(data: unknown): unknown {
-  const dataset = datasetSchema.parse(data);
-  if (!dataset.settings) return dataset;
+  validateDataset(data);
+  if (!data.settings) return data;
   // Discard only the retired setting, regardless of its value. Preserve other historical fields.
-  const { dayStartHour: _removed, ...settings } = dataset.settings;
-  return { ...dataset, settings };
+  const { dayStartHour: _removed, ...settings } = data.settings;
+  return { ...data, settings };
+}
+
+function validateDataset(data: unknown): asserts data is z.infer<typeof datasetSchema> {
+  // Use validation without the parsed copy so historical JSON keys remain intact.
+  datasetSchema.parse(data);
 }
 
 export const removeDayStartMigration: Migration = {

--- a/infrastructure/storage/migrations/003-remove-day-start.ts
+++ b/infrastructure/storage/migrations/003-remove-day-start.ts
@@ -5,17 +5,17 @@ import { loadLegacyData } from './legacy-storage';
 
 const datasetSchema = z.looseObject({ settings: z.record(z.string(), z.unknown()).optional() });
 
-export function migrate(data: unknown): unknown {
+function validateDataset(data: unknown): asserts data is z.infer<typeof datasetSchema> {
+  // Use validation without the parsed copy so historical JSON keys remain intact.
+  datasetSchema.parse(data);
+}
+
+function migrate(data: unknown): unknown {
   validateDataset(data);
   if (!data.settings) return data;
   // Discard only the retired setting, regardless of its value. Preserve other historical fields.
   const { dayStartHour: _removed, ...settings } = data.settings;
   return { ...data, settings };
-}
-
-function validateDataset(data: unknown): asserts data is z.infer<typeof datasetSchema> {
-  // Use validation without the parsed copy so historical JSON keys remain intact.
-  datasetSchema.parse(data);
 }
 
 export const removeDayStartMigration: Migration = {

--- a/infrastructure/storage/migrations/003-remove-day-start.ts
+++ b/infrastructure/storage/migrations/003-remove-day-start.ts
@@ -5,23 +5,39 @@ import { loadLegacyData } from './legacy-storage';
 
 const datasetSchema = z.looseObject({ settings: z.record(z.string(), z.unknown()).optional() });
 
-function validateDataset(data: unknown): asserts data is z.infer<typeof datasetSchema> {
+type InputDataset = z.infer<typeof datasetSchema>;
+type OutputDataset = InputDataset & {
+  settings?: Record<string, unknown> & { dayStartHour?: never };
+};
+
+function validateDataset(data: unknown): asserts data is InputDataset {
   // Use validation without the parsed copy so historical JSON keys remain intact.
   datasetSchema.parse(data);
 }
 
-function migrate(data: unknown): unknown {
+function validateOutput(data: unknown): asserts data is OutputDataset {
   validateDataset(data);
-  if (!data.settings) return data;
-  // Discard only the retired setting, regardless of its value. Preserve other historical fields.
-  const { dayStartHour: _removed, ...settings } = data.settings;
-  return { ...data, settings };
+  if (data.settings && Object.hasOwn(data.settings, 'dayStartHour')) {
+    throw new Error('Migrated settings must not contain dayStartHour');
+  }
 }
 
-export const removeDayStartMigration: Migration = {
+function migrate(data: unknown): OutputDataset {
+  validateDataset(data);
+  let output = data;
+  if (data.settings) {
+    // Discard only the retired setting, regardless of its value. Preserve other historical fields.
+    const { dayStartHour: _removed, ...settings } = data.settings;
+    output = { ...data, settings };
+  }
+  validateOutput(output);
+  return output;
+}
+
+export const removeDayStartMigration = {
   description: 'Remove configurable day start',
   load: loadLegacyData,
   migrate,
   save: async () => {},
   cleanup: () => storage.removeItems(['sync:leetsrs:dayStartHour']),
-};
+} satisfies Migration;

--- a/infrastructure/storage/migrations/contract.ts
+++ b/infrastructure/storage/migrations/contract.ts
@@ -1,0 +1,9 @@
+export interface Migration {
+  description: string;
+  // Return JSON-serializable data containing every input needed to repeat migrate and cleanup.
+  load: () => Promise<unknown>;
+  // Check historical input and output here; startup and imports always use this transformation.
+  migrate: (data: unknown) => unknown;
+  save: (data: unknown) => Promise<void>;
+  cleanup?: (input: unknown) => Promise<void>;
+}

--- a/infrastructure/storage/migrations/contract.ts
+++ b/infrastructure/storage/migrations/contract.ts
@@ -3,6 +3,7 @@ export interface Migration {
   // Return JSON-serializable data containing every input needed to repeat migrate and cleanup.
   load: () => Promise<unknown>;
   // Check historical input and output here; startup and imports always use this transformation.
+  // Concrete migrations retain local output types; the heterogeneous version sequence handles unknown data.
   migrate: (data: unknown) => unknown;
   save: (data: unknown) => Promise<void>;
   cleanup?: (input: unknown) => Promise<void>;

--- a/infrastructure/storage/migrations/legacy-storage.ts
+++ b/infrastructure/storage/migrations/legacy-storage.ts
@@ -1,0 +1,37 @@
+import { storage } from '#imports';
+
+// The physical layout used by versions 0–3. Keep these names independent of current models/adapters.
+const settingNames = [
+  'maxNewCardsPerDay',
+  'theme',
+  'autoClearLeetcode',
+  'resetEditorOnDueReview',
+  'badgeEnabled',
+  'language',
+  'dayStartHour',
+] as const;
+
+export async function loadLegacyData(): Promise<unknown> {
+  const [local, sync] = await Promise.all([storage.snapshot('local'), storage.snapshot('sync')]);
+  return {
+    ...Object.fromEntries(
+      ['cards', 'stats', 'monthlyStats'].flatMap((name) =>
+        Object.hasOwn(local, `leetsrs:${name}`) ? [[name, local[`leetsrs:${name}`]]] : []
+      )
+    ),
+    notes: Object.fromEntries(
+      Object.entries(local)
+        .filter(([key]) => key.startsWith('leetsrs:notes:'))
+        .map(([key, value]) => [key.slice('leetsrs:notes:'.length), value])
+    ),
+    settings: Object.fromEntries(
+      settingNames.flatMap((name) => (Object.hasOwn(sync, `leetsrs:${name}`) ? [[name, sync[`leetsrs:${name}`]]] : []))
+    ),
+    gistSync: Object.fromEntries(
+      [
+        ['gistId', 'gistId'],
+        ['enabled', 'gistSyncEnabled'],
+      ].flatMap(([name, key]) => (Object.hasOwn(sync, `leetsrs:${key}`) ? [[name, sync[`leetsrs:${key}`]]] : []))
+    ),
+  };
+}

--- a/infrastructure/storage/storage-keys.ts
+++ b/infrastructure/storage/storage-keys.ts
@@ -9,6 +9,8 @@ export const STORAGE_KEYS = {
   badgeEnabled: 'sync:leetsrs:badgeEnabled',
   language: 'sync:leetsrs:language',
   schemaVersion: 'local:leetsrs:schemaVersion',
+  // Recovery metadata stays in local storage even when learning data moves elsewhere.
+  migrationSnapshot: 'local:leetsrs:migrationSnapshot',
   // Tracks when actual data was last modified (for sync)
   dataUpdatedAt: 'local:leetsrs:dataUpdatedAt',
   // GitHub Gist Sync

--- a/services/__tests__/import-export.test.ts
+++ b/services/__tests__/import-export.test.ts
@@ -482,7 +482,7 @@ describe('import-export', () => {
       const notes = { ...validExportData.data.notes, 'cn-card-id': { text: 'Keep the carry' } };
       const dataUpdatedAt = '2024-01-15T10:00:00.000Z';
 
-      it.each([0, undefined, 2, 3])(
+      it.each([0, undefined, 1, 2, 3])(
         'prepares and imports schema %s cards identically to startup migration',
         async (schemaVersion) => {
           await storage.setItem(STORAGE_KEYS.cards, legacyCards);

--- a/services/__tests__/import-export.test.ts
+++ b/services/__tests__/import-export.test.ts
@@ -2,10 +2,11 @@ import { createEmptyCard, Rating, State } from 'ts-fsrs';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { fakeBrowser } from 'wxt/testing/fake-browser';
 import { storage } from 'wxt/utils/storage';
+import { z } from 'zod';
 import type { Card } from '@/domain/cards';
 import type { Note } from '@/domain/notes';
 import type { DailyStats } from '@/domain/statistics';
-import { runStartupMigrations, setSchemaVersion } from '@/infrastructure/storage/migrations';
+import { type Migration, runStartupMigrations, setSchemaVersion } from '@/infrastructure/storage/migrations';
 import { STORAGE_KEYS } from '@/infrastructure/storage/storage-keys';
 import { malformedBackupCases, mixedRecordBackup } from '@/test/utils/backup-mocks';
 import { createMockCard } from '@/test/utils/card-mocks';
@@ -97,7 +98,7 @@ describe('import-export', () => {
       const result = await exportData();
       const parsed = JSON.parse(result);
 
-      expect(parsed.schemaVersion).toBe(0);
+      expect(parsed.schemaVersion).toBe(3);
       expect(parsed.exportDate).toMatch(/^\d{4}-\d{2}-\d{2}T/);
       expect(parsed.data.stats).toEqual(mockStats);
       expect(parsed.data.notes).toEqual(mockNotes);
@@ -116,7 +117,7 @@ describe('import-export', () => {
       const parsed = JSON.parse(result);
 
       expect(parsed).toMatchObject({
-        schemaVersion: 0,
+        schemaVersion: 3,
         exportDate: expect.any(String),
         data: {
           cards: {},
@@ -144,6 +145,56 @@ describe('import-export', () => {
   });
 
   describe('importData', () => {
+    it('migrates raw historical shapes and configuration before current validation', async () => {
+      const card = createMockCard(State.New, { id: 'one', slug: 'two-sum' });
+      const notes = { one: { text: 'Keep this note' } };
+      const historicalSchema = z.tuple([
+        z.array(z.looseObject({ slug: z.string() })),
+        z.record(z.string(), z.unknown()),
+        z.object({ theme: z.literal('night'), historicalField: z.literal('needed to migrate') }),
+      ]);
+      const noStorage = () => {
+        throw new Error('Import must not execute startup I/O');
+      };
+      const migration: Migration = {
+        description: 'Convert a historical tuple to the current dataset',
+        load: noStorage,
+        migrate: (data) => {
+          const [cards, notes] = historicalSchema.parse(data);
+          return {
+            cards: Object.fromEntries(cards.map((card) => [card.slug, card])),
+            notes,
+            stats: {},
+            settings: { theme: 'dark' },
+          };
+        },
+        save: noStorage,
+        cleanup: noStorage,
+      };
+      const payload = {
+        exportDate: '2024-01-01T00:00:00.000Z',
+        data: [[card], notes, { theme: 'night', historicalField: 'needed to migrate' }],
+      };
+      const before = await storage.snapshot('local');
+
+      const prepared = await prepareImportData(JSON.stringify(payload), [migration]);
+
+      expect(prepared.cards).toEqual({ 'two-sum': card });
+      expect(prepared.notes).toEqual(notes);
+      expect(prepared.settings).toEqual({ theme: 'dark' });
+      await expect(prepareImportData(JSON.stringify({ ...payload, schemaVersion: 2 }), [migration])).rejects.toThrow(
+        'newer version'
+      );
+      await expect(
+        prepareImportData(
+          JSON.stringify({ ...payload, data: [[card], { orphan: { text: 'invalid owner' } }, payload.data[2]] }),
+          [migration]
+        )
+      ).rejects.toThrow('Note has no owning card');
+      expect(await storage.snapshot('local')).toEqual(before);
+      expect(await storage.snapshot('sync')).toEqual({});
+    });
+
     it.each(['cards', 'stats', 'notes'] as const)(
       'rejects mixed invalid %s during preparation and import without changing storage',
       async (collection) => {
@@ -217,7 +268,7 @@ describe('import-export', () => {
         expect(restored.data).toMatchObject(JSON.parse(JSON.stringify(data)));
         expect(restored.data.cards).toEqual(JSON.parse(JSON.stringify(data.cards)));
         expect(restored.dataUpdatedAt).toBe(payload.dataUpdatedAt);
-        expect(restored.schemaVersion).toBe(2);
+        expect(restored.schemaVersion).toBe(3);
       }
     );
 
@@ -283,7 +334,7 @@ describe('import-export', () => {
       await setSchemaVersion(2);
     }
 
-    it('propagates schema-read failures without changing existing data', async () => {
+    it('accepts code-supported backups without consulting device progress or writing recovery snapshots', async () => {
       await seedExistingData();
       const failure = new Error('schema unavailable');
       const read = storage.getItem.bind(storage);
@@ -292,7 +343,8 @@ describe('import-export', () => {
       );
       const before = await fakeBrowser.storage.local.get(null);
 
-      await expect(importData(JSON.stringify(validExportData))).rejects.toBe(failure);
+      const prepared = await prepareImportData(JSON.stringify({ ...validExportData, schemaVersion: 3 }));
+      expect(prepared.cards).toEqual(validExportData.data.cards);
       expect(await fakeBrowser.storage.local.get(null)).toEqual(before);
     });
 

--- a/services/import-export.ts
+++ b/services/import-export.ts
@@ -1,8 +1,8 @@
-import { normalizeImportData, validateImportRelationships, validateImportStructure } from '@/domain/backup-import';
+import { normalizeImportData, parseImportEnvelope, validateImportRelationships } from '@/domain/backup-import';
 import type { ExportData, PreparedImportData } from '@/infrastructure/storage/backup';
 import { validateBackupRecords } from '@/infrastructure/storage/backup';
 import { getAllCards, removeCards, saveCards } from '@/infrastructure/storage/cards';
-import { getCurrentSchemaVersion, migrateBackupData } from '@/infrastructure/storage/migrations';
+import { LATEST_SCHEMA_VERSION, type Migration, migrateBackupData } from '@/infrastructure/storage/migrations';
 import { deleteNote, getNotesForCards, saveNote } from '@/infrastructure/storage/notes';
 import { getStats, removeStats, saveStats } from '@/infrastructure/storage/stats';
 import { readSyncMetadata, removeSyncMetadata, writeSyncMetadata } from '@/infrastructure/storage/sync-metadata';
@@ -11,7 +11,7 @@ import { exportSettings, resetSettings, updateSettings } from './settings';
 
 export async function exportData(): Promise<string> {
   const cardsPromise = getAllCards();
-  const [cards, stats, notes, settings, gistId, gistSyncEnabled, dataUpdatedAt, schemaVersion] = await Promise.all([
+  const [cards, stats, notes, settings, gistId, gistSyncEnabled, dataUpdatedAt] = await Promise.all([
     cardsPromise,
     getStats(),
     cardsPromise.then((cards) => getNotesForCards(cards)),
@@ -19,11 +19,10 @@ export async function exportData(): Promise<string> {
     readSyncMetadata('gistId'),
     readSyncMetadata('gistSyncEnabled'),
     readSyncMetadata('dataUpdatedAt'),
-    getCurrentSchemaVersion(),
   ]);
 
   const exportData: ExportData = {
-    schemaVersion,
+    schemaVersion: LATEST_SCHEMA_VERSION,
     exportDate: new Date().toISOString(),
     dataUpdatedAt: dataUpdatedAt ?? undefined,
     data: {
@@ -41,7 +40,7 @@ export async function exportData(): Promise<string> {
   return JSON.stringify(exportData, null, 2);
 }
 
-export async function prepareImportData(jsonData: string): Promise<PreparedImportData> {
+export async function prepareImportData(jsonData: string, steps?: readonly Migration[]): Promise<PreparedImportData> {
   let data: unknown;
   try {
     data = JSON.parse(jsonData);
@@ -49,12 +48,12 @@ export async function prepareImportData(jsonData: string): Promise<PreparedImpor
     throw new Error('Invalid JSON format');
   }
 
-  validateImportStructure(data);
-  const currentSchema = await getCurrentSchemaVersion();
-  const { schemaVersion, ...normalizedData } = normalizeImportData(data, currentSchema);
-  const migrated = migrateBackupData({ cards: normalizedData.cards }, schemaVersion);
+  const latestVersion = steps?.length ?? LATEST_SCHEMA_VERSION;
+  const envelope = parseImportEnvelope(data, latestVersion);
+  const migrated = migrateBackupData(envelope.data, envelope.schemaVersion, steps);
+  const normalizedData = normalizeImportData({ ...envelope, data: migrated }, latestVersion);
   const validRecords = validateBackupRecords({
-    cards: migrated.cards,
+    cards: normalizedData.cards,
     stats: normalizedData.stats,
     notes: normalizedData.notes,
   });


### PR DESCRIPTION
- Share numbered, whole-dataset migrations with local output types and validation between startup and backup import.
- Recover interrupted startup steps from durable original-input snapshots, keeping data operations blocked until recovery succeeds.
- Migrate raw imports before current validation and use the code-supported schema version for compatibility and exports.
- Verify recovery phases, storage moves, historical record policies, 1→3 upgrades, and background readiness; `npm run check` (912 tests) and `npm run build` pass.

Closes #344
