### PR TITLE
refactor: prepare document-backed settings

### DIFF
--- a/domain/settings.ts
+++ b/domain/settings.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { languageSchema } from './language';
+import { type Language, languageSchema } from './language';
 
 export const SETTINGS_CONSTRAINTS = {
   maxNewCardsPerDay: { min: 0, max: 100 },
@@ -36,6 +36,14 @@ export const DEFAULT_SETTINGS = {
 } satisfies Omit<Settings, 'language'>;
 
 export const SETTING_KEYS = settingsSchema.keyof().options;
+
+export function resolveSettings(overrides: Partial<Settings>, fallbackLanguage: Language): Settings {
+  const entries = SETTING_KEYS.map((key) => [
+    key,
+    overrides[key] ?? (key === 'language' ? fallbackLanguage : DEFAULT_SETTINGS[key]),
+  ]);
+  return settingsSchema.parse(Object.fromEntries(entries));
+}
 
 // Updates use only own settings; undefined means no change.
 export const settingsUpdateSchema = z.preprocess((changes) => {

--- a/entrypoints/background/__tests__/document-settings.test.ts
+++ b/entrypoints/background/__tests__/document-settings.test.ts
@@ -1,0 +1,173 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { fakeBrowser } from 'wxt/testing/fake-browser';
+import { storage } from 'wxt/utils/storage';
+import { type MessageData, type MessageName, onMessage } from '@/infrastructure/browser/messages';
+import { readLearningDocument, replaceLearningDocument } from '@/infrastructure/storage/learning-document';
+import { STORAGE_KEYS } from '@/infrastructure/storage/storage-keys';
+import { mixedRecordBackup } from '@/test/utils/backup-mocks';
+import { buildSettings } from '@/test/utils/settings-mocks';
+import background from '../index';
+
+vi.mock('@/infrastructure/browser/messages', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/infrastructure/browser/messages')>()),
+  onMessage: vi.fn(),
+}));
+
+// Test-only activation of the prepared paths; production switches together in #378.
+vi.mock('@/services/settings', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/services/settings')>()),
+  ...(await import('@/services/document-settings')),
+}));
+vi.mock('@/infrastructure/storage/migrations/runner', async () => ({
+  runStartupMigrations: (await import('@/infrastructure/storage/learning-document-startup')).initializeLearningDocument,
+}));
+
+function dispatch(name: MessageName, data?: unknown) {
+  const listener = vi.mocked(onMessage).mock.calls.find(([registered]) => registered === name)?.[1];
+  if (!listener) throw new Error(`Missing listener for ${name}`);
+  return listener({ id: 1, type: name, data: data as MessageData<MessageName>, timestamp: 0, sender: {} });
+}
+
+describe('document settings through background commands', () => {
+  beforeEach(() => {
+    fakeBrowser.reset();
+    fakeBrowser.runtime.id = 'test';
+    vi.mocked(onMessage).mockClear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('resolves defaults and browser language without storing them or reading stale settings', async () => {
+    vi.stubGlobal('navigator', { languages: ['pl'] });
+    await replaceLearningDocument({ schemaVersion: 6, cards: {}, stats: {}, settings: { theme: 'dark' } });
+    await storage.setItem(STORAGE_KEYS.theme, 'light');
+    await storage.setItem(STORAGE_KEYS.language, 'de');
+    background.main();
+
+    expect(await dispatch('getSettings')).toEqual(buildSettings({ theme: 'dark', language: 'pl' }));
+    vi.stubGlobal('navigator', { languages: ['de'] });
+    expect(await dispatch('getSettings')).toEqual(buildSettings({ theme: 'dark', language: 'de' }));
+    expect(await readLearningDocument()).toEqual({
+      schemaVersion: 6,
+      cards: {},
+      stats: {},
+      settings: { theme: 'dark' },
+    });
+  });
+
+  it('saves explicit overrides and their timestamp together while preserving learning data and connection state', async () => {
+    const { embedded, payload } = mixedRecordBackup();
+    const document = { ...embedded, schemaVersion: 6 as const, settings: {}, dataUpdatedAt: payload.dataUpdatedAt };
+    await replaceLearningDocument(document);
+    await storage.setItem(STORAGE_KEYS.gistConnection, { pat: 'secret', gistId: 'gist', enabled: true });
+    await storage.setItem(STORAGE_KEYS.lastSyncTime, payload.dataUpdatedAt);
+    background.main();
+    await dispatch('getSettings');
+    const sync = await fakeBrowser.storage.sync.get();
+    const writes = vi.spyOn(fakeBrowser.storage.local, 'set');
+    const now = new Date('2026-09-12T12:00:00.000Z');
+    vi.useFakeTimers({ toFake: ['Date'] });
+    vi.setSystemTime(now);
+
+    const changes = {
+      maxNewCardsPerDay: 0,
+      theme: 'system',
+      language: 'en',
+      badgeEnabled: false,
+      resetEditorOnEveryProblem: false,
+      resetEditorOnDueReview: true,
+    } as const;
+    await dispatch('updateSettings', { changes });
+
+    expect(await dispatch('getSettings')).toEqual(changes);
+    expect(await readLearningDocument()).toEqual({ ...document, settings: changes, dataUpdatedAt: now.toISOString() });
+    expect(writes).toHaveBeenCalledOnce();
+    expect(await fakeBrowser.storage.sync.get()).toEqual(sync);
+    expect(await storage.getItem(STORAGE_KEYS.lastSyncTime)).toBe(payload.dataUpdatedAt);
+    expect(await storage.getItem(STORAGE_KEYS.dataUpdatedAt)).toBeNull();
+  });
+
+  it.each(['validation', 'clock', 'write'] as const)(
+    'preserves the document after a %s failure and accepts the next edit',
+    async (failure) => {
+      const { embedded, payload } = mixedRecordBackup();
+      const document = {
+        ...embedded,
+        schemaVersion: 6 as const,
+        dataUpdatedAt: payload.dataUpdatedAt,
+        settings: { language: 'de' as const, theme: 'dark' as const },
+      };
+      await replaceLearningDocument(document);
+      background.main();
+      const before = await dispatch('getSettings');
+      const writes = vi.spyOn(fakeBrowser.storage.local, 'set');
+      if (failure === 'write') {
+        writes.mockRejectedValueOnce(new Error('Write failed'));
+      }
+      if (failure === 'clock') {
+        vi.useFakeTimers({ toFake: ['Date'] });
+        vi.setSystemTime(Number.NaN);
+      }
+
+      await expect(
+        dispatch('updateSettings', {
+          changes: { theme: 'light', maxNewCardsPerDay: failure === 'validation' ? -1 : 8 },
+        })
+      ).rejects.toThrow();
+      vi.useRealTimers();
+      expect(await dispatch('getSettings')).toEqual(before);
+      expect(await readLearningDocument()).toEqual(document);
+      expect(writes).toHaveBeenCalledTimes(failure === 'write' ? 1 : 0);
+
+      await dispatch('updateSettings', { changes: { theme: 'light' } });
+      expect(await dispatch('getSettings')).toEqual(buildSettings({ theme: 'light', language: 'de' }));
+      expect((await readLearningDocument())?.settings).toEqual({ theme: 'light', language: 'de' });
+    }
+  );
+
+  it('ignores empty, undefined, unknown, and inherited updates without materializing defaults', async () => {
+    background.main();
+    await dispatch('getSettings');
+    const writes = vi.spyOn(fakeBrowser.storage.local, 'set');
+    const changes = Object.assign(Object.create({ badgeEnabled: false }), { theme: undefined, unknown: 1 });
+
+    await dispatch('updateSettings', { changes: {} });
+    await dispatch('updateSettings', { changes });
+
+    expect(writes).not.toHaveBeenCalled();
+    expect(await readLearningDocument()).toEqual({ schemaVersion: 6, cards: {}, stats: {}, settings: {} });
+    await dispatch('updateSettings', { changes: { theme: undefined, maxNewCardsPerDay: 5 } });
+    expect((await readLearningDocument())?.settings).toEqual({ maxNewCardsPerDay: 5 });
+  });
+
+  it('resolves each read from its captured document and follows replacement without retained overrides', async () => {
+    vi.stubGlobal('navigator', { languages: ['pl'] });
+    const document = {
+      schemaVersion: 6 as const,
+      cards: {},
+      stats: {},
+      settings: { language: 'de' as const, theme: 'dark' as const },
+    };
+    await replaceLearningDocument(document);
+    background.main();
+    await dispatch('getSettings');
+    const initial = Promise.withResolvers<typeof document>();
+    const started = Promise.withResolvers<void>();
+    const reads = vi.spyOn(storage, 'getItem').mockImplementationOnce(() => {
+      started.resolve();
+      return initial.promise;
+    });
+
+    const pending = dispatch('getSettings');
+    await started.promise;
+    await replaceLearningDocument({ schemaVersion: 6, cards: {}, stats: {}, settings: {} });
+    initial.resolve(document);
+    expect(await pending).toEqual(buildSettings({ language: 'de', theme: 'dark' }));
+    expect(reads).toHaveBeenCalledExactlyOnceWith(STORAGE_KEYS.learningDocument);
+    expect(await dispatch('getSettings')).toEqual(buildSettings({ language: 'pl' }));
+  });
+});

--- a/entrypoints/popup/queries/__tests__/settings.test.tsx
+++ b/entrypoints/popup/queries/__tests__/settings.test.tsx
@@ -2,11 +2,16 @@
  * @vitest-environment happy-dom
  */
 
-import { act, renderHook } from '@testing-library/react';
-import { expect, it, vi } from 'vitest';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { fakeBrowser } from 'wxt/testing/fake-browser';
+import { sendMessage } from '@/infrastructure/browser/messages';
+import { readLearningDocument, replaceLearningDocument } from '@/infrastructure/storage/learning-document';
+import { getSettings, updateSettings } from '@/services/document-settings';
+import { createMessageMock } from '@/test/utils/message-mocks';
 import { createTestWrapper } from '@/test/utils/test-wrapper';
 import { cardQueryKeys } from '../cards';
-import { settingsQueryKeys, useUpdateSettingsMutation } from '../settings';
+import { settingsQueryKeys, useSettingsQuery, useUpdateSettingsMutation } from '../settings';
 
 vi.mock('@/infrastructure/browser/messages', () => ({
   sendMessage: vi.fn(() => Promise.resolve(undefined)),
@@ -25,4 +30,57 @@ it('invalidates only the queries affected by each settings change', async () => 
 
   await expectInvalidations({ theme: 'dark' }, [settingsQueryKeys.all]);
   await expectInvalidations({ maxNewCardsPerDay: 10 }, [settingsQueryKeys.all, cardQueryKeys.all]);
+});
+
+describe('popup settings with the prepared document workflows', () => {
+  beforeEach(async () => {
+    fakeBrowser.reset();
+    const messages = createMessageMock(vi.mocked(sendMessage));
+    messages
+      .reset()
+      .handle('getSettings', getSettings)
+      .handle('updateSettings', ({ changes }) => updateSettings(changes));
+    await replaceLearningDocument({ schemaVersion: 6, cards: {}, stats: {}, settings: {} });
+  });
+
+  afterEach(() => vi.restoreAllMocks());
+
+  it('loads defaults, displays saved edits, and reloads replaced overrides through the existing commands', async () => {
+    const { wrapper, queryClient } = createTestWrapper();
+    const { result } = renderHook(() => ({ settings: useSettingsQuery(), update: useUpdateSettingsMutation() }), {
+      wrapper,
+    });
+    await waitFor(() => expect(result.current?.settings.data.theme).toBe('system'));
+    expect((await readLearningDocument())?.settings).toEqual({});
+
+    await act(() => result.current.update.mutateAsync({ theme: 'dark' }));
+    await waitFor(() => expect(result.current.settings.data.theme).toBe('dark'));
+    expect((await readLearningDocument())?.settings).toEqual({ theme: 'dark' });
+
+    await replaceLearningDocument({ schemaVersion: 6, cards: {}, stats: {}, settings: { maxNewCardsPerDay: 0 } });
+    await act(() => queryClient.invalidateQueries({ queryKey: settingsQueryKeys.all }));
+    await waitFor(() => expect(result.current.settings.data.theme).toBe('system'));
+    expect(result.current.settings.data.maxNewCardsPerDay).toBe(0);
+  });
+
+  it('reports a rejected save while retaining displayed and stored settings, then allows retry', async () => {
+    const { wrapper } = createTestWrapper();
+    const { result } = renderHook(() => ({ settings: useSettingsQuery(), update: useUpdateSettingsMutation() }), {
+      wrapper,
+    });
+    await waitFor(() => expect(result.current?.settings.data.theme).toBe('system'));
+    const failure = new Error('Storage unavailable');
+    vi.spyOn(fakeBrowser.storage.local, 'set').mockRejectedValueOnce(failure);
+
+    await act(async () => {
+      await expect(result.current.update.mutateAsync({ theme: 'dark' })).rejects.toBe(failure);
+    });
+    await waitFor(() => expect(result.current.update.error).toBe(failure));
+    expect(result.current.settings.data.theme).toBe('system');
+    expect((await readLearningDocument())?.settings).toEqual({});
+
+    await act(() => result.current.update.mutateAsync({ theme: 'dark' }));
+    await waitFor(() => expect(result.current.settings.data.theme).toBe('dark'));
+    expect((await readLearningDocument())?.settings).toEqual({ theme: 'dark' });
+  });
 });

--- a/infrastructure/storage/__tests__/translations.test.ts
+++ b/infrastructure/storage/__tests__/translations.test.ts
@@ -3,9 +3,29 @@ import { fakeBrowser } from 'wxt/testing/fake-browser';
 import { storage } from 'wxt/utils/storage';
 import { translations } from '@/i18n';
 import { STORAGE_KEYS } from '@/infrastructure/storage/storage-keys';
-import { getStoredTranslations, watchStoredTranslations } from '../translations';
+import {
+  getDocumentTranslations,
+  getStoredTranslations,
+  watchDocumentTranslations,
+  watchStoredTranslations,
+} from '../translations';
 
-describe('stored translations', () => {
+describe.each([
+  {
+    source: 'legacy language',
+    key: STORAGE_KEYS.language,
+    read: getStoredTranslations,
+    watch: watchStoredTranslations,
+    storedValue: (language: unknown): unknown => language,
+  },
+  {
+    source: 'learning document',
+    key: STORAGE_KEYS.learningDocument,
+    read: getDocumentTranslations,
+    watch: watchDocumentTranslations,
+    storedValue: (language: unknown): unknown => ({ schemaVersion: 6, cards: {}, stats: {}, settings: { language } }),
+  },
+])('stored translations from $source', ({ key, read, watch, storedValue }) => {
   beforeEach(() => {
     fakeBrowser.reset();
     fakeBrowser.runtime.id = 'test';
@@ -19,21 +39,21 @@ describe('stored translations', () => {
 
   describe('stored language', () => {
     it.each(['de', 'en', 'hi', 'pl', 'zh-CN'] as const)('uses stored language %s', async (language) => {
-      await storage.setItem(STORAGE_KEYS.language, language);
-      expect(await getStoredTranslations()).toBe(translations[language]);
+      await storage.setItem(key, storedValue(language));
+      expect(await read()).toBe(translations[language]);
     });
 
     it.each(['xx-INVALID', 'toString', 'constructor', '__proto__', 42, null])(
       'falls back to browser language for %s',
       async (language) => {
         vi.stubGlobal('navigator', { languages: ['pl'] });
-        await storage.setItem(STORAGE_KEYS.language, language);
-        expect(await getStoredTranslations()).toBe(translations.pl);
+        await storage.setItem(key, storedValue(language));
+        expect(await read()).toBe(translations.pl);
       }
     );
   });
 
-  it('reads only language and detects fallback after the storage read resolves', async () => {
+  it('reads its source once and detects fallback after the storage read resolves', async () => {
     const languageRead = Promise.withResolvers<null>();
     const getItem = vi.spyOn(storage, 'getItem').mockReturnValueOnce(languageRead.promise);
     const languages = vi.fn(() => ['pl']);
@@ -43,8 +63,8 @@ describe('stored translations', () => {
       },
     });
 
-    const pending = getStoredTranslations();
-    expect(getItem.mock.calls).toEqual([[STORAGE_KEYS.language]]);
+    const pending = read();
+    expect(getItem.mock.calls).toEqual([[key]]);
     expect(languages).not.toHaveBeenCalled();
     languageRead.resolve(null);
     expect(await pending).toBe(translations.pl);
@@ -52,7 +72,7 @@ describe('stored translations', () => {
   });
 
   it('uses stored language without accessing browser preferences', async () => {
-    await storage.setItem(STORAGE_KEYS.language, 'de');
+    await storage.setItem(key, storedValue('de'));
     const languages = vi.fn(() => ['pl']);
     vi.stubGlobal('navigator', {
       get languages() {
@@ -60,8 +80,23 @@ describe('stored translations', () => {
       },
     });
 
-    expect(await getStoredTranslations()).toBe(translations.de);
+    expect(await read()).toBe(translations.de);
     expect(languages).not.toHaveBeenCalled();
+  });
+
+  it('follows replacement with an omitted override using browser language', async () => {
+    vi.stubGlobal('navigator', { languages: ['de'] });
+    await storage.setItem(key, storedValue('pl'));
+    const onChange = vi.fn();
+    const stop = watch(onChange);
+    try {
+      await vi.waitFor(() => expect(onChange).toHaveBeenLastCalledWith(translations.pl));
+      await storage.setItem(key, storedValue(undefined));
+      await vi.waitFor(() => expect(onChange).toHaveBeenLastCalledWith(translations.de));
+      expect(await read()).toBe(translations.de);
+    } finally {
+      stop();
+    }
   });
 
   it('propagates storage failure without detecting a fallback', async () => {
@@ -74,24 +109,24 @@ describe('stored translations', () => {
       },
     });
 
-    await expect(getStoredTranslations()).rejects.toBe(failure);
+    await expect(read()).rejects.toBe(failure);
     expect(languages).not.toHaveBeenCalled();
   });
 
   it('loads once, follows language changes and removal, and stops after unsubscribe', async () => {
-    await storage.setItem(STORAGE_KEYS.language, 'en');
+    await storage.setItem(key, storedValue('en'));
     vi.stubGlobal('navigator', { languages: ['de'] });
     const onChange = vi.fn();
     const onError = vi.fn();
     const getItem = vi.spyOn(storage, 'getItem');
-    const stop = watchStoredTranslations(onChange, onError);
+    const stop = watch(onChange, onError);
     try {
       await vi.waitFor(() => expect(onChange).toHaveBeenLastCalledWith(translations.en));
-      await storage.setItem(STORAGE_KEYS.language, 'pl');
+      await storage.setItem(key, storedValue('pl'));
       await vi.waitFor(() => expect(onChange).toHaveBeenLastCalledWith(translations.pl));
-      await storage.setItem(STORAGE_KEYS.language, 'toString');
+      await storage.setItem(key, storedValue('toString'));
       await vi.waitFor(() => expect(onChange).toHaveBeenLastCalledWith(translations.de));
-      await storage.removeItem(STORAGE_KEYS.language);
+      await storage.removeItem(key);
       await vi.waitFor(() => expect(onChange).toHaveBeenLastCalledWith(translations.de));
       expect(getItem).toHaveBeenCalledOnce();
       expect(onError).not.toHaveBeenCalled();
@@ -99,19 +134,19 @@ describe('stored translations', () => {
       stop();
     }
     onChange.mockClear();
-    await storage.setItem(STORAGE_KEYS.language, 'en');
+    await storage.setItem(key, storedValue('en'));
     expect(onChange).not.toHaveBeenCalled();
   });
 
   it('does not overwrite a storage change with an older initial read', async () => {
-    const initial = Promise.withResolvers<string>();
+    const initial = Promise.withResolvers<unknown>();
     vi.spyOn(storage, 'getItem').mockReturnValueOnce(initial.promise);
     const onChange = vi.fn();
-    const stop = watchStoredTranslations(onChange, vi.fn());
+    const stop = watch(onChange, vi.fn());
     try {
-      await storage.setItem(STORAGE_KEYS.language, 'pl');
+      await storage.setItem(key, storedValue('pl'));
       await vi.waitFor(() => expect(onChange).toHaveBeenCalledWith(translations.pl));
-      initial.resolve('en');
+      initial.resolve(storedValue('en'));
       await initial.promise;
       expect(onChange).toHaveBeenCalledOnce();
     } finally {
@@ -120,12 +155,12 @@ describe('stored translations', () => {
   });
 
   it('ignores an initial read that finishes after unsubscribe', async () => {
-    const initial = Promise.withResolvers<string>();
+    const initial = Promise.withResolvers<unknown>();
     vi.spyOn(storage, 'getItem').mockReturnValueOnce(initial.promise);
     const onChange = vi.fn();
-    const stop = watchStoredTranslations(onChange, vi.fn());
+    const stop = watch(onChange, vi.fn());
     stop();
-    initial.resolve('en');
+    initial.resolve(storedValue('en'));
     await initial.promise;
     expect(onChange).not.toHaveBeenCalled();
   });
@@ -135,11 +170,32 @@ describe('stored translations', () => {
     vi.spyOn(storage, 'getItem').mockRejectedValueOnce(error);
     const onChange = vi.fn();
     const onError = vi.fn();
-    const stop = watchStoredTranslations(onChange, onError);
+    const stop = watch(onChange, onError);
     try {
       await vi.waitFor(() => expect(onError).toHaveBeenCalledWith(error));
-      await storage.setItem(STORAGE_KEYS.language, 'pl');
+      await storage.setItem(key, storedValue('pl'));
       await vi.waitFor(() => expect(onChange).toHaveBeenCalledWith(translations.pl));
+    } finally {
+      stop();
+    }
+  });
+
+  it.each(['change', 'unsubscribe'] as const)('ignores an initial read failure after %s', async (event) => {
+    const initial = Promise.withResolvers<unknown>();
+    vi.spyOn(storage, 'getItem').mockReturnValueOnce(initial.promise);
+    const onChange = vi.fn();
+    const onError = vi.fn();
+    const stop = watch(onChange, onError);
+    try {
+      if (event === 'unsubscribe') {
+        stop();
+      } else {
+        await storage.setItem(key, storedValue('pl'));
+        await vi.waitFor(() => expect(onChange).toHaveBeenCalledWith(translations.pl));
+      }
+      initial.reject(new Error('Late failure'));
+      await initial.promise.catch(() => {});
+      expect(onError).not.toHaveBeenCalled();
     } finally {
       stop();
     }

--- a/infrastructure/storage/translations.ts
+++ b/infrastructure/storage/translations.ts
@@ -1,32 +1,59 @@
+import { z } from 'zod';
 import { storage } from '#imports';
 import { languageSchema } from '@/domain/language';
 import { type Translations, translations } from '@/i18n';
 import { detectBrowserLanguage } from '@/infrastructure/browser/language';
-import { STORAGE_KEYS } from './storage-keys';
+import { STORAGE_KEYS, type StorageKey } from './storage-keys';
 
-export async function getStoredTranslations(): Promise<Translations> {
-  const language = await storage.getItem<unknown>(STORAGE_KEYS.language);
-  return translations[languageSchema.safeParse(language).data ?? detectBrowserLanguage()];
+const documentLanguageSchema = z.object({ settings: z.object({ language: languageSchema.optional() }) });
+
+// The two sources share subscription ordering until legacy removal in #379.
+function createTranslationReader(key: StorageKey, selectLanguage: (value: unknown) => unknown) {
+  const resolve = (value: unknown): Translations =>
+    translations[languageSchema.safeParse(selectLanguage(value)).data ?? detectBrowserLanguage()];
+
+  async function get(): Promise<Translations> {
+    return resolve(await storage.getItem<unknown>(key));
+  }
+
+  // Subscribe before reading so a concurrent change wins over the initial read.
+  function watch(onChange: (t: Translations) => void, onError?: (error: unknown) => void) {
+    let changed = false;
+    let stopped = false;
+    const unwatch = storage.watch<unknown>(key, (value) => {
+      changed = true;
+      if (!stopped) {
+        onChange(resolve(value));
+      }
+    });
+    void get().then(
+      (t) => {
+        if (!stopped && !changed) {
+          onChange(t);
+        }
+      },
+      (error) => {
+        if (!stopped && !changed) {
+          onError?.(error);
+        }
+      }
+    );
+    return () => {
+      stopped = true;
+      unwatch();
+    };
+  }
+
+  return { get, watch };
 }
 
-// Subscribe before reading so a concurrent setting change wins over the initial read.
-export function watchStoredTranslations(onChange: (t: Translations) => void, onError?: (error: unknown) => void) {
-  let changed = false;
-  let stopped = false;
-  const unwatch = storage.watch<unknown>(STORAGE_KEYS.language, (language) => {
-    changed = true;
-    if (!stopped) onChange(translations[languageSchema.safeParse(language).data ?? detectBrowserLanguage()]);
-  });
-  void getStoredTranslations().then(
-    (t) => {
-      if (!stopped && !changed) onChange(t);
-    },
-    (error) => {
-      if (!stopped && !changed) onError?.(error);
-    }
-  );
-  return () => {
-    stopped = true;
-    unwatch();
-  };
-}
+export const { get: getStoredTranslations, watch: watchStoredTranslations } = createTranslationReader(
+  STORAGE_KEYS.language,
+  (value) => value
+);
+
+// Prepared for content activation in #378; content remains read-only.
+export const { get: getDocumentTranslations, watch: watchDocumentTranslations } = createTranslationReader(
+  STORAGE_KEYS.learningDocument,
+  (value) => documentLanguageSchema.safeParse(value).data?.settings.language
+);

--- a/services/document-settings.ts
+++ b/services/document-settings.ts
@@ -1,0 +1,33 @@
+import { learningDocumentSchema } from '@/domain/learning-document';
+import { resolveSettings, type Settings, type SettingsUpdate, settingsUpdateSchema } from '@/domain/settings';
+import { detectBrowserLanguage } from '@/infrastructure/browser/language';
+import { readLearningDocument, replaceLearningDocument } from '@/infrastructure/storage/learning-document';
+
+// Prepared for the coordinated runtime activation in #378.
+export async function getSettings(): Promise<Settings> {
+  const document = await readLearningDocument();
+  if (!document) {
+    throw new Error('Learning document is not initialized');
+  }
+
+  return resolveSettings(document.settings, document.settings.language ?? detectBrowserLanguage());
+}
+
+export async function updateSettings(changes: SettingsUpdate): Promise<void> {
+  const parsedChanges = settingsUpdateSchema.parse(changes);
+  if (Object.keys(parsedChanges).length === 0) {
+    return;
+  }
+
+  const document = await readLearningDocument();
+  if (!document) {
+    throw new Error('Learning document is not initialized');
+  }
+
+  const next = learningDocumentSchema.parse({
+    ...document,
+    settings: { ...document.settings, ...parsedChanges },
+    dataUpdatedAt: new Date().toISOString(),
+  });
+  await replaceLearningDocument(next);
+}


### PR DESCRIPTION
- Prepare atomic document-backed settings and translation subscriptions; keep the legacy runtime active until #378.
- Cover defaults, replacements, rejected writes, and popup flows with real storage.
- Verify with `npm run check` (1,202 tests) and `npm run build`; standards and spec reviews found no issues.

Closes #375
