### PR TITLE
ci: inline Claude code review instructions

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -28,8 +28,6 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          plugin_marketplaces: https://github.com/mattpocock/skills.git
-          plugins: mattpocock-skills@mattpocock
           # Progress tracking is not supported for review_requested runs.
           track_progress: ${{ github.event.action != 'review_requested' }}
 
@@ -40,7 +38,8 @@ jobs:
             BASE COMMIT: ${{ github.event.pull_request.base.sha }}
             HEAD COMMIT: ${{ github.event.pull_request.head.sha }}
 
-            /mattpocock-skills:code-review ${{ github.event.pull_request.base.sha }}
+            Review this PR using the inlined instructions below.
+            The fixed point is BASE COMMIT.
 
             The spec is the PR description and its linked issues.
 
@@ -54,5 +53,90 @@ jobs:
             mcp__github_comment__update_claude_comment tool, otherwise post it
             with gh pr comment.
 
+            Matt Pocock's code-review instructions (inlined from https://github.com/mattpocock/skills/blob/main/skills/engineering/code-review/SKILL.md):
+
+            Two-axis review of the diff between `HEAD` and a fixed point the user supplies:
+
+            - **Standards**: does the code conform to this repo's documented coding standards?
+            - **Spec**: does the code faithfully implement the originating issue / spec?
+
+            Both axes run as **parallel sub-agents** so they don't pollute each other's context, then this skill aggregates their findings.
+
+            The issue tracker should have been provided to you. If `docs/agents/issue-tracker.md` is missing, tell the user to run `/setup-matt-pocock-skills`.
+
+            ## Process
+
+            ### 1. Pin the fixed point
+
+            Whatever the user said is the fixed point (a commit SHA, branch name, tag, `main`, `HEAD~5`, etc.). If they didn't specify one, ask for it.
+
+            Capture the diff command once: `git diff <fixed-point>...HEAD` (three-dot, so the comparison is against the merge-base). Also note the list of commits via `git log <fixed-point>..HEAD --oneline`.
+
+            Before going further, confirm the fixed point resolves (`git rev-parse <fixed-point>`) and the diff is non-empty. A bad ref or empty diff should fail here, not inside two parallel sub-agents.
+
+            ### 2. Identify the spec source
+
+            Look for the originating spec, in this order:
+
+            1. Issue references in the commit messages (`#123`, `Closes #45`, GitLab `!67`, etc.), fetched via the workflow in `docs/agents/issue-tracker.md`.
+            2. A path the user passed as an argument.
+            3. A spec file under `docs/`, `specs/`, or `.scratch/` matching the branch name or feature.
+            4. If nothing is found, ask the user where the spec is. If they say there isn't one, the **Spec** sub-agent will skip and report "no spec available".
+
+            ### 3. Identify the standards sources
+
+            Anything in the repo that documents how code should be written, such as `CODING_STANDARDS.md` or `CONTRIBUTING.md`.
+
+            On top of whatever the repo documents, the Standards axis always carries the **smell baseline** below: a fixed set of Fowler code smells (_Refactoring_, ch.3) that applies even when a repo documents nothing. Two rules bind it:
+
+            - **The repo overrides.** A documented repo standard always wins; where it endorses something the baseline would flag, suppress the smell.
+            - **Always a judgement call.** Each smell is a labelled heuristic ("possible Feature Envy"), never a hard violation. Like any standard here, skip anything tooling already enforces.
+
+            Each smell reads *what it is* → *how to fix*; match it against the diff:
+
+            - **Mysterious Name**: a function, variable, or type whose name doesn't reveal what it does or holds. → rename it; if no honest name comes, the design's murky.
+            - **Duplicated Code**: the same logic shape appears in more than one hunk or file in the change. → extract the shared shape, call it from both.
+            - **Feature Envy**: a method that reaches into another object's data more than its own. → move the method onto the data it envies.
+            - **Data Clumps**: the same few fields or params keep travelling together (a type wanting to be born). → bundle them into one type, pass that.
+            - **Primitive Obsession**: a primitive or string standing in for a domain concept that deserves its own type. → give the concept its own small type.
+            - **Repeated Switches**: the same `switch`/`if`-cascade on the same type recurs across the change. → replace with polymorphism, or one map both sites share.
+            - **Shotgun Surgery**: one logical change forces scattered edits across many files in the diff. → gather what changes together into one module.
+            - **Divergent Change**: one file or module is edited for several unrelated reasons. → split so each module changes for one reason.
+            - **Speculative Generality**: abstraction, parameters, or hooks added for needs the spec doesn't have. → delete it; inline back until a real need shows.
+            - **Message Chains**: long `a.b().c().d()` navigation the caller shouldn't depend on. → hide the walk behind one method on the first object.
+            - **Middle Man**: a class or function that mostly just delegates onward. → cut it, call the real target direct.
+            - **Refused Bequest**: a subclass or implementer that ignores or overrides most of what it inherits. → drop the inheritance, use composition.
+
+            ### 4. Spawn both sub-agents in parallel
+
+            **Standards sub-agent prompt** should include:
+
+            - The full diff command and commit list.
+            - The list of standards-source files you found in step 3, **plus the smell baseline from step 3** pasted in full (the sub-agent has no other access to it).
+            - The brief: "Report, per file/hunk where relevant, (a) every place the diff violates a documented standard: cite the standard (file + the rule); and (b) any baseline smell you spot: name it and quote the hunk. Distinguish hard violations from judgement calls: documented-standard breaches can be hard, but baseline smells are always judgement calls, and a documented repo standard overrides the baseline. Skip anything tooling enforces. Under 400 words."
+
+            **Spec sub-agent prompt** should include:
+
+            - The diff command and commit list.
+            - The path or fetched contents of the spec.
+            - The brief: "Report: (a) requirements the spec asked for that are missing or partial; (b) behaviour in the diff that wasn't asked for (scope creep); (c) requirements that look implemented but where the implementation looks wrong. Quote the spec line for each finding. Under 400 words."
+
+            If the spec is missing, skip the Spec sub-agent and note this in the final report.
+
+            ### 5. Aggregate
+
+            Present the two reports under `## Standards` and `## Spec` headings, verbatim or lightly cleaned. Do **not** merge or rerank findings, because the two axes are deliberately separate (see _Why two axes_).
+
+            End with a one-line summary: total findings per axis, and the worst issue _within each axis_ (if any). Don't pick a single winner across axes: that's the reranking the separation exists to prevent.
+
+            ## Why two axes
+
+            A change can pass one axis and fail the other:
+
+            - Code that follows every standard but implements the wrong thing → **Standards pass, Spec fail.**
+            - Code that does exactly what the issue asked but breaks the project's conventions → **Spec pass, Standards fail.**
+
+            Reporting them separately stops one axis from masking the other.
+
           claude_args: |
-            --allowedTools "Read,Glob,Grep,Agent,TaskOutput,TaskStop,Skill(mattpocock-skills:code-review),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh issue view:*),Bash(git diff:*),Bash(git log:*),Bash(git rev-parse:*),Bash(git merge-base:*),Bash(git status:*),Bash(git show:*)"
+            --allowedTools "Read,Glob,Grep,Agent,TaskOutput,TaskStop,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh issue view:*),Bash(git diff:*),Bash(git log:*),Bash(git rev-parse:*),Bash(git merge-base:*),Bash(git status:*),Bash(git show:*)"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -35,13 +35,97 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          plugin_marketplaces: https://github.com/mattpocock/skills.git
-          plugins: mattpocock-skills@mattpocock
 
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |
             actions: read
 
+          # Bold prompt headings survive the action's shell-comment stripping.
           claude_args: |
-            --append-system-prompt "Sub-agents run in the background. Collect every sub-agent's result with TaskOutput before you aggregate, and never end your turn while a sub-agent is still running: this run is headless, so ending the turn early kills the pending sub-agents and nothing is ever published. Publish your findings before you finish, even if a sub-agent failed to return: replace your existing comment with the full review if you have the mcp__github_comment__update_claude_comment tool, otherwise post it with gh pr comment. When asked to review code, invoke /mattpocock-skills:code-review directly."
-            --allowedTools "Read,Glob,Grep,Agent,TaskOutput,TaskStop,Skill(mattpocock-skills:code-review),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh issue view:*),Bash(git diff:*),Bash(git log:*),Bash(git rev-parse:*),Bash(git merge-base:*),Bash(git status:*),Bash(git show:*)"
+            --append-system-prompt "Sub-agents run in the background. Collect every sub-agent's result with TaskOutput before you aggregate, and never end your turn while a sub-agent is still running: this run is headless, so ending the turn early kills the pending sub-agents and nothing is ever published. Publish your findings before you finish, even if a sub-agent failed to return: replace your existing comment with the full review if you have the mcp__github_comment__update_claude_comment tool, otherwise post it with gh pr comment. When asked to review code, follow the inlined instructions below. For PR reviews, use the PR base commit as the fixed point unless the request supplies another, and use the PR description and linked issues as the spec. These review instructions apply only to review requests.
+
+            Matt Pocock's code-review instructions (inlined from https://github.com/mattpocock/skills/blob/main/skills/engineering/code-review/SKILL.md):
+
+            Two-axis review of the diff between `HEAD` and a fixed point the user supplies:
+
+            - **Standards**: does the code conform to this repo's documented coding standards?
+            - **Spec**: does the code faithfully implement the originating issue / spec?
+
+            Both axes run as **parallel sub-agents** so they don't pollute each other's context, then this skill aggregates their findings.
+
+            The issue tracker should have been provided to you. If `docs/agents/issue-tracker.md` is missing, tell the user to run `/setup-matt-pocock-skills`.
+
+            **Process**
+
+            **1. Pin the fixed point**
+
+            Whatever the user said is the fixed point (a commit SHA, branch name, tag, `main`, `HEAD~5`, etc.). If they didn't specify one, ask for it.
+
+            Capture the diff command once: `git diff <fixed-point>...HEAD` (three-dot, so the comparison is against the merge-base). Also note the list of commits via `git log <fixed-point>..HEAD --oneline`.
+
+            Before going further, confirm the fixed point resolves (`git rev-parse <fixed-point>`) and the diff is non-empty. A bad ref or empty diff should fail here, not inside two parallel sub-agents.
+
+            **2. Identify the spec source**
+
+            Look for the originating spec, in this order:
+
+            1. Issue references in the commit messages (`#123`, `Closes #45`, GitLab `!67`, etc.), fetched via the workflow in `docs/agents/issue-tracker.md`.
+            2. A path the user passed as an argument.
+            3. A spec file under `docs/`, `specs/`, or `.scratch/` matching the branch name or feature.
+            4. If nothing is found, ask the user where the spec is. If they say there isn't one, the **Spec** sub-agent will skip and report \"no spec available\".
+
+            **3. Identify the standards sources**
+
+            Anything in the repo that documents how code should be written, such as `CODING_STANDARDS.md` or `CONTRIBUTING.md`.
+
+            On top of whatever the repo documents, the Standards axis always carries the **smell baseline** below: a fixed set of Fowler code smells (_Refactoring_, ch.3) that applies even when a repo documents nothing. Two rules bind it:
+
+            - **The repo overrides.** A documented repo standard always wins; where it endorses something the baseline would flag, suppress the smell.
+            - **Always a judgement call.** Each smell is a labelled heuristic (\"possible Feature Envy\"), never a hard violation. Like any standard here, skip anything tooling already enforces.
+
+            Each smell reads *what it is* → *how to fix*; match it against the diff:
+
+            - **Mysterious Name**: a function, variable, or type whose name doesn't reveal what it does or holds. → rename it; if no honest name comes, the design's murky.
+            - **Duplicated Code**: the same logic shape appears in more than one hunk or file in the change. → extract the shared shape, call it from both.
+            - **Feature Envy**: a method that reaches into another object's data more than its own. → move the method onto the data it envies.
+            - **Data Clumps**: the same few fields or params keep travelling together (a type wanting to be born). → bundle them into one type, pass that.
+            - **Primitive Obsession**: a primitive or string standing in for a domain concept that deserves its own type. → give the concept its own small type.
+            - **Repeated Switches**: the same `switch`/`if`-cascade on the same type recurs across the change. → replace with polymorphism, or one map both sites share.
+            - **Shotgun Surgery**: one logical change forces scattered edits across many files in the diff. → gather what changes together into one module.
+            - **Divergent Change**: one file or module is edited for several unrelated reasons. → split so each module changes for one reason.
+            - **Speculative Generality**: abstraction, parameters, or hooks added for needs the spec doesn't have. → delete it; inline back until a real need shows.
+            - **Message Chains**: long `a.b().c().d()` navigation the caller shouldn't depend on. → hide the walk behind one method on the first object.
+            - **Middle Man**: a class or function that mostly just delegates onward. → cut it, call the real target direct.
+            - **Refused Bequest**: a subclass or implementer that ignores or overrides most of what it inherits. → drop the inheritance, use composition.
+
+            **4. Spawn both sub-agents in parallel**
+
+            **Standards sub-agent prompt** should include:
+
+            - The full diff command and commit list.
+            - The list of standards-source files you found in step 3, **plus the smell baseline from step 3** pasted in full (the sub-agent has no other access to it).
+            - The brief: \"Report, per file/hunk where relevant, (a) every place the diff violates a documented standard: cite the standard (file + the rule); and (b) any baseline smell you spot: name it and quote the hunk. Distinguish hard violations from judgement calls: documented-standard breaches can be hard, but baseline smells are always judgement calls, and a documented repo standard overrides the baseline. Skip anything tooling enforces. Under 400 words.\"
+
+            **Spec sub-agent prompt** should include:
+
+            - The diff command and commit list.
+            - The path or fetched contents of the spec.
+            - The brief: \"Report: (a) requirements the spec asked for that are missing or partial; (b) behaviour in the diff that wasn't asked for (scope creep); (c) requirements that look implemented but where the implementation looks wrong. Quote the spec line for each finding. Under 400 words.\"
+
+            If the spec is missing, skip the Spec sub-agent and note this in the final report.
+
+            **5. Aggregate**
+
+            Present the two reports under `## Standards` and `## Spec` headings, verbatim or lightly cleaned. Do **not** merge or rerank findings, because the two axes are deliberately separate (see _Why two axes_).
+
+            End with a one-line summary: total findings per axis, and the worst issue _within each axis_ (if any). Don't pick a single winner across axes: that's the reranking the separation exists to prevent.
+
+            **Why two axes**
+
+            A change can pass one axis and fail the other:
+
+            - Code that follows every standard but implements the wrong thing → **Standards pass, Spec fail.**
+            - Code that does exactly what the issue asked but breaks the project's conventions → **Spec pass, Standards fail.**
+
+            Reporting them separately stops one axis from masking the other."
+            --allowedTools "Read,Glob,Grep,Agent,TaskOutput,TaskStop,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh issue view:*),Bash(git diff:*),Bash(git log:*),Bash(git rev-parse:*),Bash(git merge-base:*),Bash(git status:*),Bash(git show:*)"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,7 @@ Use Conventional Commits for commit subjects and pull request titles, such as `f
 
 ## Code Review Rules
 
-For local agent reviews and Claude review automation, use Matt Pocock's installed `code-review` skill directly. Hosted Codex PR reviews use its native review workflow and this repo's documented standards. The skill's upstream source is [code-review/SKILL.md](https://github.com/mattpocock/skills/blob/main/skills/engineering/code-review/SKILL.md).
+For local agent reviews, use Matt Pocock's installed `code-review` skill directly. Claude review automation uses the skill text inlined in its two workflows. Hosted Codex PR reviews use its native review workflow and this repo's documented standards. The skill's upstream source is [code-review/SKILL.md](https://github.com/mattpocock/skills/blob/main/skills/engineering/code-review/SKILL.md).
 
 ## Agent skills
 


### PR DESCRIPTION
- Inline Matt Pocock’s full code-review instructions in both Claude workflows and remove plugin installation and invocation.
- Preserve parallel Standards/Spec reviews and result publishing; align AGENTS.md with the inline instructions.
- Validated prompt argument parsing, workflow YAML, and `npm run check` (929 tests).
