### PR TITLE
ci: keep claude reviews from ending before sub-agents return

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -42,8 +42,19 @@ jobs:
 
             /mattpocock-skills:code-review ${{ github.event.pull_request.base.sha }}
 
-            The spec is the PR description and its linked issues. Post the review result
-            as a comment on this PR.
+            The spec is the PR description and its linked issues.
+
+            The skill delegates each review axis to a sub-agent, and sub-agents run in
+            the background. Collect every sub-agent's result with TaskOutput before you
+            aggregate. Do not end your turn while a sub-agent is still running: this run
+            is headless, so ending the turn early kills the pending sub-agents and the
+            review is never published.
+
+            Publish the aggregated review before ending your turn. If you have the
+            `mcp__github_comment__update_claude_comment` tool, publish by replacing your
+            existing comment with the full review; otherwise post it with
+            `gh pr comment`. If a sub-agent cannot be collected, publish the findings you
+            do have plus what failed, rather than ending the turn with nothing.
 
           claude_args: |
-            --allowedTools "Read,Glob,Grep,Agent,Skill(mattpocock-skills:code-review),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh issue view:*),Bash(git diff:*),Bash(git log:*),Bash(git rev-parse:*),Bash(git merge-base:*),Bash(git status:*),Bash(git show:*)"
+            --allowedTools "Read,Glob,Grep,Agent,TaskOutput,TaskStop,Skill(mattpocock-skills:code-review),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh issue view:*),Bash(git diff:*),Bash(git log:*),Bash(git rev-parse:*),Bash(git merge-base:*),Bash(git status:*),Bash(git show:*)"

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -44,17 +44,15 @@ jobs:
 
             The spec is the PR description and its linked issues.
 
-            The skill delegates each review axis to a sub-agent, and sub-agents run in
-            the background. Collect every sub-agent's result with TaskOutput before you
-            aggregate. Do not end your turn while a sub-agent is still running: this run
-            is headless, so ending the turn early kills the pending sub-agents and the
-            review is never published.
-
-            Publish the aggregated review before ending your turn. If you have the
-            `mcp__github_comment__update_claude_comment` tool, publish by replacing your
-            existing comment with the full review; otherwise post it with
-            `gh pr comment`. If a sub-agent cannot be collected, publish the findings you
-            do have plus what failed, rather than ending the turn with nothing.
+            Sub-agents run in the background. Collect every sub-agent's result
+            with TaskOutput before you aggregate, and never end your turn
+            while a sub-agent is still running: this run is headless, so
+            ending the turn early kills the pending sub-agents and nothing is
+            ever published. Publish your findings before you finish, even if a
+            sub-agent failed to return: replace your existing comment with the
+            full review if you have the
+            mcp__github_comment__update_claude_comment tool, otherwise post it
+            with gh pr comment.
 
           claude_args: |
             --allowedTools "Read,Glob,Grep,Agent,TaskOutput,TaskStop,Skill(mattpocock-skills:code-review),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh issue view:*),Bash(git diff:*),Bash(git log:*),Bash(git rev-parse:*),Bash(git merge-base:*),Bash(git status:*),Bash(git show:*)"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write
       issues: read
       id-token: write
       actions: read # Required for Claude to read CI results on PRs
@@ -43,5 +43,5 @@ jobs:
             actions: read
 
           claude_args: |
-            --append-system-prompt "When asked to review code, invoke /mattpocock-skills:code-review directly. That skill delegates each review axis to a sub-agent, and sub-agents run in the background. Collect every sub-agent result with TaskOutput before aggregating, and never end your turn while a sub-agent is still running: this run is headless, so ending the turn early kills the pending sub-agents and nothing is ever published. Publish your findings by updating your comment before you finish, even if a sub-agent failed to return."
-            --allowedTools "Read,Glob,Grep,Agent,TaskOutput,TaskStop,Skill(mattpocock-skills:code-review),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh issue view:*),Bash(git diff:*),Bash(git log:*),Bash(git rev-parse:*),Bash(git merge-base:*),Bash(git status:*),Bash(git show:*)"
+            --append-system-prompt "Sub-agents run in the background. Collect every sub-agent's result with TaskOutput before you aggregate, and never end your turn while a sub-agent is still running: this run is headless, so ending the turn early kills the pending sub-agents and nothing is ever published. Publish your findings before you finish, even if a sub-agent failed to return: replace your existing comment with the full review if you have the mcp__github_comment__update_claude_comment tool, otherwise post it with gh pr comment. When asked to review code, invoke /mattpocock-skills:code-review directly."
+            --allowedTools "Read,Glob,Grep,Agent,TaskOutput,TaskStop,Skill(mattpocock-skills:code-review),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh issue view:*),Bash(git diff:*),Bash(git log:*),Bash(git rev-parse:*),Bash(git merge-base:*),Bash(git status:*),Bash(git show:*)"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -43,5 +43,5 @@ jobs:
             actions: read
 
           claude_args: |
-            --append-system-prompt "When asked to review code, invoke /mattpocock-skills:code-review directly."
-            --allowedTools "Read,Glob,Grep,Agent,Skill(mattpocock-skills:code-review),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh issue view:*),Bash(git diff:*),Bash(git log:*),Bash(git rev-parse:*),Bash(git merge-base:*),Bash(git status:*),Bash(git show:*)"
+            --append-system-prompt "When asked to review code, invoke /mattpocock-skills:code-review directly. That skill delegates each review axis to a sub-agent, and sub-agents run in the background. Collect every sub-agent result with TaskOutput before aggregating, and never end your turn while a sub-agent is still running: this run is headless, so ending the turn early kills the pending sub-agents and nothing is ever published. Publish your findings by updating your comment before you finish, even if a sub-agent failed to return."
+            --allowedTools "Read,Glob,Grep,Agent,TaskOutput,TaskStop,Skill(mattpocock-skills:code-review),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh issue view:*),Bash(git diff:*),Bash(git log:*),Bash(git rev-parse:*),Bash(git merge-base:*),Bash(git status:*),Bash(git show:*)"


### PR DESCRIPTION
- The `code-review` skill delegates each axis to a sub-agent, and sub-agents run in the background. In a headless action run, ending the turn while one is still pending kills it, so the job exits `success` having published only a half-filled todo list — see [run 34569431453](https://github.com/mattcdrake/LeetSRS/actions/runs/34569431453) (`num_turns: 21`, `permission_denials_count: 1`, 1m52s) and its [stuck comment](https://github.com/mattcdrake/LeetSRS/pull/355#issuecomment-5630345146) on #355.
- Grant `TaskOutput`/`TaskStop` in both workflows so sub-agent results can be collected at all.
- State the rule in the prompt (`claude-code-review.yml`) and the appended system prompt (`claude.yml`): collect every sub-agent, never end the turn with one running, publish partial findings rather than nothing.
- `claude-code-review.yml` also picks its publishing channel explicitly: update the tracking comment when `mcp__github_comment__update_claude_comment` exists (`opened`/`reopened`, where the action's own prompt forbids extra comments), otherwise `gh pr comment` (`review_requested`, where `track_progress` is false and there is no tracking comment).

The permission grant and the prompt rule are belt-and-braces: a concurrent run on the old config did collect one sub-agent before stalling on the second, so the turn-ending rule is the load-bearing half of this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0174r8BpXsMS94btXgHKc88d