### PR TITLE
ci: follow latest Claude action v1 release

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@9c5ddab2e6d17b83ea679153b31f1d5f023cf636 # v1.0.217; pinned for anthropics/claude-code-action#1817
+        uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: https://github.com/mattpocock/skills.git

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@9c5ddab2e6d17b83ea679153b31f1d5f023cf636 # v1.0.217; pinned for anthropics/claude-code-action#1817
+        uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: https://github.com/mattpocock/skills.git


### PR DESCRIPTION
- Replace the v1.0.217 commit pin in both Claude workflows with floating `anthropics/claude-code-action@v1`, currently v1.0.221, to receive future v1 updates automatically.
- `npm run check` passes (869 tests).

Follow-up to the intermittent review stalls on #346. The [reported run](https://github.com/mattcdrake/LeetSRS/actions/runs/34536754367) eventually succeeded; this update does not confirm the stalls are resolved.
