### PR TITLE
ci: attach extension ZIPs to releases

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -15,8 +15,37 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Create release PR or GitHub release
+        id: release
         uses: googleapis/release-please-action@v5
         with:
           token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+
+      - name: Checkout release
+        if: ${{ steps.release.outputs.release_created }}
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ steps.release.outputs.tag_name }}
+
+      - name: Setup Node.js
+        if: ${{ steps.release.outputs.release_created }}
+        uses: actions/setup-node@v7
+        with:
+          node-version: 24.x
+          cache: 'npm'
+
+      - name: Install dependencies
+        if: ${{ steps.release.outputs.release_created }}
+        run: npm ci --no-audit --no-fund
+
+      - name: Build release ZIPs
+        if: ${{ steps.release.outputs.release_created }}
+        run: npm run zip
+
+      - name: Upload release ZIPs
+        if: ${{ steps.release.outputs.release_created }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ steps.release.outputs.tag_name }}
+        run: gh release upload "$RELEASE_TAG" .output/*.zip


### PR DESCRIPTION
- Build the released tag and attach extension ZIPs when release-please creates a release.
- Validated with `npm run check` (929 tests), `npm run zip`, and ZIP integrity checks.
