### PR TITLE
refactor: migrate Gist connections to device-local storage

### DIFF
--- a/docs/agents/architecture.md
+++ b/docs/agents/architecture.md
@@ -44,5 +44,6 @@ Before changing background commands or sync execution, read [ADR-0001](../adr/00
 - Services prepare file imports and Gist pulls through `parseBackup` before replacement, then orchestrate reset/restore through shared persistence adapters. Preserve the local PAT and apply imported timestamps after settings writes.
 - Historical repair and conversion belong in numbered migrations. Parsing discards extras, rejects invalid supported fields and relationships, and preserves valid `dataUpdatedAt` or falls back to the required `exportDate` without reading the clock.
 - Sync, backup/reset, and local-edit tracking share `infrastructure/storage/sync-metadata.ts`.
+- Gist connections use one device-local `{ pat, gistId, enabled }` record, updated as a whole within the background write queue. Legacy browser-sync connection keys remain only as migration input for devices that have not upgraded; runtime callers never fall back to them. Connection edits do not mark learning data updated.
 - Before changing Gist sync conflict resolution, read [ADR-0002](../adr/0002-whole-dataset-gist-sync.md). Restore pulls through backup import.
 - Sync payloads include settings and Gist configuration, exclude the PAT, and need new synchronized fields added to `ExportData`.

--- a/domain/gist-sync.ts
+++ b/domain/gist-sync.ts
@@ -1,10 +1,7 @@
 import { z } from 'zod';
+import { gistConnectionSchema } from './schemas/v5';
 
-export const gistSyncConfigSchema = z.object({
-  pat: z.string(),
-  gistId: z.string().nullable(),
-  enabled: z.boolean(),
-});
+export const gistSyncConfigSchema = gistConnectionSchema;
 export type GistSyncConfig = z.infer<typeof gistSyncConfigSchema>;
 
 export const gistSyncConfigUpdateSchema = gistSyncConfigSchema.partial();

--- a/domain/schemas/v5.ts
+++ b/domain/schemas/v5.ts
@@ -1,0 +1,8 @@
+import { z } from 'zod';
+
+// Version 5 device-local connection contract. Keep fixed for historical migrations.
+export const gistConnectionSchema = z.object({
+  pat: z.string(),
+  gistId: z.string().nullable(),
+  enabled: z.boolean(),
+});

--- a/entrypoints/background/__tests__/execution.test.ts
+++ b/entrypoints/background/__tests__/execution.test.ts
@@ -49,6 +49,52 @@ beforeEach(async () => {
 const problem = buildProblem();
 
 describe('registered background execution', () => {
+  it('serializes connection edits without marking learning data or changing another device’s legacy settings', async () => {
+    const legacy = {
+      'leetsrs:githubPat': 'other-device',
+      'leetsrs:gistId': 'other-gist',
+      'leetsrs:gistSyncEnabled': true,
+    };
+    await fakeBrowser.storage.sync.set(legacy);
+    const timestamp = '2024-01-01T00:00:00.000Z';
+    await storage.setItem(STORAGE_KEYS.dataUpdatedAt, timestamp);
+
+    expect(await dispatch('getGistSyncConfig')).toEqual({ pat: '', gistId: null, enabled: false });
+    await Promise.all([
+      dispatch('setGistSyncConfig', { config: { pat: 'this-device' } }),
+      dispatch('setGistSyncConfig', { config: { gistId: 'this-gist' } }),
+      dispatch('setGistSyncConfig', { config: { enabled: true } }),
+    ]);
+    expect(await dispatch('getGistSyncConfig')).toEqual({ pat: 'this-device', gistId: 'this-gist', enabled: true });
+    expect(await storage.getItem(STORAGE_KEYS.dataUpdatedAt)).toBe(timestamp);
+    expect(await fakeBrowser.storage.sync.get(null)).toEqual(legacy);
+
+    await dispatch('resetAllData');
+    expect(await dispatch('getGistSyncConfig')).toEqual({ pat: '', gistId: null, enabled: false });
+    expect(await fakeBrowser.storage.sync.get(null)).toEqual(legacy);
+  });
+
+  it('blocks connection commands after migration failure and accepts them after a successful restart', async () => {
+    fakeBrowser.reset();
+    vi.mocked(onMessage).mockClear();
+    await storage.setItem(STORAGE_KEYS.schemaVersion, 4);
+    await storage.setItem('sync:leetsrs:githubPat', 'migrated-token');
+    const failure = vi.spyOn(storage, 'setItem').mockRejectedValueOnce(new Error('Connection unavailable'));
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    background.main();
+    await expect(dispatch('getGistSyncConfig')).rejects.toThrow('Failed to run migration 5');
+    await expect(dispatch('setGistSyncConfig', { config: { pat: 'replacement' } })).rejects.toThrow(
+      'Failed to run migration 5'
+    );
+    expect(await storage.getItem(STORAGE_KEYS.schemaVersion)).toBe(4);
+    failure.mockRestore();
+    vi.mocked(onMessage).mockClear();
+    background.main();
+    expect(await dispatch('getGistSyncConfig')).toEqual({ pat: 'migrated-token', gistId: null, enabled: false });
+    await dispatch('setGistSyncConfig', { config: { enabled: true } });
+    expect(await dispatch('getGistSyncConfig')).toEqual({ pat: 'migrated-token', gistId: null, enabled: true });
+  });
+
   it('edits a card note by slug while preserving the card and its schedule', async () => {
     const card = await cards.addCard(problem);
     await expect(dispatch('getNote', { slug: problem.slug })).resolves.toBeNull();

--- a/entrypoints/background/__tests__/index.test.ts
+++ b/entrypoints/background/__tests__/index.test.ts
@@ -2,14 +2,11 @@ import { Octokit } from 'octokit';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { browser } from 'wxt/browser';
 import { fakeBrowser } from 'wxt/testing/fake-browser';
-import { storage } from 'wxt/utils/storage';
 import { messagePayloadSchemas, onMessage } from '@/infrastructure/browser/messages';
 import * as tracker from '@/infrastructure/storage/data-tracker';
 import { runStartupMigrations } from '@/infrastructure/storage/migrations/runner';
-import { STORAGE_KEYS } from '@/infrastructure/storage/storage-keys';
 import * as cards from '@/services/cards';
 import * as setup from '@/services/gist-setup';
-import * as auth from '@/services/github-auth';
 import { triggerGistSync } from '@/services/github-sync';
 import * as notes from '@/services/notes';
 import { getSettings } from '@/services/settings';
@@ -41,9 +38,7 @@ describe('background sync alarm', () => {
     vi.mocked(getSettings).mockResolvedValue(buildSettings());
     vi.spyOn(cards, 'getReviewQueue').mockResolvedValue([]);
     vi.mocked(triggerGistSync).mockResolvedValue({ success: true, action: 'no-change', timestamp: 'now' });
-    await storage.setItem(STORAGE_KEYS.githubPat, 'token');
-    await storage.setItem(STORAGE_KEYS.gistId, 'gist');
-    await storage.setItem(STORAGE_KEYS.gistSyncEnabled, true);
+    await setup.setGistSyncConfig({ pat: 'token', gistId: 'gist', enabled: true });
   });
 
   it.each([
@@ -51,25 +46,19 @@ describe('background sync alarm', () => {
     { name: 'disabled', enabled: false, pat: 'token', gistId: 'gist', syncs: false },
     { name: 'missing credential', enabled: true, pat: null, gistId: 'gist', syncs: false },
     { name: 'empty credential', enabled: true, pat: '', gistId: 'gist', syncs: false },
-    { name: 'missing destination', enabled: true, pat: 'token', gistId: null, syncs: false },
-    { name: 'empty destination', enabled: true, pat: 'token', gistId: '', syncs: false },
+    { name: 'missing connection', enabled: true, pat: 'token', gistId: null, syncs: false },
+    { name: 'empty connection', enabled: true, pat: 'token', gistId: '', syncs: false },
   ])(
     'handles $name configuration without network requests during readiness',
     async ({ enabled, pat, gistId, syncs }) => {
-      await storage.setItem(STORAGE_KEYS.gistSyncEnabled, enabled);
-      if (pat === null) await storage.removeItem(STORAGE_KEYS.githubPat);
-      else await storage.setItem(STORAGE_KEYS.githubPat, pat);
-      if (gistId === null) await storage.removeItem(STORAGE_KEYS.gistId);
-      else await storage.setItem(STORAGE_KEYS.gistId, gistId);
-      const credentials = vi.spyOn(auth, 'hasGitHubCredentials');
-      const destination = vi.spyOn(setup, 'getGistDestinationConfig');
+      await setup.setGistSyncConfig({ pat: pat ?? '', gistId, enabled });
+      const connection = vi.spyOn(setup, 'getGistSyncConfig');
       const badge = vi.spyOn(browser.action, 'setBadgeText');
       const fireAlarm = startBackground();
 
       await fireAlarm();
 
-      expect(credentials).toHaveBeenCalledOnce();
-      expect(destination).toHaveBeenCalledOnce();
+      expect(connection).toHaveBeenCalledOnce();
       expect(triggerGistSync).toHaveBeenCalledTimes(syncs ? 1 : 0);
       expect(Octokit).not.toHaveBeenCalled();
       // Startup refresh plus either the sync runner's refresh or the skipped-alarm fallback.
@@ -80,13 +69,11 @@ describe('background sync alarm', () => {
   it('registers synchronously but waits for startup before checking readiness', async () => {
     const migrations = Promise.withResolvers<void>();
     vi.mocked(runStartupMigrations).mockReturnValue(migrations.promise);
-    const credentials = vi.spyOn(auth, 'hasGitHubCredentials');
-    const destination = vi.spyOn(setup, 'getGistDestinationConfig');
+    const connection = vi.spyOn(setup, 'getGistSyncConfig');
     const fireAlarm = startBackground();
     const pending = fireAlarm();
     await Promise.resolve();
-    expect(credentials).not.toHaveBeenCalled();
-    expect(destination).not.toHaveBeenCalled();
+    expect(connection).not.toHaveBeenCalled();
     expect(triggerGistSync).not.toHaveBeenCalled();
 
     migrations.resolve();
@@ -105,8 +92,7 @@ describe('background sync alarm', () => {
       const writeHandler = vi.spyOn(cards, 'removeCard').mockResolvedValue(undefined);
       const tracking = vi.spyOn(tracker, 'markDataUpdated');
       const writes = vi.spyOn(storage, 'setItem');
-      const credentials = vi.spyOn(auth, 'hasGitHubCredentials');
-      const destination = vi.spyOn(setup, 'getGistDestinationConfig');
+      const connection = vi.spyOn(setup, 'getGistSyncConfig');
       const alarmRead = vi.spyOn(browser.alarms, 'get');
       const alarmCreate = vi.spyOn(browser.alarms, 'create');
       const badgeText = vi.spyOn(browser.action, 'setBadgeText');
@@ -137,8 +123,7 @@ describe('background sync alarm', () => {
       expect.soft(Octokit).not.toHaveBeenCalled();
       expect.soft(tracking).not.toHaveBeenCalled();
       expect.soft(writes).not.toHaveBeenCalled();
-      expect.soft(credentials).not.toHaveBeenCalled();
-      expect.soft(destination).not.toHaveBeenCalled();
+      expect.soft(connection).not.toHaveBeenCalled();
       expect.soft(alarmRead).not.toHaveBeenCalled();
       expect.soft(alarmCreate).not.toHaveBeenCalled();
       expect.soft(getSettings).not.toHaveBeenCalled();
@@ -157,9 +142,9 @@ describe('background sync alarm', () => {
       writeStarted.resolve();
       await releaseWrite.promise;
     });
-    const hasCredentials = auth.hasGitHubCredentials;
-    vi.spyOn(auth, 'hasGitHubCredentials').mockImplementation(async () => {
-      const ready = await hasCredentials();
+    const getConfig = setup.getGistSyncConfig;
+    vi.spyOn(setup, 'getGistSyncConfig').mockImplementation(async () => {
+      const ready = await getConfig();
       checked.resolve();
       return ready;
     });
@@ -224,13 +209,13 @@ describe('background sync alarm', () => {
   });
 
   it('ignores unrelated alarms', async () => {
-    const credentials = vi.spyOn(auth, 'hasGitHubCredentials');
+    const connection = vi.spyOn(setup, 'getGistSyncConfig');
     const fireAlarm = startBackground();
     await fireAlarm();
     vi.clearAllMocks();
 
     await fireAlarm('unrelated');
-    expect(credentials).not.toHaveBeenCalled();
+    expect(connection).not.toHaveBeenCalled();
     expect(triggerGistSync).not.toHaveBeenCalled();
   });
 });

--- a/entrypoints/background/index.ts
+++ b/entrypoints/background/index.ts
@@ -20,14 +20,8 @@ import {
   setPauseStatus,
 } from '@/services/cards';
 import { shouldResetEditor } from '@/services/editor-reset';
-import {
-  createNewGist,
-  getGistDestinationConfig,
-  getGistSyncConfig,
-  setGistSyncConfig,
-  validateGistId,
-} from '@/services/gist-setup';
-import { hasGitHubCredentials, validatePat } from '@/services/github-auth';
+import { createNewGist, getGistSyncConfig, setGistSyncConfig, validateGistId } from '@/services/gist-setup';
+import { validatePat } from '@/services/github-auth';
 import { getGistSyncStatus, triggerGistSync } from '@/services/github-sync';
 import { exportData, importData, resetAllData } from '@/services/import-export';
 import { deleteNote, getNote, saveNote } from '@/services/notes';
@@ -168,8 +162,8 @@ export default defineBackground(() => {
       return;
     }
 
-    const [config, hasCredentials] = await Promise.all([getGistDestinationConfig(), hasGitHubCredentials()]);
-    if (config.enabled && hasCredentials && config.gistId) {
+    const config = await getGistSyncConfig();
+    if (config.enabled && config.pat && config.gistId) {
       await dispatch('triggerGistSync', undefined);
     } else {
       await updateBadge();

--- a/i18n/de.ts
+++ b/i18n/de.ts
@@ -158,7 +158,8 @@ const de: Translations = {
     gistSync: {
       title: 'GitHub-Gist-Synchronisierung',
       gistDescription: 'LeetSRS-Sicherung – Daten zum verteilten Lernen',
-      description: 'Synchronisiere deine Daten über GitHub Gists zwischen Browsern',
+      description:
+        'Synchronisiere deine Daten über GitHub Gists. Richte Token, Gist-ID und Synchronisierung auf jedem Gerät separat ein.',
       patLabel: 'Personal Access Token',
       patPlaceholder: 'ghp_xxxxxxxxxxxx',
       patHelpText: 'Erstelle ein Token mit dem Scope "gist" unter',

--- a/i18n/en.ts
+++ b/i18n/en.ts
@@ -201,7 +201,8 @@ const en = {
     gistSync: {
       title: 'GitHub Gist Sync',
       gistDescription: 'LeetSRS Backup - Spaced Repetition Data',
-      description: 'Sync your data across browsers using GitHub Gists',
+      description:
+        'Sync your data using GitHub Gists. Set up the token, Gist ID, and sync toggle separately on each device.',
       // PAT field
       patLabel: 'Personal Access Token',
       patPlaceholder: 'ghp_xxxxxxxxxxxx',

--- a/i18n/hi.ts
+++ b/i18n/hi.ts
@@ -180,7 +180,7 @@ const hi: Translations = {
     gistSync: {
       title: 'GitHub Gist सिंक',
       gistDescription: 'LeetSRS बैकअप - स्पेस्ड रिपिटिशन डेटा',
-      description: 'GitHub Gists का यूज़ करके ब्राउज़रों में डेटा सिंक करें',
+      description: 'GitHub Gists से डेटा सिंक करें। हर डिवाइस पर टोकन, Gist ID और सिंक स्विच अलग से सेट करें।',
       // PAT field
       patLabel: 'पर्सनल एक्सेस टोकन (PAT)',
       patPlaceholder: 'ghp_xxxxxxxxxxxx',

--- a/i18n/pl.ts
+++ b/i18n/pl.ts
@@ -202,7 +202,8 @@ const pl: Translations = {
     gistSync: {
       title: 'Synchronizacja przez GitHub Gist',
       gistDescription: 'Kopia zapasowa LeetSRS - Dane powtórek rozłożonych w czasie',
-      description: 'Synchronizuj dane między przeglądarkami za pomocą GitHub Gists',
+      description:
+        'Synchronizuj dane przez GitHub Gist. Ustaw token, ID Gista i włącz synchronizację osobno na każdym urządzeniu.',
       // PAT field
       patLabel: 'Osobisty token dostępu',
       patPlaceholder: 'ghp_xxxxxxxxxxxx',

--- a/i18n/zh-CN.ts
+++ b/i18n/zh-CN.ts
@@ -180,7 +180,7 @@ const zhCN: Translations = {
     gistSync: {
       title: 'GitHub Gist 同步',
       gistDescription: 'LeetSRS 备份 - 间隔重复数据',
-      description: '通过 GitHub Gist 在不同浏览器间同步数据',
+      description: '通过 GitHub Gist 同步数据。请在每台设备上分别设置令牌、Gist ID 和同步开关。',
       patLabel: '个人访问令牌',
       patPlaceholder: 'ghp_xxxxxxxxxxxx',
       patHelpText: '在以下位置创建具有 "gist" 权限的令牌：',

--- a/infrastructure/storage/__tests__/backup.test.ts
+++ b/infrastructure/storage/__tests__/backup.test.ts
@@ -151,7 +151,7 @@ describe('parseBackup', () => {
   });
 
   it.each([
-    { schemaVersion: 5 },
+    { schemaVersion: 6 },
     { schemaVersion: -1 },
     { schemaVersion: null },
     { schemaVersion: 1.5 },

--- a/infrastructure/storage/__tests__/sync-metadata.test.ts
+++ b/infrastructure/storage/__tests__/sync-metadata.test.ts
@@ -7,9 +7,7 @@ import { readSyncMetadata } from '../sync-metadata';
 
 type MetadataKey = Parameters<typeof readSyncMetadata>[0];
 const cases: [MetadataKey, unknown, unknown][] = [
-  ['githubPat', ' token ', 42],
-  ['gistId', '', 42],
-  ['gistSyncEnabled', false, 'false'],
+  ['gistConnection', { pat: ' token ', gistId: null, enabled: false }, { pat: 'token', gistId: 42, enabled: false }],
   ['lastSyncTime', '2024-01-01T00:00:00.000Z', 42],
   ['lastSyncDirection', 'pull', 'invalid'],
   ['dataUpdatedAt', '2024-01-01T00:00:00.000Z', 42],
@@ -21,7 +19,7 @@ describe('sync metadata decoding', () => {
   it.each(cases)('decodes missing, valid, and invalid %s', async (key, value, invalid) => {
     expect(await readSyncMetadata(key)).toBeNull();
     await storage.setItem(STORAGE_KEYS[key], value);
-    expect(await readSyncMetadata(key)).toBe(value);
+    expect(await readSyncMetadata(key)).toEqual(value);
     await storage.setItem(STORAGE_KEYS[key], invalid);
     await expect(readSyncMetadata(key)).rejects.toBeInstanceOf(ZodError);
     expect(await storage.getItem(STORAGE_KEYS[key])).toEqual(invalid);

--- a/infrastructure/storage/migrations/005-local-gist-connection.ts
+++ b/infrastructure/storage/migrations/005-local-gist-connection.ts
@@ -1,0 +1,42 @@
+import { z } from 'zod';
+import { storage } from '#imports';
+import { gistConnectionSchema } from '@/domain/schemas/v5';
+import { type Output as Input, validateOutput as validateInput } from './004-embed-notes';
+import { readDataset } from './layouts/v4';
+import type { Migration } from './migration';
+
+export type Output = Input;
+export const validateOutput: typeof validateInput = validateInput;
+
+export const localGistConnection = {
+  description: 'Move the Gist connection to one device-local record',
+  validateOutput,
+  async load(): Promise<Input> {
+    const input = await readDataset();
+    validateInput(input);
+    return input;
+  },
+  migrate(data: unknown): Output {
+    validateInput(data);
+    return data;
+  },
+  async save(output: Output): Promise<void> {
+    validateOutput(output);
+    // A prior attempt may have saved the destination before recording completion.
+    // Prefer it even if another device has since changed the legacy sync keys.
+    let connection = output.gistConnection;
+    if (connection == null) {
+      const destination = z
+        .object({ gistId: z.string().nullish(), enabled: z.boolean().nullish() })
+        .parse(output.gistSync ?? {});
+      connection = {
+        pat: output.settings?.githubPat ?? '',
+        gistId: destination.gistId ?? null,
+        enabled: destination.enabled ?? false,
+      };
+    }
+    const validated = gistConnectionSchema.parse(connection);
+    await storage.setItem('local:leetsrs:gistConnection', validated);
+    // Keep legacy sync keys for devices that have not upgraded yet.
+  },
+} satisfies Migration<Input, Output>;

--- a/infrastructure/storage/migrations/__tests__/embedded-notes.test.ts
+++ b/infrastructure/storage/migrations/__tests__/embedded-notes.test.ts
@@ -3,9 +3,14 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { fakeBrowser } from 'wxt/testing/fake-browser';
 import { storage } from 'wxt/utils/storage';
 import { createMockCard } from '@/test/utils/card-mocks';
+import { addCardDomain } from '../001-add-card-domain';
+import { addSystemTheme } from '../002-add-system-theme';
+import { removeDayStart } from '../003-remove-day-start';
 import { embedNotes, validateOutput } from '../004-embed-notes';
 import { readDataset } from '../layouts/v4';
 import { migrateBackupData, runStartupMigrations, setSchemaVersion } from '../runner';
+
+const historicalMigrations = [addCardDomain, addSystemTheme, removeDayStart, embedNotes];
 
 describe('embedded note migration', () => {
   beforeEach(() => fakeBrowser.reset());
@@ -99,7 +104,7 @@ describe('embedded note migration', () => {
       vi.spyOn(storage, 'snapshot').mockImplementation(async (area) => (area === 'local' ? local : {}));
       const write = vi.spyOn(fakeBrowser.storage.local, 'set');
       const remove = vi.spyOn(fakeBrowser.storage.local, 'remove');
-      await expect(runStartupMigrations()).rejects.toThrow('Failed to run migration 4');
+      await expect(runStartupMigrations(historicalMigrations)).rejects.toThrow('Failed to run migration 4');
       expect(write).not.toHaveBeenCalled();
       expect(remove).not.toHaveBeenCalled();
       expect(await storage.getItem('local:leetsrs:schemaVersion')).toBe(3);
@@ -127,7 +132,7 @@ describe('embedded note migration', () => {
               .mockImplementation((key, value) =>
                 key === 'local:leetsrs:schemaVersion' ? Promise.reject(failure) : write(key, value)
               );
-    await expect(runStartupMigrations()).rejects.toThrow('Failed to run migration 4');
+    await expect(runStartupMigrations(historicalMigrations)).rejects.toThrow('Failed to run migration 4');
     expect(await storage.getItem('local:leetsrs:schemaVersion')).toBe(3);
     expect(await storage.getItem('local:leetsrs:notes:owner')).toEqual(
       stage === 'version' ? null : { text: 'Keep the schedule' }
@@ -136,8 +141,8 @@ describe('embedded note migration', () => {
       'two-sum': { ...card, ...(stage !== 'save' && { note: 'Keep the schedule' }) },
     });
     failed.mockRestore();
-    await runStartupMigrations();
-    await runStartupMigrations();
+    await runStartupMigrations(historicalMigrations);
+    await runStartupMigrations(historicalMigrations);
     expect(await fakeBrowser.storage.local.get(null)).toEqual({
       'leetsrs:cards': { 'two-sum': { ...card, note: 'Keep the schedule' } },
       'leetsrs:schemaVersion': 4,

--- a/infrastructure/storage/migrations/__tests__/local-gist-connection.test.ts
+++ b/infrastructure/storage/migrations/__tests__/local-gist-connection.test.ts
@@ -1,0 +1,131 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fakeBrowser } from 'wxt/testing/fake-browser';
+import { storage } from 'wxt/utils/storage';
+import { readSyncMetadata } from '../../sync-metadata';
+import { readDataset } from '../layouts/v5';
+import { migrateBackupData, runStartupMigrations, setSchemaVersion } from '../runner';
+
+describe('device-local Gist connection migration', () => {
+  beforeEach(() => fakeBrowser.reset());
+
+  it.each([
+    { name: 'fresh install', legacy: {}, expected: { pat: '', gistId: null, enabled: false } },
+    {
+      name: 'configured device',
+      legacy: { 'leetsrs:githubPat': ' token ', 'leetsrs:gistId': 'gist', 'leetsrs:gistSyncEnabled': true },
+      expected: { pat: ' token ', gistId: 'gist', enabled: true },
+    },
+    {
+      name: 'partial setup',
+      legacy: { 'leetsrs:githubPat': 'token' },
+      expected: { pat: 'token', gistId: null, enabled: false },
+    },
+    {
+      name: 'empty credentials',
+      legacy: { 'leetsrs:githubPat': '', 'leetsrs:gistId': '', 'leetsrs:gistSyncEnabled': false },
+      expected: { pat: '', gistId: '', enabled: false },
+    },
+  ])('upgrades $name in one connection write and retains legacy migration input', async ({ legacy, expected }) => {
+    await setSchemaVersion(4);
+    await fakeBrowser.storage.sync.set<Record<string, unknown>>(legacy);
+    const writes = vi.spyOn(fakeBrowser.storage.local, 'set');
+
+    await runStartupMigrations();
+    await runStartupMigrations();
+
+    expect(await readSyncMetadata('gistConnection')).toEqual(expected);
+    expect(writes.mock.calls).toEqual([[{ 'leetsrs:gistConnection': expected }], [{ 'leetsrs:schemaVersion': 5 }]]);
+    expect(await fakeBrowser.storage.sync.get(null)).toEqual(legacy);
+    expect(await readSyncMetadata('dataUpdatedAt')).toBeNull();
+  });
+
+  it.each(['load', 'save', 'version'] as const)(
+    'restarts after a failed %s without losing the connection',
+    async (stage) => {
+      await setSchemaVersion(4);
+      const legacy = {
+        'leetsrs:githubPat': 'original',
+        'leetsrs:gistId': 'original-gist',
+        'leetsrs:gistSyncEnabled': true,
+      };
+      await fakeBrowser.storage.sync.set(legacy);
+      const write = storage.setItem.bind(storage);
+      const failure = new Error('Storage unavailable');
+      const failed =
+        stage === 'load'
+          ? vi.spyOn(storage, 'snapshot').mockRejectedValueOnce(failure)
+          : vi.spyOn(storage, 'setItem').mockImplementation((key, value) => {
+              if (key === (stage === 'save' ? 'local:leetsrs:gistConnection' : 'local:leetsrs:schemaVersion')) {
+                return Promise.reject(failure);
+              }
+              return write(key, value);
+            });
+
+      await expect(runStartupMigrations()).rejects.toThrow('Storage unavailable');
+      expect(await storage.getItem('local:leetsrs:schemaVersion')).toBe(4);
+      expect(await readSyncMetadata('gistConnection')).toEqual(
+        stage === 'version' ? { pat: 'original', gistId: 'original-gist', enabled: true } : null
+      );
+      expect(await fakeBrowser.storage.sync.get(null)).toEqual(legacy);
+      failed.mockRestore();
+      if (stage === 'version') await storage.setItem('sync:leetsrs:githubPat', 'changed-on-another-device');
+
+      await runStartupMigrations();
+      await runStartupMigrations();
+
+      expect(await readSyncMetadata('gistConnection')).toEqual({
+        pat: 'original',
+        gistId: 'original-gist',
+        enabled: true,
+      });
+      expect(await storage.getItem('local:leetsrs:schemaVersion')).toBe(5);
+    }
+  );
+
+  it.each([
+    { pat: 'local', gistId: 'local-gist', enabled: true },
+    { pat: '', gistId: null, enabled: false },
+  ])('prefers an already-written local record, including explicit defaults: %j', async (connection) => {
+    await setSchemaVersion(4);
+    await storage.setItem('local:leetsrs:gistConnection', connection);
+    // Malformed stale fields must not override or invalidate a complete destination.
+    const legacy = { 'leetsrs:githubPat': 42, 'leetsrs:gistId': 42, 'leetsrs:gistSyncEnabled': 'yes' };
+    await fakeBrowser.storage.sync.set(legacy);
+    await runStartupMigrations();
+    expect(await readSyncMetadata('gistConnection')).toEqual(connection);
+    expect(await fakeBrowser.storage.sync.get(null)).toEqual(legacy);
+    expect(await readDataset()).toEqual({ settings: {}, gistSync: connection });
+  });
+
+  it('migrates fresh storage and keeps backup transformations independent of the installed connection', async () => {
+    await runStartupMigrations();
+    expect(await readSyncMetadata('gistConnection')).toEqual({ pat: '', gistId: null, enabled: false });
+    const input = Object.freeze({
+      cards: {},
+      settings: {},
+      gistSync: Object.freeze({ gistId: 'backup-gist', enabled: true }),
+    });
+    const snapshots = vi.spyOn(storage, 'snapshot').mockRejectedValue(new Error('No storage access'));
+    const reads = vi.spyOn(storage, 'getItem').mockRejectedValue(new Error('No storage access'));
+    const writes = vi.spyOn(storage, 'setItem').mockRejectedValue(new Error('No storage access'));
+    expect(migrateBackupData(input, 4)).toBe(input);
+    expect(migrateBackupData(input, 5)).toBe(input);
+    expect(snapshots).not.toHaveBeenCalled();
+    expect(reads).not.toHaveBeenCalled();
+    expect(writes).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    { area: 'sync', key: 'leetsrs:githubPat', value: 42 },
+    { area: 'sync', key: 'leetsrs:gistId', value: false },
+    { area: 'sync', key: 'leetsrs:gistSyncEnabled', value: 'true' },
+    { area: 'local', key: 'leetsrs:gistConnection', value: { pat: 'token' } },
+  ] as const)('rejects malformed $key before writing the connection or completion', async ({ area, key, value }) => {
+    await setSchemaVersion(4);
+    await fakeBrowser.storage[area].set<Record<string, unknown>>({ [key]: value });
+    const writes = vi.spyOn(fakeBrowser.storage.local, 'set');
+    await expect(runStartupMigrations()).rejects.toThrow('Failed to run migration 5');
+    expect(writes).not.toHaveBeenCalled();
+    expect(await storage.getItem('local:leetsrs:schemaVersion')).toBe(4);
+  });
+});

--- a/infrastructure/storage/migrations/layouts/v5.ts
+++ b/infrastructure/storage/migrations/layouts/v5.ts
@@ -1,0 +1,25 @@
+import { storage } from '#imports';
+
+// Layout v5 keeps the connection in local storage. Expose its raw value for the
+// caller's historical validator; retained legacy sync keys are no longer inputs.
+export async function readDataset(): Promise<Record<string, unknown>> {
+  const [local, sync] = await Promise.all([storage.snapshot('local'), storage.snapshot('sync')]);
+  const localData = Object.fromEntries(
+    Object.entries(local)
+      .filter(
+        ([key]) => key.startsWith('leetsrs:') && key !== 'leetsrs:schemaVersion' && !key.startsWith('leetsrs:notes:')
+      )
+      .map(([key, value]) => [key.slice('leetsrs:'.length), value])
+  );
+  const settings = Object.fromEntries(
+    Object.entries(sync)
+      .filter(
+        ([key]) =>
+          key.startsWith('leetsrs:') &&
+          !['leetsrs:githubPat', 'leetsrs:gistId', 'leetsrs:gistSyncEnabled'].includes(key)
+      )
+      .map(([key, value]) => [key.slice('leetsrs:'.length), value])
+  );
+  const { gistConnection, ...data } = localData;
+  return { ...data, settings, gistSync: gistConnection ?? {} };
+}

--- a/infrastructure/storage/migrations/runner.ts
+++ b/infrastructure/storage/migrations/runner.ts
@@ -4,10 +4,17 @@ import { addCardDomain } from './001-add-card-domain';
 import { addSystemTheme } from './002-add-system-theme';
 import { removeDayStart } from './003-remove-day-start';
 import { embedNotes } from './004-embed-notes';
+import { localGistConnection } from './005-local-gist-connection';
 import type { Migration } from './migration';
 
 // Append only: index + 1 is the schema version. Never reorder or remove entries.
-const migrations = [addCardDomain, addSystemTheme, removeDayStart, embedNotes] as const satisfies readonly Migration[];
+const migrations = [
+  addCardDomain,
+  addSystemTheme,
+  removeDayStart,
+  embedNotes,
+  localGistConnection,
+] as const satisfies readonly Migration[];
 export const LATEST_SCHEMA_VERSION = migrations.length;
 
 export async function setSchemaVersion(version: number): Promise<void> {

--- a/infrastructure/storage/storage-keys.ts
+++ b/infrastructure/storage/storage-keys.ts
@@ -11,9 +11,7 @@ export const STORAGE_KEYS = {
   // Tracks when actual data was last modified (for sync)
   dataUpdatedAt: 'local:leetsrs:dataUpdatedAt',
   // GitHub Gist Sync
-  githubPat: 'sync:leetsrs:githubPat',
-  gistId: 'sync:leetsrs:gistId',
-  gistSyncEnabled: 'sync:leetsrs:gistSyncEnabled',
+  gistConnection: 'local:leetsrs:gistConnection',
   lastSyncTime: 'local:leetsrs:lastSyncTime',
   lastSyncDirection: 'local:leetsrs:lastSyncDirection',
 } as const;

--- a/infrastructure/storage/sync-metadata.ts
+++ b/infrastructure/storage/sync-metadata.ts
@@ -7,9 +7,7 @@ import { STORAGE_KEYS } from './storage-keys';
 // Callers retain defaults, PAT preservation, timestamps, and operation order.
 // These calls do not mark local edits.
 const syncMetadataSchema = z.object({
-  githubPat: gistSyncConfigSchema.shape.pat,
-  gistId: gistSyncConfigSchema.shape.gistId.unwrap(),
-  gistSyncEnabled: gistSyncConfigSchema.shape.enabled,
+  gistConnection: gistSyncConfigSchema,
   lastSyncTime: z.string(),
   lastSyncDirection: z.enum(['push', 'pull']),
   dataUpdatedAt: z.string(),
@@ -24,7 +22,7 @@ export async function readSyncMetadata<K extends keyof SyncMetadata>(key: K): Pr
 }
 
 export function writeSyncMetadata<K extends keyof SyncMetadata>(key: K, value: SyncMetadata[K]): Promise<void> {
-  return storage.setItem(STORAGE_KEYS[key], value);
+  return storage.setItem(STORAGE_KEYS[key], fields[key].parse(value));
 }
 
 export function removeSyncMetadata(key: keyof SyncMetadata): Promise<void> {

--- a/services/__tests__/gist-setup.test.ts
+++ b/services/__tests__/gist-setup.test.ts
@@ -32,16 +32,17 @@ describe('gist-setup boundaries', () => {
     { name: 'saved configuration', saved: true, expected: { pat: 'token', gistId: 'gist', enabled: true } },
   ])('reads $name', async ({ saved, expected }) => {
     if (saved) {
-      await storage.setItem(STORAGE_KEYS.githubPat, expected.pat);
-      await storage.setItem(STORAGE_KEYS.gistId, expected.gistId);
-      await storage.setItem(STORAGE_KEYS.gistSyncEnabled, expected.enabled);
+      await storage.setItem(STORAGE_KEYS.gistConnection, expected);
     }
     expect(await getGistSyncConfig()).toEqual(expected);
   });
 
   it('persists the complete configuration without marking learning data edited', async () => {
     const config = { pat: ' token ', gistId: 'gist', enabled: true };
+    const writes = vi.spyOn(fakeBrowser.storage.local, 'set');
     await setGistSyncConfig(config);
+    expect(writes).toHaveBeenCalledExactlyOnceWith({ 'leetsrs:gistConnection': config });
+    expect(await fakeBrowser.storage.sync.get(null)).toEqual({});
     expect(await getGistSyncConfig()).toEqual(config);
     expect(await storage.getItem(STORAGE_KEYS.dataUpdatedAt)).toBeNull();
   });
@@ -72,7 +73,7 @@ describe('gist-setup boundaries', () => {
   });
 
   it('validates with the exact supplied PAT without reading or changing saved credentials', async () => {
-    await storage.setItem(STORAGE_KEYS.githubPat, 'saved');
+    await storage.setItem(STORAGE_KEYS.gistConnection, { pat: 'saved', gistId: null, enabled: false });
     const reads = vi.spyOn(storage, 'getItem');
     const writes = vi.spyOn(storage, 'setItem');
     const acquire = vi.spyOn(auth, 'getAuthenticatedGitHubClient');
@@ -101,10 +102,10 @@ describe('gist-setup boundaries', () => {
   });
 
   it('propagates configuration-read failures during creation', async () => {
-    await storage.setItem(STORAGE_KEYS.githubPat, 'saved');
+    await storage.setItem(STORAGE_KEYS.gistConnection, { pat: 'saved', gistId: null, enabled: false });
     const read = storage.getItem.bind(storage);
     vi.spyOn(storage, 'getItem').mockImplementation((key, options) => {
-      if (key === STORAGE_KEYS.gistId) return Promise.reject(new Error('read failed'));
+      if (key === STORAGE_KEYS.gistConnection) return Promise.reject(new Error('read failed'));
       return read(key, options);
     });
     await expect(createNewGist()).rejects.toThrow('read failed');
@@ -114,7 +115,7 @@ describe('gist-setup boundaries', () => {
   it.each(['export', 'request', 'destination'] as const)(
     'stops creation persistence after a failed %s',
     async (stage) => {
-      await storage.setItem(STORAGE_KEYS.githubPat, 'saved');
+      await storage.setItem(STORAGE_KEYS.gistConnection, { pat: 'saved', gistId: null, enabled: false });
       const failure = new Error('failed');
       exportData.mockResolvedValue('{}');
       create.mockResolvedValue({ data: { id: 'created' } });
@@ -124,7 +125,11 @@ describe('gist-setup boundaries', () => {
       if (stage === 'destination') writes.mockRejectedValue(failure);
 
       await expect(createNewGist()).rejects.toBe(failure);
-      expect(writes.mock.calls).toEqual(stage === 'destination' ? [[STORAGE_KEYS.gistId, 'created']] : []);
+      expect(writes.mock.calls).toEqual(
+        stage === 'destination'
+          ? [[STORAGE_KEYS.gistConnection, { pat: 'saved', gistId: 'created', enabled: false }]]
+          : []
+      );
       if (stage === 'export') expect(create).not.toHaveBeenCalled();
     }
   );
@@ -132,14 +137,11 @@ describe('gist-setup boundaries', () => {
     'applies partial update %j while preserving other fields',
     async (update) => {
       const original = { pat: 'original', gistId: 'original-gist', enabled: false };
-      await storage.setItem(STORAGE_KEYS.githubPat, original.pat);
-      await storage.setItem(STORAGE_KEYS.gistId, original.gistId);
-      await storage.setItem(STORAGE_KEYS.gistSyncEnabled, original.enabled);
+      await storage.setItem(STORAGE_KEYS.gistConnection, original);
 
       await setGistSyncConfig(update);
 
       expect(await getGistSyncConfig()).toEqual({ ...original, ...update });
-      if (update.gistId === null) expect(await storage.getItem(STORAGE_KEYS.gistId)).toBeNull();
     }
   );
 
@@ -168,7 +170,7 @@ describe('gist-setup boundaries', () => {
     });
 
     it('should throw when gist creation fails with no ID', async () => {
-      await storage.setItem(STORAGE_KEYS.githubPat, 'ghp_test');
+      await storage.setItem(STORAGE_KEYS.gistConnection, { pat: 'ghp_test', gistId: null, enabled: false });
       exportData.mockResolvedValue('{}');
       create.mockResolvedValue({ data: {} });
 
@@ -182,8 +184,7 @@ describe('gist-setup boundaries', () => {
     beforeEach(async () => {
       vi.useFakeTimers();
       vi.setSystemTime(new Date(now));
-      await storage.setItem(STORAGE_KEYS.githubPat, 'ghp_test');
-      await storage.setItem(STORAGE_KEYS.gistId, 'gist123');
+      await storage.setItem(STORAGE_KEYS.gistConnection, { pat: 'ghp_test', gistId: 'gist123', enabled: false });
     });
 
     afterEach(() => vi.useRealTimers());
@@ -202,13 +203,13 @@ describe('gist-setup boundaries', () => {
         await expect(createNewGist()).rejects.toThrow('status failed');
 
         expect(create).toHaveBeenCalledOnce();
-        expect(await storage.getItem(STORAGE_KEYS.gistId)).toBe('created');
+        expect((await getGistSyncConfig()).gistId).toBe('created');
         expect(await storage.getItem(STORAGE_KEYS.lastSyncTime)).toBe(
           failedKey === STORAGE_KEYS.lastSyncTime ? null : now
         );
         expect(await storage.getItem(STORAGE_KEYS.lastSyncDirection)).toBeNull();
         const expectedWrites: unknown[][] = [
-          [STORAGE_KEYS.gistId, 'created'],
+          [STORAGE_KEYS.gistConnection, { pat: 'ghp_test', gistId: 'created', enabled: false }],
           [STORAGE_KEYS.lastSyncTime, now],
         ];
         if (failedKey === STORAGE_KEYS.lastSyncDirection) expectedWrites.push([STORAGE_KEYS.lastSyncDirection, 'push']);
@@ -229,21 +230,23 @@ describe('gist-setup boundaries', () => {
         public: false,
         files: { 'leetsrs-backup.json': { content: '{"local":"snapshot"}' } },
       });
-      expect(await storage.getItem(STORAGE_KEYS.gistId)).toBe('created');
+      expect((await getGistSyncConfig()).gistId).toBe('created');
       expect(await storage.getItem(STORAGE_KEYS.lastSyncTime)).toBe(now);
       expect(await storage.getItem(STORAGE_KEYS.lastSyncDirection)).toBe('push');
     });
 
-    it('keeps an earlier config write when a later update fails, skipping remaining fields', async () => {
-      const remove = vi.spyOn(storage, 'removeItem').mockRejectedValue(new Error('remove failed'));
-      const writes = vi.spyOn(storage, 'setItem');
+    it('preserves the whole connection when its replacement fails', async () => {
+      const before = await getGistSyncConfig();
+      const writes = vi.spyOn(storage, 'setItem').mockRejectedValueOnce(new Error('write failed'));
 
-      await expect(setGistSyncConfig({ pat: 'new-pat', gistId: null, enabled: true })).rejects.toThrow('remove failed');
+      await expect(setGistSyncConfig({ pat: 'new-pat', gistId: null, enabled: true })).rejects.toThrow('write failed');
 
-      expect(writes.mock.calls).toEqual([[STORAGE_KEYS.githubPat, 'new-pat']]);
-      expect(remove).toHaveBeenCalledExactlyOnceWith(STORAGE_KEYS.gistId);
-      expect(await storage.getItem(STORAGE_KEYS.githubPat)).toBe('new-pat');
-      expect(await storage.getItem(STORAGE_KEYS.gistSyncEnabled)).toBeNull();
+      expect(writes).toHaveBeenCalledExactlyOnceWith(STORAGE_KEYS.gistConnection, {
+        pat: 'new-pat',
+        gistId: null,
+        enabled: true,
+      });
+      expect(await getGistSyncConfig()).toEqual(before);
     });
   });
 });

--- a/services/__tests__/github-auth.test.ts
+++ b/services/__tests__/github-auth.test.ts
@@ -3,8 +3,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { fakeBrowser } from 'wxt/testing/fake-browser';
 import { storage } from 'wxt/utils/storage';
 import { STORAGE_KEYS } from '@/infrastructure/storage/storage-keys';
-import { getGistSyncConfig, setGistSyncConfig } from '../gist-setup';
-import { getGitHubPat, setGitHubPat, validatePat } from '../github-auth';
+import { setGistSyncConfig } from '../gist-setup';
+import { getGitHubPat, validatePat } from '../github-auth';
 
 const { getAuthenticated, getGist } = vi.hoisted(() => ({
   getAuthenticated: vi.fn(),
@@ -28,29 +28,19 @@ describe('github-auth', () => {
     fakeBrowser.runtime.id = 'test';
   });
 
-  it.each(['', ' token '])(
-    'changes credential %j while preserving the destination and learning timestamp',
-    async (pat) => {
-      expect(await getGitHubPat()).toBeNull();
-      await setGistSyncConfig({ gistId: 'keep-gist', enabled: true });
-      await setGitHubPat(pat);
-      expect(await getGistSyncConfig()).toEqual({ pat, gistId: 'keep-gist', enabled: true });
-      expect(await getGitHubPat()).toBe(pat);
-
-      await setGitHubPat('');
-      expect(await getGitHubPat()).toBe('');
-      expect(await storage.getItem(STORAGE_KEYS.dataUpdatedAt)).toBeNull();
-      expect(Octokit).not.toHaveBeenCalled();
-    }
-  );
+  it.each(['', ' token '])('reads the exact saved credential %j without making a request', async (pat) => {
+    expect(await getGitHubPat()).toBeNull();
+    await setGistSyncConfig({ pat, gistId: 'keep-gist', enabled: true });
+    expect(await getGitHubPat()).toBe(pat);
+    expect(await storage.getItem(STORAGE_KEYS.dataUpdatedAt)).toBeNull();
+    expect(Octokit).not.toHaveBeenCalled();
+  });
 
   it('propagates credential persistence failures', async () => {
     const failure = new Error('storage unavailable');
     vi.spyOn(storage, 'getItem').mockRejectedValue(failure);
-    vi.spyOn(storage, 'setItem').mockRejectedValue(failure);
 
     await expect(getGitHubPat()).rejects.toBe(failure);
-    await expect(setGitHubPat('token')).rejects.toBe(failure);
     expect(Octokit).not.toHaveBeenCalled();
   });
 

--- a/services/__tests__/github-auth.test.ts
+++ b/services/__tests__/github-auth.test.ts
@@ -3,7 +3,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { fakeBrowser } from 'wxt/testing/fake-browser';
 import { storage } from 'wxt/utils/storage';
 import { STORAGE_KEYS } from '@/infrastructure/storage/storage-keys';
-import { getGitHubPat, removeGitHubPat, setGitHubPat, validatePat } from '../github-auth';
+import { getGistSyncConfig, setGistSyncConfig } from '../gist-setup';
+import { getGitHubPat, setGitHubPat, validatePat } from '../github-auth';
 
 const { getAuthenticated, getGist } = vi.hoisted(() => ({
   getAuthenticated: vi.fn(),
@@ -27,27 +28,29 @@ describe('github-auth', () => {
     fakeBrowser.runtime.id = 'test';
   });
 
-  it.each(['', ' token '])('persists and removes credential %j without marking local edits', async (pat) => {
-    expect(await getGitHubPat()).toBeNull();
-    await setGitHubPat(pat);
-    expect(await storage.getItem(STORAGE_KEYS.githubPat)).toBe(pat);
-    expect(await getGitHubPat()).toBe(pat);
+  it.each(['', ' token '])(
+    'changes credential %j while preserving the destination and learning timestamp',
+    async (pat) => {
+      expect(await getGitHubPat()).toBeNull();
+      await setGistSyncConfig({ gistId: 'keep-gist', enabled: true });
+      await setGitHubPat(pat);
+      expect(await getGistSyncConfig()).toEqual({ pat, gistId: 'keep-gist', enabled: true });
+      expect(await getGitHubPat()).toBe(pat);
 
-    await removeGitHubPat();
-    expect(await storage.getItem(STORAGE_KEYS.githubPat)).toBeNull();
-    expect(await storage.getItem(STORAGE_KEYS.dataUpdatedAt)).toBeNull();
-    expect(Octokit).not.toHaveBeenCalled();
-  });
+      await setGitHubPat('');
+      expect(await getGitHubPat()).toBe('');
+      expect(await storage.getItem(STORAGE_KEYS.dataUpdatedAt)).toBeNull();
+      expect(Octokit).not.toHaveBeenCalled();
+    }
+  );
 
   it('propagates credential persistence failures', async () => {
     const failure = new Error('storage unavailable');
     vi.spyOn(storage, 'getItem').mockRejectedValue(failure);
     vi.spyOn(storage, 'setItem').mockRejectedValue(failure);
-    vi.spyOn(storage, 'removeItem').mockRejectedValue(failure);
 
     await expect(getGitHubPat()).rejects.toBe(failure);
     await expect(setGitHubPat('token')).rejects.toBe(failure);
-    await expect(removeGitHubPat()).rejects.toBe(failure);
     expect(Octokit).not.toHaveBeenCalled();
   });
 
@@ -64,7 +67,7 @@ describe('github-auth', () => {
     });
 
     it('validates the untrimmed input and returns the username without accessing stored credentials', async () => {
-      await storage.setItem(STORAGE_KEYS.githubPat, 'stored');
+      await setGistSyncConfig({ pat: 'stored' });
       const reads = vi.spyOn(storage, 'getItem');
       const writes = vi.spyOn(storage, 'setItem');
       getAuthenticated.mockResolvedValue({ data: { login: 'testuser' } });

--- a/services/__tests__/github-sync.test.ts
+++ b/services/__tests__/github-sync.test.ts
@@ -6,6 +6,7 @@ import { parseBackup } from '@/infrastructure/storage/backup';
 import { setSchemaVersion } from '@/infrastructure/storage/migrations/runner';
 import { STORAGE_KEYS } from '@/infrastructure/storage/storage-keys';
 import { mixedRecordBackup } from '@/test/utils/backup-mocks';
+import { getGistSyncConfig, setGistSyncConfig } from '../gist-setup';
 import { getGistSyncStatus, triggerGistSync } from '../github-sync';
 
 // Mock Octokit
@@ -66,7 +67,7 @@ describe('github-sync', () => {
         const { payload, accepted } = mixedRecordBackup();
         const actual = await vi.importActual<typeof import('../import-export')>('../import-export');
         await actual.importData(JSON.stringify({ ...payload, data: accepted }));
-        await storage.setItem(STORAGE_KEYS.gistId, 'gist123');
+        await setGistSyncConfig({ gistId: 'gist123' });
         await storage.setItem(STORAGE_KEYS.dataUpdatedAt, '2023-01-01T00:00:00.000Z');
         const before = await fakeBrowser.storage.local.get(null);
         const syncBefore = await fakeBrowser.storage.sync.get(null);
@@ -108,19 +109,18 @@ describe('github-sync', () => {
       expect(await triggerGistSync()).toMatchObject({ success: true, action: 'pulled' });
       const { dataUpdatedAt, ...data } = prepared;
       expect(JSON.parse(await actual.exportData())).toMatchObject({ data, dataUpdatedAt });
-      expect(await storage.getItem(STORAGE_KEYS.githubPat)).toBe('ghp_test');
+      expect((await getGistSyncConfig()).pat).toBe('ghp_test');
     });
 
     beforeEach(async () => {
-      await storage.setItem(STORAGE_KEYS.githubPat, 'ghp_test');
-      await storage.setItem(STORAGE_KEYS.gistId, 'gist123');
+      await setGistSyncConfig({ pat: 'ghp_test', gistId: 'gist123' });
     });
 
     it.each([
-      [STORAGE_KEYS.githubPat, 'PAT is not configured'],
-      [STORAGE_KEYS.gistId, 'Gist ID is not configured'],
-    ])('rejects missing configuration at %s', async (key, error) => {
-      await storage.removeItem(key);
+      [{ pat: '' }, 'PAT is not configured'],
+      [{ gistId: null }, 'Gist ID is not configured'],
+    ] as const)('rejects missing configuration %j', async (config, error) => {
+      await setGistSyncConfig(config);
       expect(await triggerGistSync()).toEqual({ success: false, error });
       expect(Octokit).not.toHaveBeenCalled();
     });
@@ -164,8 +164,7 @@ describe('github-sync', () => {
     beforeEach(async () => {
       vi.useFakeTimers();
       vi.setSystemTime(new Date(now));
-      await storage.setItem(STORAGE_KEYS.githubPat, 'ghp_test');
-      await storage.setItem(STORAGE_KEYS.gistId, 'gist123');
+      await setGistSyncConfig({ pat: 'ghp_test', gistId: 'gist123' });
     });
 
     it('retains one client and destination when credentials change during the remote read', async () => {
@@ -180,8 +179,7 @@ describe('github-sync', () => {
 
       const syncing = triggerGistSync();
       await started.promise;
-      await storage.setItem(STORAGE_KEYS.githubPat, 'replacement');
-      await storage.setItem(STORAGE_KEYS.gistId, 'replacement-gist');
+      await setGistSyncConfig({ pat: 'replacement', gistId: 'replacement-gist' });
       request.resolve({ data: { files: {} } });
       expect(await syncing).toMatchObject({ success: true, action: 'pushed' });
 

--- a/services/__tests__/import-export.test.ts
+++ b/services/__tests__/import-export.test.ts
@@ -11,6 +11,7 @@ import { STORAGE_KEYS } from '@/infrastructure/storage/storage-keys';
 import { malformedBackupCases, mixedRecordBackup } from '@/test/utils/backup-mocks';
 import { createMockCard } from '@/test/utils/card-mocks';
 import { buildSettings } from '@/test/utils/settings-mocks';
+import { getGistSyncConfig, setGistSyncConfig } from '../gist-setup';
 import { exportData, importData, resetAllData } from '../import-export';
 
 describe('import-export', () => {
@@ -84,16 +85,14 @@ describe('import-export', () => {
       await storage.setItem(STORAGE_KEYS.badgeEnabled, mockSettings.badgeEnabled);
       await storage.setItem(STORAGE_KEYS.language, mockSettings.language);
 
-      await storage.setItem(STORAGE_KEYS.githubPat, 'private-pat');
-      await storage.setItem(STORAGE_KEYS.gistId, 'exported-gist');
-      await storage.setItem(STORAGE_KEYS.gistSyncEnabled, false);
+      await setGistSyncConfig({ pat: 'private-pat', gistId: 'exported-gist', enabled: false });
       await storage.setItem(STORAGE_KEYS.lastSyncTime, 'private-sync-time');
       await storage.setItem(STORAGE_KEYS.dataUpdatedAt, '2024-01-01T00:00:00.000Z');
 
       const result = await exportData();
       const parsed = JSON.parse(result);
 
-      expect(parsed.schemaVersion).toBe(4);
+      expect(parsed.schemaVersion).toBe(5);
       expect(parsed.exportDate).toMatch(/^\d{4}-\d{2}-\d{2}T/);
       expect(parsed.data.stats).toEqual(mockStats);
       expect(parsed.data).not.toHaveProperty('notes');
@@ -112,7 +111,7 @@ describe('import-export', () => {
       const parsed = JSON.parse(result);
 
       expect(parsed).toMatchObject({
-        schemaVersion: 4,
+        schemaVersion: 5,
         exportDate: expect.any(String),
         data: {
           cards: {},
@@ -134,7 +133,7 @@ describe('import-export', () => {
           }
           return read(key, options);
         });
-        expect(JSON.parse(await exportData()).schemaVersion).toBe(4);
+        expect(JSON.parse(await exportData()).schemaVersion).toBe(5);
       }
     );
 
@@ -154,8 +153,7 @@ describe('import-export', () => {
         await setSchemaVersion(2);
         const { payload, accepted } = mixedRecordBackup();
         await importData(JSON.stringify({ ...payload, data: accepted }));
-        await storage.setItem(STORAGE_KEYS.githubPat, 'existing-pat');
-        await storage.setItem(STORAGE_KEYS.gistId, 'existing-gist');
+        await setGistSyncConfig({ pat: 'existing-pat', gistId: 'existing-gist' });
         await storage.setItem(STORAGE_KEYS.lastSyncTime, payload.dataUpdatedAt);
         const before = await fakeBrowser.storage.local.get(null);
         const json = JSON.stringify({ ...payload, data: { ...accepted, [collection]: payload.data[collection] } });
@@ -227,7 +225,7 @@ describe('import-export', () => {
           )
         );
         expect(restored.dataUpdatedAt).toBe(payload.dataUpdatedAt);
-        expect(restored.schemaVersion).toBe(4);
+        expect(restored.schemaVersion).toBe(5);
       }
     );
 
@@ -292,8 +290,7 @@ describe('import-export', () => {
         old: createMockCard(State.New, { id: 'old', slug: 'old', note: 'old note' }),
       });
       await storage.setItem(STORAGE_KEYS.stats, { '2023-12-31': { totalReviews: 7 } });
-      await storage.setItem(STORAGE_KEYS.githubPat, 'existing-pat');
-      await storage.setItem(STORAGE_KEYS.gistId, 'old-gist');
+      await setGistSyncConfig({ pat: 'existing-pat', gistId: 'old-gist' });
       await storage.setItem(STORAGE_KEYS.dataUpdatedAt, '2023-12-31T00:00:00.000Z');
       await setSchemaVersion(2);
     }
@@ -339,15 +336,15 @@ describe('import-export', () => {
         await seedExistingData();
         await storage.setItem(STORAGE_KEYS.theme, 'light');
         await storage.setItem(STORAGE_KEYS.maxNewCardsPerDay, 12);
-        await storage.setItem(STORAGE_KEYS.gistSyncEnabled, true);
+        await setGistSyncConfig({ enabled: true });
         await importData(
           JSON.stringify({ ...validExportData, data: { ...validExportData.data, settings: undefined, gistSync } })
         );
         expect(await storage.getItem(STORAGE_KEYS.theme)).toBeNull();
         expect(await storage.getItem(STORAGE_KEYS.maxNewCardsPerDay)).toBeNull();
-        expect(await storage.getItem(STORAGE_KEYS.gistId)).toBe(gistSync?.gistId ?? null);
-        expect(await storage.getItem(STORAGE_KEYS.gistSyncEnabled)).toBe(gistSync?.enabled ?? null);
-        expect(await storage.getItem(STORAGE_KEYS.githubPat)).toBe('existing-pat');
+        expect((await getGistSyncConfig()).gistId).toBe(gistSync?.gistId ?? null);
+        expect((await getGistSyncConfig()).enabled).toBe(gistSync?.enabled ?? false);
+        expect((await getGistSyncConfig()).pat).toBe('existing-pat');
         expect(await storage.getItem(STORAGE_KEYS.cards)).toEqual(embeddedData.cards);
       }
     );
@@ -387,7 +384,7 @@ describe('import-export', () => {
         validExportData.data.settings.maxNewCardsPerDay
       );
       expect(await storage.getItem(STORAGE_KEYS.dataUpdatedAt)).toBe('2024-01-01T00:00:00.000Z');
-      expect(await storage.getItem(STORAGE_KEYS.githubPat)).toBe('existing-pat');
+      expect((await getGistSyncConfig()).pat).toBe('existing-pat');
       expect(await storage.getItem(STORAGE_KEYS.schemaVersion)).toBe(2);
       expect(JSON.parse(await exportData()).data).toEqual({
         ...embeddedData,
@@ -421,14 +418,14 @@ describe('import-export', () => {
     );
 
     it.each([null, 'existing-pat'])('ignores imported credentials when the local PAT is %s', async (pat) => {
-      if (pat !== null) await storage.setItem(STORAGE_KEYS.githubPat, pat);
+      if (pat !== null) await setGistSyncConfig({ pat: pat });
       await importData(
         JSON.stringify({
           ...validExportData,
           data: { ...validExportData.data, gistSync: { pat: 'untrusted-pat', githubPat: 'untrusted-legacy-pat' } },
         })
       );
-      expect(await storage.getItem(STORAGE_KEYS.githubPat)).toBe(pat || null);
+      expect((await getGistSyncConfig()).pat).toBe(pat || '');
     });
 
     describe('schema migrations', () => {
@@ -472,7 +469,7 @@ describe('import-export', () => {
             await storage.setItem(STORAGE_KEYS[key as keyof typeof validExportData.data.settings], value);
           }
           if (schemaVersion !== 3) await storage.setItem('sync:leetsrs:dayStartHour', 4);
-          await storage.setItem(STORAGE_KEYS.githubPat, 'existing-pat');
+          await setGistSyncConfig({ pat: 'existing-pat' });
           await runStartupMigrations();
           const startupCards = await storage.getItem(STORAGE_KEYS.cards);
           expect(startupCards).toEqual(embeddedCards);
@@ -511,7 +508,7 @@ describe('import-export', () => {
             expect(await storage.getItem(`local:leetsrs:notes:${id}`)).toBeNull();
           }
           expect(await storage.getItem(STORAGE_KEYS.theme)).toBe('light');
-          expect(await storage.getItem(STORAGE_KEYS.githubPat)).toBe('existing-pat');
+          expect((await getGistSyncConfig()).pat).toBe('existing-pat');
           expect(await storage.getItem(STORAGE_KEYS.dataUpdatedAt)).toBe(dataUpdatedAt);
           expect(await storage.getItem(STORAGE_KEYS.schemaVersion)).toBe(0);
           expect(await storage.getItem('sync:leetsrs:dayStartHour')).toBe(9);
@@ -587,9 +584,7 @@ describe('import-export', () => {
           await storage.setItem(`local:leetsrs:notes:${id}`, note);
         }
         await storage.setItem(STORAGE_KEYS.theme, 'dark');
-        await storage.setItem(STORAGE_KEYS.githubPat, 'existing-pat');
-        await storage.setItem(STORAGE_KEYS.gistId, 'existing-gist');
-        await storage.setItem(STORAGE_KEYS.gistSyncEnabled, true);
+        await setGistSyncConfig({ pat: 'existing-pat', gistId: 'existing-gist', enabled: true });
         await storage.setItem(STORAGE_KEYS.lastSyncTime, dataUpdatedAt);
         await storage.setItem(STORAGE_KEYS.lastSyncDirection, 'push');
         await storage.setItem(STORAGE_KEYS.dataUpdatedAt, dataUpdatedAt);
@@ -629,7 +624,7 @@ describe('import-export', () => {
           data: { ...validExportData.data, settings: { resetEditorOnEveryProblem: false, [key]: true } },
         }),
       ]),
-      ['future schema version', JSON.stringify({ ...validExportData, schemaVersion: 5 })],
+      ['future schema version', JSON.stringify({ ...validExportData, schemaVersion: 6 })],
       ['null root', 'null'],
       ['missing export date', JSON.stringify({ data: {} })],
       ...['cards', 'stats', 'notes'].map((key) => [
@@ -644,9 +639,7 @@ describe('import-export', () => {
       for (const [key, value] of Object.entries(validExportData.data.settings)) {
         await storage.setItem(STORAGE_KEYS[key as keyof typeof validExportData.data.settings], value);
       }
-      await storage.setItem(STORAGE_KEYS.githubPat, 'existing-pat');
-      await storage.setItem(STORAGE_KEYS.gistId, 'existing-gist');
-      await storage.setItem(STORAGE_KEYS.gistSyncEnabled, true);
+      await setGistSyncConfig({ pat: 'existing-pat', gistId: 'existing-gist', enabled: true });
       await storage.setItem(STORAGE_KEYS.lastSyncTime, '2024-02-01T00:00:00.000Z');
       await storage.setItem(STORAGE_KEYS.lastSyncDirection, 'push');
       await storage.setItem(STORAGE_KEYS.dataUpdatedAt, '2024-02-02T00:00:00.000Z');
@@ -784,13 +777,13 @@ describe('import-export', () => {
       await storage.setItem(STORAGE_KEYS.badgeEnabled, true);
       await storage.setItem(STORAGE_KEYS.language, 'en');
 
-      await storage.setItem(STORAGE_KEYS.githubPat, 'existing-pat');
+      await setGistSyncConfig({ pat: 'existing-pat' });
       await storage.setItem(STORAGE_KEYS.dataUpdatedAt, '2024-01-01T00:00:00.000Z');
       await setSchemaVersion(2);
 
       await resetAllData();
 
-      expect(await storage.getItem(STORAGE_KEYS.githubPat)).toBeNull();
+      expect(await storage.getItem(STORAGE_KEYS.gistConnection)).toBeNull();
       expect(await storage.getItem(STORAGE_KEYS.dataUpdatedAt)).toBeNull();
       expect(await storage.getItem(STORAGE_KEYS.schemaVersion)).toBe(2);
 

--- a/services/__tests__/import-export.test.ts
+++ b/services/__tests__/import-export.test.ts
@@ -356,6 +356,7 @@ describe('import-export', () => {
 
       const card = validExportData.data.cards['two-sum'];
       const stats = validExportData.data.stats['2024-01-01'];
+      const writes = vi.spyOn(fakeBrowser.storage.local, 'set');
       await importData(
         JSON.stringify({
           ...validExportData,
@@ -385,6 +386,9 @@ describe('import-export', () => {
       );
       expect(await storage.getItem(STORAGE_KEYS.dataUpdatedAt)).toBe('2024-01-01T00:00:00.000Z');
       expect((await getGistSyncConfig()).pat).toBe('existing-pat');
+      expect(writes.mock.calls.filter(([items]) => Object.hasOwn(items, 'leetsrs:gistConnection'))).toEqual([
+        [{ 'leetsrs:gistConnection': { pat: 'existing-pat', gistId: 'incoming-gist', enabled: false } }],
+      ]);
       expect(await storage.getItem(STORAGE_KEYS.schemaVersion)).toBe(2);
       expect(JSON.parse(await exportData()).data).toEqual({
         ...embeddedData,

--- a/services/gist-setup.ts
+++ b/services/gist-setup.ts
@@ -5,40 +5,20 @@ import {
   gistSyncConfigUpdateSchema,
 } from '@/domain/gist-sync';
 import { GIST_FILENAME, type GitHubClient } from '@/infrastructure/github/client';
-import { readSyncMetadata, removeSyncMetadata, writeSyncMetadata } from '@/infrastructure/storage/sync-metadata';
+import { readSyncMetadata, writeSyncMetadata } from '@/infrastructure/storage/sync-metadata';
 import { getStoredTranslations } from '@/infrastructure/storage/translations';
-import { getAuthenticatedGitHubClient, getGitHubPat, setGitHubPat } from './github-auth';
+import { getAuthenticatedGitHubClient } from './github-auth';
 import { exportData } from './import-export';
 
 export async function getGistSyncConfig(): Promise<GistSyncConfig> {
-  const [pat, destination] = await Promise.all([getGitHubPat(), getGistDestinationConfig()]);
-  return { pat: pat ?? '', ...destination };
+  return (await readSyncMetadata('gistConnection')) ?? { pat: '', gistId: null, enabled: false };
 }
 
 export async function setGistSyncConfig(config: GistSyncConfigUpdate): Promise<void> {
   const parsed = gistSyncConfigUpdateSchema.parse(config);
-  if (parsed.pat !== undefined) {
-    await setGitHubPat(parsed.pat);
-  }
-  await setGistDestinationConfig(parsed);
-}
-
-export async function getGistDestinationConfig(): Promise<Omit<GistSyncConfig, 'pat'>> {
-  const [gistId, enabled] = await Promise.all([readSyncMetadata('gistId'), readSyncMetadata('gistSyncEnabled')]);
-  return { gistId: gistId ?? null, enabled: enabled ?? false };
-}
-
-export async function setGistDestinationConfig(config: Partial<Omit<GistSyncConfig, 'pat'>>): Promise<void> {
-  if (config.gistId !== undefined) {
-    if (config.gistId === null) {
-      await removeSyncMetadata('gistId');
-    } else {
-      await writeSyncMetadata('gistId', config.gistId);
-    }
-  }
-  if (config.enabled !== undefined) {
-    await writeSyncMetadata('gistSyncEnabled', config.enabled);
-  }
+  const changes = Object.fromEntries(Object.entries(parsed).filter(([, value]) => value !== undefined));
+  if (Object.keys(changes).length === 0) return;
+  await writeSyncMetadata('gistConnection', { ...(await getGistSyncConfig()), ...changes });
 }
 
 export async function validateGistId(gistId: string, pat: string): Promise<GistValidationResult> {
@@ -100,7 +80,7 @@ export async function createGist(github: GitHubClient): Promise<{ gistId: string
 
   const gistId = data.id;
 
-  await setGistDestinationConfig({ gistId });
+  await setGistSyncConfig({ gistId });
 
   const now = new Date().toISOString();
   await writeSyncMetadata('lastSyncTime', now);

--- a/services/github-auth.ts
+++ b/services/github-auth.ts
@@ -1,22 +1,14 @@
 import type { PatValidationResult } from '@/domain/gist-sync';
 import { createGitHubClient, type GitHubClient } from '@/infrastructure/github/client';
-import { readSyncMetadata, removeSyncMetadata, writeSyncMetadata } from '@/infrastructure/storage/sync-metadata';
+import { readSyncMetadata, writeSyncMetadata } from '@/infrastructure/storage/sync-metadata';
 
-export function getGitHubPat(): Promise<string | null> {
-  return readSyncMetadata('githubPat');
+export async function getGitHubPat(): Promise<string | null> {
+  return (await readSyncMetadata('gistConnection'))?.pat ?? null;
 }
 
-export function setGitHubPat(pat: string): Promise<void> {
-  return writeSyncMetadata('githubPat', pat);
-}
-
-export function removeGitHubPat(): Promise<void> {
-  return removeSyncMetadata('githubPat');
-}
-
-// Readiness matches the existing truthy-credential gate without making a request.
-export async function hasGitHubCredentials(): Promise<boolean> {
-  return Boolean(await getGitHubPat());
+export async function setGitHubPat(pat: string): Promise<void> {
+  const connection = (await readSyncMetadata('gistConnection')) ?? { pat: '', gistId: null, enabled: false };
+  await writeSyncMetadata('gistConnection', { ...connection, pat });
 }
 
 export function getAuthenticatedGitHubClient(pat: string): Promise<GitHubClient>;

--- a/services/github-auth.ts
+++ b/services/github-auth.ts
@@ -1,14 +1,9 @@
 import type { PatValidationResult } from '@/domain/gist-sync';
 import { createGitHubClient, type GitHubClient } from '@/infrastructure/github/client';
-import { readSyncMetadata, writeSyncMetadata } from '@/infrastructure/storage/sync-metadata';
+import { readSyncMetadata } from '@/infrastructure/storage/sync-metadata';
 
 export async function getGitHubPat(): Promise<string | null> {
   return (await readSyncMetadata('gistConnection'))?.pat ?? null;
-}
-
-export async function setGitHubPat(pat: string): Promise<void> {
-  const connection = (await readSyncMetadata('gistConnection')) ?? { pat: '', gistId: null, enabled: false };
-  await writeSyncMetadata('gistConnection', { ...connection, pat });
 }
 
 export function getAuthenticatedGitHubClient(pat: string): Promise<GitHubClient>;

--- a/services/github-sync.ts
+++ b/services/github-sync.ts
@@ -2,8 +2,8 @@ import { decideGistSync, type GistSyncDecision, type GistSyncStatus, type SyncRe
 import { GIST_FILENAME } from '@/infrastructure/github/client';
 import type { ExportData } from '@/infrastructure/storage/backup';
 import { readSyncMetadata, writeSyncMetadata } from '@/infrastructure/storage/sync-metadata';
-import { getGistDestinationConfig } from './gist-setup';
-import { getAuthenticatedGitHubClient, getGitHubPat } from './github-auth';
+import { getGistSyncConfig } from './gist-setup';
+import { getAuthenticatedGitHubClient } from './github-auth';
 import { exportData, importData } from './import-export';
 
 // In-memory state for sync status (not persisted)
@@ -26,9 +26,9 @@ export async function triggerGistSync(): Promise<SyncResult> {
   lastError = null;
 
   try {
-    const [pat, config] = await Promise.all([getGitHubPat(), getGistDestinationConfig()]);
+    const config = await getGistSyncConfig();
 
-    if (!pat) {
+    if (!config.pat) {
       return { success: false, error: 'PAT is not configured' };
     }
 
@@ -36,7 +36,7 @@ export async function triggerGistSync(): Promise<SyncResult> {
       return { success: false, error: 'Gist ID is not configured' };
     }
 
-    const github = await getAuthenticatedGitHubClient(pat);
+    const github = await getAuthenticatedGitHubClient(config.pat);
 
     let remoteGist: Awaited<ReturnType<typeof github.getGist>>['data'];
     try {

--- a/services/import-export.ts
+++ b/services/import-export.ts
@@ -4,16 +4,15 @@ import { getAllCards, removeCards, saveCards } from '@/infrastructure/storage/ca
 import { LATEST_SCHEMA_VERSION } from '@/infrastructure/storage/migrations/runner';
 import { getStats, removeStats, saveStats } from '@/infrastructure/storage/stats';
 import { readSyncMetadata, removeSyncMetadata, writeSyncMetadata } from '@/infrastructure/storage/sync-metadata';
-import { getGitHubPat, removeGitHubPat, setGitHubPat } from './github-auth';
+import { getGitHubPat, setGitHubPat } from './github-auth';
 import { exportSettings, resetSettings, updateSettings } from './settings';
 
 export async function exportData(): Promise<string> {
-  const [cards, stats, settings, gistId, gistSyncEnabled, dataUpdatedAt] = await Promise.all([
+  const [cards, stats, settings, connection, dataUpdatedAt] = await Promise.all([
     getAllCards(),
     getStats(),
     exportSettings(),
-    readSyncMetadata('gistId'),
-    readSyncMetadata('gistSyncEnabled'),
+    readSyncMetadata('gistConnection'),
     readSyncMetadata('dataUpdatedAt'),
   ]);
 
@@ -26,8 +25,8 @@ export async function exportData(): Promise<string> {
       stats,
       settings,
       gistSync: {
-        ...(gistId != null && { gistId }),
-        ...(gistSyncEnabled != null && { enabled: gistSyncEnabled }),
+        ...(connection?.gistId != null && { gistId: connection.gistId }),
+        ...(connection != null && { enabled: connection.enabled }),
       },
     },
   };
@@ -49,12 +48,11 @@ export async function applyImportData(preparedData: PreparedImportData): Promise
   await updateSettings(preparedData.settings);
 
   if (preparedData.gistSync) {
-    if (preparedData.gistSync.gistId != null) {
-      await writeSyncMetadata('gistId', preparedData.gistSync.gistId);
-    }
-    if (preparedData.gistSync.enabled != null) {
-      await writeSyncMetadata('gistSyncEnabled', preparedData.gistSync.enabled);
-    }
+    await writeSyncMetadata('gistConnection', {
+      pat: existingPat || '',
+      gistId: preparedData.gistSync.gistId ?? null,
+      enabled: preparedData.gistSync.enabled ?? false,
+    });
   }
 
   await writeSyncMetadata('dataUpdatedAt', preparedData.dataUpdatedAt);
@@ -69,9 +67,7 @@ export async function resetAllData(): Promise<void> {
   await removeCards();
   await removeStats();
   await resetSettings();
-  await removeGitHubPat();
-  await removeSyncMetadata('gistId');
-  await removeSyncMetadata('gistSyncEnabled');
+  await removeSyncMetadata('gistConnection');
   await removeSyncMetadata('lastSyncTime');
   await removeSyncMetadata('lastSyncDirection');
   await removeSyncMetadata('dataUpdatedAt');

--- a/services/import-export.ts
+++ b/services/import-export.ts
@@ -4,7 +4,7 @@ import { getAllCards, removeCards, saveCards } from '@/infrastructure/storage/ca
 import { LATEST_SCHEMA_VERSION } from '@/infrastructure/storage/migrations/runner';
 import { getStats, removeStats, saveStats } from '@/infrastructure/storage/stats';
 import { readSyncMetadata, removeSyncMetadata, writeSyncMetadata } from '@/infrastructure/storage/sync-metadata';
-import { getGitHubPat, setGitHubPat } from './github-auth';
+import { getGitHubPat } from './github-auth';
 import { exportSettings, resetSettings, updateSettings } from './settings';
 
 export async function exportData(): Promise<string> {
@@ -37,23 +37,23 @@ export async function exportData(): Promise<string> {
 export async function applyImportData(preparedData: PreparedImportData): Promise<void> {
   // Preserve PAT before reset (it's not in export for security)
   const existingPat = await getGitHubPat();
+  const connection =
+    existingPat || preparedData.gistSync
+      ? gistSyncConfigSchema.parse({
+          pat: existingPat || '',
+          gistId: preparedData.gistSync?.gistId ?? null,
+          enabled: preparedData.gistSync?.enabled ?? false,
+        })
+      : null;
   await resetAllData();
 
-  if (existingPat) {
-    await setGitHubPat(existingPat);
+  if (connection) {
+    await writeSyncMetadata('gistConnection', connection);
   }
 
   await saveCards(Object.values(preparedData.cards));
   await saveStats(preparedData.stats);
   await updateSettings(preparedData.settings);
-
-  if (preparedData.gistSync) {
-    await writeSyncMetadata('gistConnection', {
-      pat: existingPat || '',
-      gistId: preparedData.gistSync.gistId ?? null,
-      enabled: preparedData.gistSync.enabled ?? false,
-    });
-  }
 
   await writeSyncMetadata('dataUpdatedAt', preparedData.dataUpdatedAt);
 }
@@ -72,3 +72,5 @@ export async function resetAllData(): Promise<void> {
   await removeSyncMetadata('lastSyncDirection');
   await removeSyncMetadata('dataUpdatedAt');
 }
+
+import { gistSyncConfigSchema } from '@/domain/gist-sync';


### PR DESCRIPTION
- Migrate Gist connections into one device-local record, preserving legacy sync keys and retrying interrupted upgrades safely.
- Adapt runtime callers to whole-record writes, preserve current import/reset behavior, and explain per-device setup in all five locales.
- `npm run check` passes (1,022 tests); production build passes. Standards and spec code-review findings are resolved.
- Manually exercised the production popup in an isolated preview: configured/fresh upgrades, reload, failed-migration restart, separate device records, validate/create/toggle/manual-sync, and light/dark layouts. Browser APIs and GitHub responses were mocked; native Chrome upgrade/restart remains unverified because browser access was unavailable.
- Line deltas: production +133/−96 (net +37); tests +274/−118 (net +156).

Closes #306
