### PR TITLE
fix: migrate raw backups before validation

### DIFF
--- a/domain/__tests__/backup-import.test.ts
+++ b/domain/__tests__/backup-import.test.ts
@@ -33,14 +33,11 @@ describe('backup import policy', () => {
             },
           },
         })
-      ),
-      0
+      ).data
     );
     expect(prepared).toEqual({
       ...payload.data,
-      schemaVersion: 0,
       settings: { resetEditorOnEveryProblem: false },
-      dataUpdatedAt: incomingTime,
     });
   });
 
@@ -50,14 +47,14 @@ describe('backup import policy', () => {
       dayStartHour: 5,
       maxNewCardsPerDay: 8,
     });
-    expect(normalizeImportData({ ...payload, data: { ...payload.data, settings } }, 2).settings).toEqual({
+    expect(normalizeImportData({ ...payload.data, settings }).settings).toEqual({
       maxNewCardsPerDay: 8,
     });
   });
 
   it.each([true, false])('maps legacy autoClearLeetcode %s to the current setting', (value) => {
-    expect(
-      normalizeImportData({ ...payload, data: { ...payload.data, settings: { autoClearLeetcode: value } } }, 2).settings
-    ).toEqual({ resetEditorOnEveryProblem: value });
+    expect(normalizeImportData({ ...payload.data, settings: { autoClearLeetcode: value } }).settings).toEqual({
+      resetEditorOnEveryProblem: value,
+    });
   });
 });

--- a/domain/backup-import.ts
+++ b/domain/backup-import.ts
@@ -48,22 +48,25 @@ function getImportedSettings(settings: unknown): Partial<Settings> {
   return settingsUpdateSchema.parse(importedSettings);
 }
 
-export function normalizeImportData(data: BackupImportEnvelope, currentSchema: number) {
+export function parseImportMetadata(data: BackupImportEnvelope, supportedSchema: number) {
   const importedSchema = schemaVersionSchema.optional().parse(data.schemaVersion) ?? 0;
-  if (importedSchema > currentSchema) {
+  if (importedSchema > supportedSchema) {
     throw new Error(`Export is from a newer version (schema ${importedSchema}). Please update the extension.`);
   }
   timestampSchema.parse(data.exportDate);
   const dataUpdatedAt = timestampSchema.optional().parse(data.dataUpdatedAt);
 
+  return { schemaVersion: importedSchema, dataUpdatedAt };
+}
+
+export function normalizeImportData(data: unknown) {
+  const records = structureSchema.shape.data.parse(data);
   return {
-    schemaVersion: importedSchema,
-    cards: objectMapSchema.parse(data.data.cards),
-    stats: objectMapSchema.parse(data.data.stats),
-    notes: objectMapSchema.parse(data.data.notes),
-    settings: getImportedSettings(data.data.settings),
-    gistSync: gistSyncBackupSchema.optional().parse(data.data.gistSync),
-    dataUpdatedAt,
+    cards: objectMapSchema.parse(records.cards),
+    stats: objectMapSchema.parse(records.stats),
+    notes: objectMapSchema.parse(records.notes),
+    settings: getImportedSettings(records.settings),
+    gistSync: gistSyncBackupSchema.optional().parse(records.gistSync),
   };
 }
 

--- a/domain/backup-import.ts
+++ b/domain/backup-import.ts
@@ -30,6 +30,7 @@ export const backupMetadataSchema = z.object({
 });
 
 export function validateImportStructure(data: unknown): asserts data is BackupImportEnvelope {
+  // Validate without replacing the raw input; parsing strips fields historical migrations may need.
   structureSchema.parse(data);
 }
 

--- a/infrastructure/storage/migrations/__tests__/runner.test.ts
+++ b/infrastructure/storage/migrations/__tests__/runner.test.ts
@@ -10,13 +10,7 @@ import { STORAGE_KEYS } from '../../storage-keys';
 import type { addCardDomain } from '../001-add-card-domain';
 import type { addSystemTheme } from '../002-add-system-theme';
 import type { removeDayStart } from '../003-remove-day-start';
-import {
-  getCurrentSchemaVersion,
-  LATEST_SCHEMA_VERSION,
-  migrateBackupData,
-  runStartupMigrations,
-  setSchemaVersion,
-} from '../runner';
+import { LATEST_SCHEMA_VERSION, migrateBackupData, runStartupMigrations, setSchemaVersion } from '../runner';
 
 describe('migrations', () => {
   beforeEach(() => {
@@ -170,19 +164,6 @@ describe('migrations', () => {
     });
   });
 
-  describe('getCurrentSchemaVersion', () => {
-    it('should return 0 when no version is stored', async () => {
-      const version = await getCurrentSchemaVersion();
-      expect(version).toBe(0);
-    });
-
-    it('should return stored version', async () => {
-      await storage.setItem(STORAGE_KEYS.schemaVersion, 5);
-      const version = await getCurrentSchemaVersion();
-      expect(version).toBe(5);
-    });
-  });
-
   describe('setSchemaVersion', () => {
     it('should set schema version', async () => {
       await setSchemaVersion(3);
@@ -295,7 +276,7 @@ describe('migrations', () => {
               : vi.spyOn(storage, 'removeItem').mockRejectedValueOnce(new Error('cleanup unavailable'));
           try {
             await expect(runStartupMigrations(steps)).rejects.toThrow('Failed to run migration 1');
-            expect(await getCurrentSchemaVersion()).toBe(0);
+            expect(await storage.getItem(STORAGE_KEYS.schemaVersion)).toBeNull();
             expect(await storage.getItem('local:test:source')).toEqual(source);
             expect(await storage.getItem('local:test:titles')).toEqual(
               failure === 'save' ? null : ['Two Sum', 'Add Two Numbers']
@@ -357,7 +338,7 @@ describe('migrations', () => {
       await runStartupMigrations();
       await runStartupMigrations();
 
-      expect(await getCurrentSchemaVersion()).toBe(3);
+      expect(await storage.getItem(STORAGE_KEYS.schemaVersion)).toBe(3);
       expect(await fakeBrowser.storage.local.get(null)).toEqual({
         ...localBefore,
         'leetsrs:schemaVersion': 3,
@@ -412,7 +393,7 @@ describe('migrations', () => {
       });
       try {
         await expect(runStartupMigrations()).rejects.toThrow('Failed to run migration 1');
-        expect(await getCurrentSchemaVersion()).toBe(0);
+        expect(await storage.getItem(STORAGE_KEYS.schemaVersion)).toBeNull();
         expect(writes.mock.calls.map(([key]) => key)).not.toContain(STORAGE_KEYS.schemaVersion);
       } finally {
         writes.mockRestore();
@@ -453,7 +434,7 @@ describe('migrations', () => {
       });
       try {
         await expect(runStartupMigrations()).rejects.toThrow('schema persistence failed');
-        expect(await getCurrentSchemaVersion()).toBe(0);
+        expect(await storage.getItem(STORAGE_KEYS.schemaVersion)).toBeNull();
         expect(await fakeBrowser.storage.local.get(null)).toEqual(expectedAfterCardWrite);
       } finally {
         writes.mockRestore();
@@ -471,7 +452,7 @@ describe('migrations', () => {
     it('should handle empty or missing cards storage', async () => {
       await runStartupMigrations();
 
-      expect(await getCurrentSchemaVersion()).toBe(3);
+      expect(await storage.getItem(STORAGE_KEYS.schemaVersion)).toBe(3);
     });
   });
 
@@ -490,7 +471,7 @@ describe('migrations', () => {
       await runStartupMigrations();
       await runStartupMigrations();
 
-      expect(await getCurrentSchemaVersion()).toBe(3);
+      expect(await storage.getItem(STORAGE_KEYS.schemaVersion)).toBe(3);
       expect(await fakeBrowser.storage.sync.get(null)).toEqual(remainingSettings);
       expect(await fakeBrowser.storage.local.get(null)).toEqual({
         ...localBefore,
@@ -504,10 +485,10 @@ describe('migrations', () => {
       const remove = vi.spyOn(storage, 'removeItems').mockRejectedValueOnce(new Error('storage unavailable'));
       try {
         await expect(runStartupMigrations()).rejects.toThrow('Failed to run migration 3');
-        expect(await getCurrentSchemaVersion()).toBe(2);
+        expect(await storage.getItem(STORAGE_KEYS.schemaVersion)).toBe(2);
         await runStartupMigrations();
         expect(await storage.getItem('sync:leetsrs:dayStartHour')).toBeNull();
-        expect(await getCurrentSchemaVersion()).toBe(3);
+        expect(await storage.getItem(STORAGE_KEYS.schemaVersion)).toBe(3);
       } finally {
         remove.mockRestore();
       }
@@ -521,7 +502,7 @@ describe('migrations', () => {
 
       await runStartupMigrations();
 
-      expect(await getCurrentSchemaVersion()).toBe(3);
+      expect(await storage.getItem(STORAGE_KEYS.schemaVersion)).toBe(3);
       expect(await storage.getItem(STORAGE_KEYS.theme)).toBe('dark');
     });
   });

--- a/infrastructure/storage/migrations/runner.ts
+++ b/infrastructure/storage/migrations/runner.ts
@@ -9,10 +9,6 @@ import type { Migration } from './migration';
 const migrations = [addCardDomain, addSystemTheme, removeDayStart] as const satisfies readonly Migration[];
 export const LATEST_SCHEMA_VERSION = migrations.length;
 
-export async function getCurrentSchemaVersion(): Promise<number> {
-  return (await storage.getItem<number>(STORAGE_KEYS.schemaVersion)) ?? 0;
-}
-
 export async function setSchemaVersion(version: number): Promise<void> {
   await storage.setItem(STORAGE_KEYS.schemaVersion, version);
 }

--- a/services/__tests__/import-export.test.ts
+++ b/services/__tests__/import-export.test.ts
@@ -5,6 +5,7 @@ import { storage } from 'wxt/utils/storage';
 import type { Card } from '@/domain/cards';
 import type { Note } from '@/domain/notes';
 import type { DailyStats } from '@/domain/statistics';
+import { removeDayStart } from '@/infrastructure/storage/migrations/003-remove-day-start';
 import { runStartupMigrations, setSchemaVersion } from '@/infrastructure/storage/migrations/runner';
 import { STORAGE_KEYS } from '@/infrastructure/storage/storage-keys';
 import { malformedBackupCases, mixedRecordBackup } from '@/test/utils/backup-mocks';
@@ -97,7 +98,7 @@ describe('import-export', () => {
       const result = await exportData();
       const parsed = JSON.parse(result);
 
-      expect(parsed.schemaVersion).toBe(0);
+      expect(parsed.schemaVersion).toBe(3);
       expect(parsed.exportDate).toMatch(/^\d{4}-\d{2}-\d{2}T/);
       expect(parsed.data.stats).toEqual(mockStats);
       expect(parsed.data.notes).toEqual(mockNotes);
@@ -116,7 +117,7 @@ describe('import-export', () => {
       const parsed = JSON.parse(result);
 
       expect(parsed).toMatchObject({
-        schemaVersion: 0,
+        schemaVersion: 3,
         exportDate: expect.any(String),
         data: {
           cards: {},
@@ -128,11 +129,20 @@ describe('import-export', () => {
       expect(parsed.data.monthlyStats).toBeUndefined();
     });
 
-    it('should export schema version 3 after migrations run', async () => {
-      await runStartupMigrations();
-      const parsed = JSON.parse(await exportData());
-      expect(parsed.schemaVersion).toBe(3);
-    });
+    it.each([undefined, 0, 1, 2, 3, 'unreadable'])(
+      'labels exports with the supported schema regardless of device progress %s',
+      async (progress) => {
+        if (typeof progress === 'number') await setSchemaVersion(progress);
+        const read = storage.getItem.bind(storage);
+        vi.spyOn(storage, 'getItem').mockImplementation((key, options) => {
+          if (progress === 'unreadable' && key === STORAGE_KEYS.schemaVersion) {
+            throw new Error('Progress unavailable');
+          }
+          return read(key, options);
+        });
+        expect(JSON.parse(await exportData()).schemaVersion).toBe(3);
+      }
+    );
 
     it('does not export legacy monthly stats', async () => {
       await storage.setItem(legacyMonthlyStatsKey, { '2024-01': { totalReviews: 15 } });
@@ -217,7 +227,7 @@ describe('import-export', () => {
         expect(restored.data).toMatchObject(JSON.parse(JSON.stringify(data)));
         expect(restored.data.cards).toEqual(JSON.parse(JSON.stringify(data.cards)));
         expect(restored.dataUpdatedAt).toBe(payload.dataUpdatedAt);
-        expect(restored.schemaVersion).toBe(2);
+        expect(restored.schemaVersion).toBe(3);
       }
     );
 
@@ -283,18 +293,31 @@ describe('import-export', () => {
       await setSchemaVersion(2);
     }
 
-    it('propagates schema-read failures without changing existing data', async () => {
-      await seedExistingData();
-      const failure = new Error('schema unavailable');
-      const read = storage.getItem.bind(storage);
-      vi.spyOn(storage, 'getItem').mockImplementation((key, options) =>
-        key === STORAGE_KEYS.schemaVersion ? Promise.reject(failure) : read(key, options)
-      );
-      const before = await fakeBrowser.storage.local.get(null);
+    it.each([undefined, 0, 1, 2, 3, 'unreadable'])(
+      'imports the supported schema independently of device progress %s without advancing it',
+      async (progress) => {
+        await seedExistingData();
+        await storage.removeItem(STORAGE_KEYS.schemaVersion);
+        if (typeof progress === 'number') await setSchemaVersion(progress);
+        const read = storage.getItem.bind(storage);
+        vi.spyOn(storage, 'getItem').mockImplementation((key, options) => {
+          if (progress === 'unreadable' && key === STORAGE_KEYS.schemaVersion) {
+            throw new Error('Progress unavailable');
+          }
+          return read(key, options);
+        });
+        const json = JSON.stringify({ ...validExportData, schemaVersion: 3 });
+        const before = await fakeBrowser.storage.local.get(null);
+        const syncBefore = await fakeBrowser.storage.sync.get(null);
 
-      await expect(importData(JSON.stringify(validExportData))).rejects.toBe(failure);
-      expect(await fakeBrowser.storage.local.get(null)).toEqual(before);
-    });
+        expect((await prepareImportData(json)).cards).toEqual(validExportData.data.cards);
+        expect(await fakeBrowser.storage.local.get(null)).toEqual(before);
+        expect(await fakeBrowser.storage.sync.get(null)).toEqual(syncBefore);
+        await importData(json);
+        expect(JSON.parse(await exportData()).data).toMatchObject(JSON.parse(json).data);
+        expect(await read(STORAGE_KEYS.schemaVersion)).toBe(typeof progress === 'number' ? progress : null);
+      }
+    );
 
     it.each(['2024-01-01T00:00:00.000Z', '2024-01-01T05:30:00+05:30', '2024-01-01', 'Mon, 01 Jan 2024 00:00:00 GMT'])(
       'accepts and preserves the timestamp format %s',
@@ -433,16 +456,24 @@ describe('import-export', () => {
       it.each([0, undefined, 1, 2, 3])(
         'prepares and imports schema %s cards identically to startup migration',
         async (schemaVersion) => {
-          await storage.setItem(STORAGE_KEYS.cards, legacyCards);
+          if (schemaVersion !== undefined) await setSchemaVersion(schemaVersion);
+          await storage.setItem(STORAGE_KEYS.cards, schemaVersion ? currentCards : legacyCards);
           await storage.setItem(STORAGE_KEYS.stats, validExportData.data.stats);
           for (const [id, note] of Object.entries(notes)) {
             await storage.setItem(`${STORAGE_KEYS.notes}:${id}`, note);
           }
-          await storage.setItem(STORAGE_KEYS.theme, 'light');
+          for (const [key, value] of Object.entries(validExportData.data.settings)) {
+            await storage.setItem(STORAGE_KEYS[key as keyof typeof validExportData.data.settings], value);
+          }
+          if (schemaVersion !== 3) await storage.setItem('sync:leetsrs:dayStartHour', 4);
           await storage.setItem(STORAGE_KEYS.githubPat, 'existing-pat');
           await runStartupMigrations();
           const startupCards = await storage.getItem(STORAGE_KEYS.cards);
           expect(startupCards).toEqual(currentCards);
+          const startupData = JSON.parse(await exportData()).data;
+          await setSchemaVersion(0);
+          await storage.setItem('sync:leetsrs:dayStartHour', 9);
+          const syncBefore = await fakeBrowser.storage.sync.get(null);
           const before = await fakeBrowser.storage.local.get(null);
           const json = JSON.stringify({
             ...validExportData,
@@ -451,7 +482,7 @@ describe('import-export', () => {
             data: {
               ...validExportData.data,
               cards: schemaVersion ? currentCards : legacyCards,
-              settings: { ...validExportData.data.settings, dayStartHour: 4 },
+              settings: { ...validExportData.data.settings, ...(schemaVersion !== 3 && { dayStartHour: 4 }) },
               notes,
             },
           });
@@ -464,6 +495,7 @@ describe('import-export', () => {
           expect(prepared.settings).toEqual(validExportData.data.settings);
           expect(prepared.dataUpdatedAt).toBe(dataUpdatedAt);
           expect(await fakeBrowser.storage.local.get(null)).toEqual(before);
+          expect(await fakeBrowser.storage.sync.get(null)).toEqual(syncBefore);
 
           await importData(json);
 
@@ -475,9 +507,70 @@ describe('import-export', () => {
           expect(await storage.getItem(STORAGE_KEYS.theme)).toBe('light');
           expect(await storage.getItem(STORAGE_KEYS.githubPat)).toBe('existing-pat');
           expect(await storage.getItem(STORAGE_KEYS.dataUpdatedAt)).toBe(dataUpdatedAt);
-          expect(await storage.getItem(STORAGE_KEYS.schemaVersion)).toBe(3);
-          expect(await storage.getItem('sync:leetsrs:dayStartHour')).toBeNull();
-          expect(JSON.parse(await exportData()).data.settings).toEqual(validExportData.data.settings);
+          expect(await storage.getItem(STORAGE_KEYS.schemaVersion)).toBe(0);
+          expect(await storage.getItem('sync:leetsrs:dayStartHour')).toBe(9);
+          expect(JSON.parse(await exportData()).data).toEqual(startupData);
+        }
+      );
+
+      it.each([undefined, 0, 1, 2])(
+        'passes raw schema %s fields to their transformation without storage access',
+        async (schemaVersion) => {
+          const rawData = {
+            ...validExportData.data,
+            cards: schemaVersion ? currentCards : legacyCards,
+            notes,
+            settings: {
+              ...validExportData.data.settings,
+              dayStartHour: { historical: 'retain until migration' },
+              autoClearLeetcode: true,
+              historicalSetting: { nested: [1, 2] },
+            },
+            historicalRoot: { keep: true },
+          };
+          // Observe the real historical transformation: final normalization alone
+          // cannot prove that retired fields reached the migration intact.
+          const transform = vi.spyOn(removeDayStart, 'migrate');
+          for (const area of ['local', 'sync'] as const) {
+            for (const operation of ['get', 'set', 'remove', 'clear'] as const) {
+              vi.spyOn(fakeBrowser.storage[area], operation).mockImplementation(() => {
+                throw new Error('Preparation must not access storage');
+              });
+            }
+          }
+
+          const prepared = await prepareImportData(
+            JSON.stringify({ ...validExportData, schemaVersion, dataUpdatedAt, data: rawData })
+          );
+
+          expect(transform).toHaveBeenCalledWith({ ...rawData, cards: currentCards });
+          expect(prepared).toEqual({
+            cards: currentCards,
+            stats: validExportData.data.stats,
+            notes,
+            settings: validExportData.data.settings,
+            gistSync: undefined,
+            dataUpdatedAt,
+          });
+        }
+      );
+
+      it.each([1, 2, 3])(
+        'rejects schema %s cards missing their required domain without repair',
+        async (schemaVersion) => {
+          await seedExistingData();
+          const before = await fakeBrowser.storage.local.get(null);
+          const syncBefore = await fakeBrowser.storage.sync.get(null);
+          const json = JSON.stringify({
+            ...validExportData,
+            schemaVersion,
+            data: { ...validExportData.data, cards: legacyCards, notes },
+          });
+
+          await expect(prepareImportData(json)).rejects.toThrow();
+          await expect(importData(json)).rejects.toThrow();
+          expect(await fakeBrowser.storage.local.get(null)).toEqual(before);
+          expect(await fakeBrowser.storage.sync.get(null)).toEqual(syncBefore);
         }
       );
 
@@ -523,6 +616,7 @@ describe('import-export', () => {
 
     it.each([
       ...malformedBackupCases(validExportData),
+      ['future schema version', JSON.stringify({ ...validExportData, schemaVersion: 4 })],
       ['null root', 'null'],
       ['missing export date', JSON.stringify({ data: {} })],
       ...['cards', 'stats', 'notes'].map((key) => [

--- a/services/import-export.ts
+++ b/services/import-export.ts
@@ -1,8 +1,13 @@
-import { normalizeImportData, validateImportRelationships, validateImportStructure } from '@/domain/backup-import';
+import {
+  normalizeImportData,
+  parseImportMetadata,
+  validateImportRelationships,
+  validateImportStructure,
+} from '@/domain/backup-import';
 import type { ExportData, PreparedImportData } from '@/infrastructure/storage/backup';
 import { exportDataSchema } from '@/infrastructure/storage/backup';
 import { getAllCards, removeCards, saveCards } from '@/infrastructure/storage/cards';
-import { getCurrentSchemaVersion, migrateBackupData } from '@/infrastructure/storage/migrations/runner';
+import { LATEST_SCHEMA_VERSION, migrateBackupData } from '@/infrastructure/storage/migrations/runner';
 import { deleteNote, getNotesForCards, saveNote } from '@/infrastructure/storage/notes';
 import { getStats, removeStats, saveStats } from '@/infrastructure/storage/stats';
 import { readSyncMetadata, removeSyncMetadata, writeSyncMetadata } from '@/infrastructure/storage/sync-metadata';
@@ -11,7 +16,7 @@ import { exportSettings, resetSettings, updateSettings } from './settings';
 
 export async function exportData(): Promise<string> {
   const cardsPromise = getAllCards();
-  const [cards, stats, notes, settings, gistId, gistSyncEnabled, dataUpdatedAt, schemaVersion] = await Promise.all([
+  const [cards, stats, notes, settings, gistId, gistSyncEnabled, dataUpdatedAt] = await Promise.all([
     cardsPromise,
     getStats(),
     cardsPromise.then((cards) => getNotesForCards(cards)),
@@ -19,11 +24,10 @@ export async function exportData(): Promise<string> {
     readSyncMetadata('gistId'),
     readSyncMetadata('gistSyncEnabled'),
     readSyncMetadata('dataUpdatedAt'),
-    getCurrentSchemaVersion(),
   ]);
 
   const exportData: ExportData = {
-    schemaVersion,
+    schemaVersion: LATEST_SCHEMA_VERSION,
     exportDate: new Date().toISOString(),
     dataUpdatedAt: dataUpdatedAt ?? undefined,
     data: {
@@ -50,15 +54,14 @@ export async function prepareImportData(jsonData: string): Promise<PreparedImpor
   }
 
   validateImportStructure(data);
-  const currentSchema = await getCurrentSchemaVersion();
-  const { schemaVersion, ...normalizedData } = normalizeImportData(data, currentSchema);
-  const migrated = migrateBackupData(normalizedData, schemaVersion);
-  const validData = exportDataSchema.shape.data.parse(migrated);
+  const { schemaVersion, dataUpdatedAt } = parseImportMetadata(data, LATEST_SCHEMA_VERSION);
+  const migrated = migrateBackupData(data.data, schemaVersion);
+  const validData = exportDataSchema.shape.data.parse(normalizeImportData(migrated));
   validateImportRelationships(validData);
 
   return {
     ...validData,
-    dataUpdatedAt: normalizedData.dataUpdatedAt ?? new Date().toISOString(),
+    dataUpdatedAt: dataUpdatedAt ?? new Date().toISOString(),
   };
 }
 


### PR DESCRIPTION
- Migrate raw backup data before current normalization and validation.
- Use the code-supported schema for imports and exports independently of startup progress.
- Cover historical backups, storage preservation, and startup/import equivalence; `npm run check` passes (929 tests).

Closes #351
