### PR TITLE
refactor: activate single-document persistence

### DIFF
--- a/content/__tests__/bootstrap.test.ts
+++ b/content/__tests__/bootstrap.test.ts
@@ -6,12 +6,12 @@ import { ContentScriptContext } from 'wxt/utils/content-script-context';
 import { setupLeetcodeAutoReset } from '@/content/auto-reset';
 import { translations } from '@/i18n';
 import { sendMessage } from '@/infrastructure/browser/messages';
-import { watchStoredTranslations } from '@/infrastructure/storage/translations';
+import { watchDocumentTranslations } from '@/infrastructure/storage/translations';
 import { requireDefined } from '@/test/utils/assertions';
 import { bootstrapContent } from '../bootstrap';
 
 vi.mock('@/content/auto-reset', () => ({ setupLeetcodeAutoReset: vi.fn() }));
-vi.mock('@/infrastructure/storage/translations', () => ({ watchStoredTranslations: vi.fn() }));
+vi.mock('@/infrastructure/storage/translations', () => ({ watchDocumentTranslations: vi.fn() }));
 vi.mock('@/infrastructure/browser/messages', () => ({ sendMessage: vi.fn() }));
 
 let ctx: ContentScriptContext;
@@ -38,7 +38,7 @@ beforeEach(() => {
   );
   document.body.innerHTML = '<div id="ide-top-btns"><div id="last-group"></div></div>';
   vi.mocked(sendMessage).mockResolvedValue(undefined);
-  vi.mocked(watchStoredTranslations).mockImplementation((onChange) => {
+  vi.mocked(watchDocumentTranslations).mockImplementation((onChange) => {
     onChange(translations.en);
     return unwatchTranslations;
   });

--- a/content/ui/LeetSrsControl.tsx
+++ b/content/ui/LeetSrsControl.tsx
@@ -2,7 +2,7 @@ import { type CSSProperties, type Ref, useEffect, useRef, useState } from 'react
 import { Button, type ButtonProps, Dialog, DialogTrigger, Popover, TooltipTrigger } from 'react-aria-components';
 import { addCurrentProblem, rateCurrentProblem } from '@/content/rating-actions';
 import type { Translations } from '@/i18n';
-import { watchStoredTranslations } from '@/infrastructure/storage/translations';
+import { watchDocumentTranslations } from '@/infrastructure/storage/translations';
 import { RatingMenu } from './RatingMenu';
 import { Tooltip } from './Tooltip';
 import { LEETSRS_BUTTON_COLOR, THEME_COLORS, useDarkMode } from './theme';
@@ -13,7 +13,7 @@ export function LeetSrsControl() {
   const buttonRef = useRef<HTMLButtonElement>(null);
   const wasMenuOpen = useRef(false);
 
-  useEffect(() => watchStoredTranslations(setTranslations), []);
+  useEffect(() => watchDocumentTranslations(setTranslations), []);
 
   useEffect(() => {
     // React Aria's restore-focus guard only checks document.activeElement,

--- a/content/ui/__tests__/LeetSrsControl.test.tsx
+++ b/content/ui/__tests__/LeetSrsControl.test.tsx
@@ -5,15 +5,15 @@ import { Rating } from 'ts-fsrs';
 import { beforeEach, expect, it, vi } from 'vitest';
 import { addCurrentProblem, rateCurrentProblem } from '@/content/rating-actions';
 import { translations } from '@/i18n';
-import { watchStoredTranslations } from '@/infrastructure/storage/translations';
+import { watchDocumentTranslations } from '@/infrastructure/storage/translations';
 
 vi.mock('@/infrastructure/storage/translations', () => ({
-  watchStoredTranslations: vi.fn(),
+  watchDocumentTranslations: vi.fn(),
 }));
 vi.mock('@/content/rating-actions', () => ({ addCurrentProblem: vi.fn(), rateCurrentProblem: vi.fn() }));
 const unwatch = vi.fn();
 beforeEach(() => {
-  vi.mocked(watchStoredTranslations).mockImplementation((onChange) => {
+  vi.mocked(watchDocumentTranslations).mockImplementation((onChange) => {
     onChange(translations.en);
     return unwatch;
   });
@@ -116,11 +116,11 @@ it('cycles focus through every choice with Tab after opening with the mouse', as
 it('updates an open menu when stored language changes without resubscribing on clicks', () => {
   const { button, unmount } = setup();
   fireEvent.click(button);
-  const onChange = vi.mocked(watchStoredTranslations).mock.calls[0][0];
+  const onChange = vi.mocked(watchDocumentTranslations).mock.calls[0][0];
   act(() => onChange(translations.pl));
   fireEvent.click(screen.getByRole('button', { name: translations.pl.ratings[Rating.Good] }));
   fireEvent.click(button);
-  expect(watchStoredTranslations).toHaveBeenCalledOnce();
+  expect(watchDocumentTranslations).toHaveBeenCalledOnce();
   unmount();
   expect(unwatch).toHaveBeenCalledOnce();
 });

--- a/content/ui/__tests__/shadow-root.test.tsx
+++ b/content/ui/__tests__/shadow-root.test.tsx
@@ -3,18 +3,18 @@
 import { act, fireEvent, screen, waitFor, within } from '@testing-library/react';
 import { afterEach, beforeEach, expect, it, vi } from 'vitest';
 import { translations } from '@/i18n';
-import { watchStoredTranslations } from '@/infrastructure/storage/translations';
+import { watchDocumentTranslations } from '@/infrastructure/storage/translations';
 import { requireDefined } from '@/test/utils/assertions';
 import { LeetSrsControl } from '../LeetSrsControl';
 import { createContentRoot } from '../shadow-root';
 
-vi.mock('@/infrastructure/storage/translations', () => ({ watchStoredTranslations: vi.fn() }));
+vi.mock('@/infrastructure/storage/translations', () => ({ watchDocumentTranslations: vi.fn() }));
 vi.mock('@/infrastructure/browser/messages', () => ({ sendMessage: vi.fn() }));
 
 let root: ReturnType<typeof createContentRoot>;
 let host: HTMLElement;
 beforeEach(() => {
-  vi.mocked(watchStoredTranslations).mockImplementation((onChange) => {
+  vi.mocked(watchDocumentTranslations).mockImplementation((onChange) => {
     onChange(translations.en);
     return vi.fn();
   });

--- a/docs/agents/architecture.md
+++ b/docs/agents/architecture.md
@@ -20,7 +20,7 @@ These rules apply to runtime and type-only imports:
 Before changing background commands or sync execution, read [ADR-0001](../adr/0001-background-command-execution.md).
 
 - RPC contracts and transport belong in `infrastructure/browser/messages.ts`.
-- `entrypoints/background/index.ts` owns startup, listener registration, and an exhaustive typed command registry. Its private dispatcher validates payloads by message name and shares one write queue between messages and alarms, including network work and ordered post-handler effects. Reads may overlap writes. The single-document transition moves local-edit timestamps into the prepared document write; imported timestamps remain unchanged. Badge failures must not overturn a successful data write.
+- `entrypoints/background/index.ts` owns startup, listener registration, and an exhaustive typed command registry. Its private dispatcher validates payloads by message name and shares one write queue between messages and alarms, including network work and ordered post-handler effects. Reads may overlap writes. Prepared document writes include local-edit timestamps; imported timestamps remain unchanged. Badge failures must not overturn a successful data write.
 - Register message and alarm listeners synchronously during startup. Handlers wait for startup readiness before accessing storage.
 
 ## Content UI lifecycle
@@ -30,7 +30,7 @@ Before changing background commands or sync execution, read [ADR-0001](../adr/00
 
 ## Storage, backup, and sync
 
-[ADR-0003](../adr/0003-single-document-learning-data.md) records the accepted target. The [canonical implementation plan](https://github.com/mattcdrake/LeetSRS/issues/371) owns its transition; the current multi-key implementation is awaiting replacement.
+[ADR-0003](../adr/0003-single-document-learning-data.md) records the single-document design. The document is authoritative at runtime; the [canonical implementation plan](https://github.com/mattcdrake/LeetSRS/issues/371) tracks the remaining superseded-code cleanup.
 
 - One browser-local document owns its schema version, modification timestamp, slug-keyed cards with embedded notes, daily statistics, and stored settings overrides. Dates remain numbers. Missing settings retain normal defaults, including browser-language detection.
 - Domain owns current schemas and explicit-input policy. Services prepare and validate complete changes, including timestamps, before infrastructure writes the document once. Reviews commit cards, statistics, and their edit timestamp together; queue calculations use one captured document and time. Keep normal operations behind startup readiness and the existing background write queue.

--- a/entrypoints/background/__tests__/document-learning.test.ts
+++ b/entrypoints/background/__tests__/document-learning.test.ts
@@ -16,19 +16,6 @@ vi.mock('@/infrastructure/browser/messages', async (importOriginal) => ({
   onMessage: vi.fn(),
 }));
 
-// Test-only activation; #378 switches production paths and removes the old timestamp effect.
-vi.mock('@/services/cards', () => import('@/services/document-learning'));
-vi.mock('@/services/stats', () => import('@/services/document-learning'));
-vi.mock('@/services/editor-reset', () => import('@/services/document-learning'));
-vi.mock('@/services/settings', async (importOriginal) => ({
-  ...(await importOriginal<typeof import('@/services/settings')>()),
-  ...(await import('@/services/document-settings')),
-}));
-vi.mock('@/infrastructure/storage/migrations/runner', async () => ({
-  runStartupMigrations: (await import('@/infrastructure/storage/learning-document-startup')).initializeLearningDocument,
-}));
-vi.mock('@/infrastructure/storage/data-tracker', () => ({ markDataUpdated: () => Promise.resolve() }));
-
 function dispatch<Name extends MessageName>(name: Name, data?: MessageData<Name>): Promise<MessageResult<Name>> {
   const listener = vi.mocked(onMessage).mock.calls.find(([registered]) => registered === name)?.[1];
   if (!listener) {

--- a/entrypoints/background/__tests__/document-learning.test.ts
+++ b/entrypoints/background/__tests__/document-learning.test.ts
@@ -4,9 +4,10 @@ import { fakeBrowser } from 'wxt/testing/fake-browser';
 import { storage } from 'wxt/utils/storage';
 import { type LearningDocument, learningDocumentSchema } from '@/domain/learning-document';
 import { createDailyStats } from '@/domain/statistics';
-import { type MessageData, type MessageName, type MessageResult, onMessage } from '@/infrastructure/browser/messages';
+import { onMessage } from '@/infrastructure/browser/messages';
 import { readLearningDocument, replaceLearningDocument } from '@/infrastructure/storage/learning-document';
 import { STORAGE_KEYS } from '@/infrastructure/storage/storage-keys';
+import { dispatchBackgroundCommand as dispatch } from '@/test/utils/background-messages';
 import { mixedRecordBackup } from '@/test/utils/backup-mocks';
 import { buildProblem, createMockCard } from '@/test/utils/card-mocks';
 import background from '../index';
@@ -15,16 +16,6 @@ vi.mock('@/infrastructure/browser/messages', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@/infrastructure/browser/messages')>()),
   onMessage: vi.fn(),
 }));
-
-function dispatch<Name extends MessageName>(name: Name, data?: MessageData<Name>): Promise<MessageResult<Name>> {
-  const listener = vi.mocked(onMessage).mock.calls.find(([registered]) => registered === name)?.[1];
-  if (!listener) {
-    throw new Error(`Missing listener for ${name}`);
-  }
-  return Promise.resolve(
-    listener({ id: 1, type: name, data: data as MessageData<MessageName>, timestamp: 0, sender: {} })
-  ) as Promise<MessageResult<Name>>;
-}
 
 describe('document learning through background commands', () => {
   beforeEach(async () => {

--- a/entrypoints/background/__tests__/document-settings.test.ts
+++ b/entrypoints/background/__tests__/document-settings.test.ts
@@ -1,9 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { fakeBrowser } from 'wxt/testing/fake-browser';
 import { storage } from 'wxt/utils/storage';
-import { type MessageData, type MessageName, onMessage } from '@/infrastructure/browser/messages';
+import { onMessage } from '@/infrastructure/browser/messages';
 import { readLearningDocument, replaceLearningDocument } from '@/infrastructure/storage/learning-document';
 import { STORAGE_KEYS } from '@/infrastructure/storage/storage-keys';
+import { dispatchBackgroundCommand as dispatch } from '@/test/utils/background-messages';
 import { mixedRecordBackup } from '@/test/utils/backup-mocks';
 import { buildSettings } from '@/test/utils/settings-mocks';
 import background from '../index';
@@ -12,12 +13,6 @@ vi.mock('@/infrastructure/browser/messages', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@/infrastructure/browser/messages')>()),
   onMessage: vi.fn(),
 }));
-
-function dispatch(name: MessageName, data?: unknown) {
-  const listener = vi.mocked(onMessage).mock.calls.find(([registered]) => registered === name)?.[1];
-  if (!listener) throw new Error(`Missing listener for ${name}`);
-  return listener({ id: 1, type: name, data: data as MessageData<MessageName>, timestamp: 0, sender: {} });
-}
 
 describe('document settings through background commands', () => {
   beforeEach(() => {

--- a/entrypoints/background/__tests__/document-settings.test.ts
+++ b/entrypoints/background/__tests__/document-settings.test.ts
@@ -13,15 +13,6 @@ vi.mock('@/infrastructure/browser/messages', async (importOriginal) => ({
   onMessage: vi.fn(),
 }));
 
-// Test-only activation of the prepared paths; production switches together in #378.
-vi.mock('@/services/settings', async (importOriginal) => ({
-  ...(await importOriginal<typeof import('@/services/settings')>()),
-  ...(await import('@/services/document-settings')),
-}));
-vi.mock('@/infrastructure/storage/migrations/runner', async () => ({
-  runStartupMigrations: (await import('@/infrastructure/storage/learning-document-startup')).initializeLearningDocument,
-}));
-
 function dispatch(name: MessageName, data?: unknown) {
   const listener = vi.mocked(onMessage).mock.calls.find(([registered]) => registered === name)?.[1];
   if (!listener) throw new Error(`Missing listener for ${name}`);

--- a/entrypoints/background/__tests__/document-transfer.test.ts
+++ b/entrypoints/background/__tests__/document-transfer.test.ts
@@ -2,7 +2,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { browser } from 'wxt/browser';
 import { fakeBrowser } from 'wxt/testing/fake-browser';
 import { type LearningDocument, learningDocumentSchema } from '@/domain/learning-document';
-import { type MessageData, type MessageName, onMessage } from '@/infrastructure/browser/messages';
+import { onMessage } from '@/infrastructure/browser/messages';
+import { dispatchBackgroundCommand as dispatch } from '@/test/utils/background-messages';
 import { mixedRecordBackup } from '@/test/utils/backup-mocks';
 import { buildProblem } from '@/test/utils/card-mocks';
 import background from '../index';
@@ -18,14 +19,8 @@ vi.mock('@/infrastructure/browser/messages', async (importOriginal) => ({
   onMessage: vi.fn(),
 }));
 
-function dispatch(name: MessageName, data?: unknown) {
-  const listener = vi.mocked(onMessage).mock.calls.find(([registered]) => registered === name)?.[1];
-  if (!listener) throw new Error(`Missing listener for ${name}`);
-  return listener({ id: 1, type: name, data: data as MessageData<MessageName>, timestamp: 0, sender: {} });
-}
-
 async function exported(): Promise<LearningDocument> {
-  return learningDocumentSchema.parse(JSON.parse((await dispatch('exportData')) as string));
+  return learningDocumentSchema.parse(JSON.parse(await dispatch('exportData')));
 }
 
 beforeEach(async () => {

--- a/entrypoints/background/__tests__/document-transfer.test.ts
+++ b/entrypoints/background/__tests__/document-transfer.test.ts
@@ -1,0 +1,211 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { browser } from 'wxt/browser';
+import { fakeBrowser } from 'wxt/testing/fake-browser';
+import { type LearningDocument, learningDocumentSchema } from '@/domain/learning-document';
+import { type MessageData, type MessageName, onMessage } from '@/infrastructure/browser/messages';
+import { mixedRecordBackup } from '@/test/utils/backup-mocks';
+import { buildProblem } from '@/test/utils/card-mocks';
+import background from '../index';
+
+const github = vi.hoisted(() => ({ get: vi.fn(), update: vi.fn(), create: vi.fn() }));
+vi.mock('octokit', () => ({
+  Octokit: vi.fn(function MockOctokit() {
+    return { rest: { gists: github } };
+  }),
+}));
+vi.mock('@/infrastructure/browser/messages', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/infrastructure/browser/messages')>()),
+  onMessage: vi.fn(),
+}));
+
+function dispatch(name: MessageName, data?: unknown) {
+  const listener = vi.mocked(onMessage).mock.calls.find(([registered]) => registered === name)?.[1];
+  if (!listener) throw new Error(`Missing listener for ${name}`);
+  return listener({ id: 1, type: name, data: data as MessageData<MessageName>, timestamp: 0, sender: {} });
+}
+
+async function exported(): Promise<LearningDocument> {
+  return learningDocumentSchema.parse(JSON.parse((await dispatch('exportData')) as string));
+}
+
+beforeEach(async () => {
+  fakeBrowser.reset();
+  fakeBrowser.runtime.id = 'test';
+  vi.mocked(onMessage).mockClear();
+  background.main();
+  await dispatch('getSettings');
+  await dispatch('resetAllData');
+  await dispatch('setGistSyncConfig', { config: { pat: 'secret', gistId: 'gist', enabled: true } });
+});
+
+describe('file and Gist transfers through registered background commands', () => {
+  it.each(['file', 'gist'] as const)(
+    'replaces the whole document from a %s and preserves its timestamp and connection',
+    async (source) => {
+      await dispatch('addCard', { problem: buildProblem() });
+      await dispatch('saveNote', { slug: 'two-sum', text: 'Omitted from replacement' });
+      await dispatch('updateSettings', { changes: { theme: 'dark', language: 'de' } });
+      await fakeBrowser.storage.local.set({ 'leetsrs:lastSyncTime': 'previous', 'leetsrs:lastSyncDirection': 'push' });
+      const before = await exported();
+      const replacement = { ...before, settings: {}, dataUpdatedAt: '2099-01-01T00:00:00.000Z' };
+      delete replacement.cards['two-sum'].note;
+      const jsonData = JSON.stringify(replacement);
+      const writes = vi.spyOn(fakeBrowser.storage.local, 'set');
+      if (source === 'file') {
+        await dispatch('importData', { jsonData });
+        expect(await dispatch('getGistSyncStatus')).toMatchObject({
+          lastSyncTime: 'previous',
+          lastSyncDirection: 'push',
+        });
+      } else {
+        github.get.mockResolvedValue({ data: { files: { 'leetsrs-backup.json': { content: jsonData } } } });
+        await expect(dispatch('triggerGistSync')).resolves.toMatchObject({ success: true, action: 'pulled' });
+        expect(await dispatch('getGistSyncStatus')).toMatchObject({ lastSyncDirection: 'pull' });
+      }
+      expect(await exported()).toEqual(replacement);
+      expect(await dispatch('getNote', { slug: 'two-sum' })).toBeNull();
+      expect(await dispatch('getSettings')).toMatchObject({ theme: 'system' });
+      expect(await dispatch('getGistSyncConfig')).toEqual({ pat: 'secret', gistId: 'gist', enabled: true });
+      const documentWrites = writes.mock.calls.filter(([items]) => Object.hasOwn(items, 'leetsrs:learningDocument'));
+      expect(documentWrites).toEqual([[{ 'leetsrs:learningDocument': replacement }]]);
+      expect(github.update).not.toHaveBeenCalled();
+    }
+  );
+
+  it('imports supported historical data without importing its connection', async () => {
+    const { accepted, embedded, payload } = mixedRecordBackup();
+    await dispatch('importData', { jsonData: JSON.stringify({ ...payload, data: accepted }) });
+    expect(await exported()).toEqual({
+      schemaVersion: 6,
+      ...embedded,
+      settings: {},
+      dataUpdatedAt: payload.dataUpdatedAt,
+    });
+    expect(await dispatch('getGistSyncConfig')).toEqual({ pat: 'secret', gistId: 'gist', enabled: true });
+    expect(await dispatch('getNote', { slug: 'two-sum' })).toBe('Keep this note');
+  });
+
+  it.each(['file', 'gist'] as const)(
+    'retains all data after a rejected %s replacement and accepts a later command',
+    async (source) => {
+      await dispatch('addCard', { problem: buildProblem() });
+      const before = await exported();
+      const config = await dispatch('getGistSyncConfig');
+      const jsonData = JSON.stringify({
+        schemaVersion: 6,
+        cards: {},
+        stats: {},
+        settings: {},
+        dataUpdatedAt: '2099-01-01T00:00:00.000Z',
+      });
+      vi.spyOn(fakeBrowser.storage.local, 'set').mockRejectedValueOnce(new Error('Document unavailable'));
+      if (source === 'file') {
+        await expect(dispatch('importData', { jsonData })).rejects.toThrow('Document unavailable');
+      } else {
+        github.get.mockResolvedValue({ data: { files: { 'leetsrs-backup.json': { content: jsonData } } } });
+        await expect(dispatch('triggerGistSync')).resolves.toEqual({ success: false, error: 'Document unavailable' });
+      }
+      expect(await exported()).toEqual(before);
+      expect(await dispatch('getGistSyncConfig')).toEqual(config);
+      expect(await dispatch('getGistSyncStatus')).toMatchObject({ lastSyncTime: null, lastSyncDirection: null });
+      await dispatch('saveNote', { slug: 'two-sum', text: 'After failure' });
+      expect(await dispatch('getNote', { slug: 'two-sum' })).toBe('After failure');
+    }
+  );
+
+  it.each(['file', 'gist'] as const)(
+    'rejects future %s data before overwriting either side, even when local data is newer',
+    async (source) => {
+      await dispatch('addCard', { problem: buildProblem() });
+      const before = await exported();
+      const jsonData = JSON.stringify({
+        schemaVersion: 7,
+        cards: {},
+        stats: {},
+        settings: {},
+        dataUpdatedAt: '2000-01-01T00:00:00.000Z',
+      });
+      const writes = vi.spyOn(fakeBrowser.storage.local, 'set');
+      if (source === 'file') {
+        await expect(dispatch('importData', { jsonData })).rejects.toThrow();
+      } else {
+        github.get.mockResolvedValue({ data: { files: { 'leetsrs-backup.json': { content: jsonData } } } });
+        await expect(dispatch('triggerGistSync')).resolves.toMatchObject({ success: false });
+      }
+      expect(await exported()).toEqual(before);
+      expect(writes).not.toHaveBeenCalled();
+      expect(github.update).not.toHaveBeenCalled();
+    }
+  );
+
+  it.each(['success', 'failure'] as const)(
+    'holds alarm network work in the shared queue through %s while reads overlap',
+    async (outcome) => {
+      const alarmRegistration = vi.spyOn(browser.alarms.onAlarm, 'addListener');
+      vi.mocked(onMessage).mockClear();
+      background.main();
+      await dispatch('getSettings');
+      const alarm = alarmRegistration.mock.calls[0][0];
+      const started = Promise.withResolvers<void>();
+      const release = Promise.withResolvers<void>();
+      github.get.mockImplementationOnce(async () => {
+        started.resolve();
+        await release.promise;
+        if (outcome === 'failure') throw new Error('Network failed');
+        return { data: { files: {} } };
+      });
+      const before = await exported();
+      const syncing = alarm({
+        name: 'gist-sync',
+        scheduledTime: Date.now(),
+        periodInMinutes: 1,
+        persistAcrossSessions: true,
+      });
+      await started.promise;
+      const writing = dispatch('addCard', { problem: buildProblem() });
+      expect(await exported()).toEqual(before);
+      expect(await dispatch('getGistSyncStatus')).toMatchObject({ syncInProgress: true });
+      release.resolve();
+      await Promise.all([syncing, writing]);
+      expect(await dispatch('getAllCards')).toMatchObject([buildProblem()]);
+      if (outcome === 'success') {
+        expect(JSON.parse(github.update.mock.calls[0][0].files['leetsrs-backup.json'].content)).toEqual(before);
+      } else {
+        expect(github.update).not.toHaveBeenCalled();
+        expect(await dispatch('getGistSyncStatus')).toMatchObject({ lastError: 'Network failed' });
+      }
+      await dispatch('resetAllData');
+      expect(await dispatch('getGistSyncStatus')).toEqual({
+        lastSyncTime: null,
+        lastSyncDirection: null,
+        syncInProgress: false,
+        lastError: null,
+      });
+    }
+  );
+
+  it.each([
+    { enabled: false, pat: 'secret', gistId: 'gist' },
+    { enabled: true, pat: '', gistId: 'gist' },
+    { enabled: true, pat: 'secret', gistId: null },
+  ])('skips automatic sync when its connection is incomplete: %j', async (config) => {
+    await dispatch('setGistSyncConfig', { config });
+    const registration = vi.spyOn(browser.alarms.onAlarm, 'addListener');
+    background.main();
+    const alarm = registration.mock.calls[0][0];
+    await alarm({ name: 'gist-sync', scheduledTime: Date.now(), periodInMinutes: 1, persistAcrossSessions: true });
+    expect(github.get).not.toHaveBeenCalled();
+  });
+
+  it('creates a Gist from the document without treating connection changes as learning edits', async () => {
+    await dispatch('updateSettings', { changes: { language: 'de' } });
+    const before = await exported();
+    github.create.mockResolvedValueOnce({ data: { id: 'created-gist' } });
+    await expect(dispatch('createNewGist')).resolves.toEqual({ gistId: 'created-gist' });
+    expect(JSON.parse(github.create.mock.calls[0][0].files['leetsrs-backup.json'].content)).toEqual(before);
+    expect(await dispatch('getGistSyncConfig')).toEqual({ pat: 'secret', gistId: 'created-gist', enabled: true });
+    await dispatch('setGistSyncConfig', { config: { enabled: false } });
+    expect(await exported()).toEqual(before);
+    expect(await fakeBrowser.storage.local.get('leetsrs:dataUpdatedAt')).toEqual({});
+  });
+});

--- a/entrypoints/background/__tests__/execution.test.ts
+++ b/entrypoints/background/__tests__/execution.test.ts
@@ -1,7 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { browser } from 'wxt/browser';
 import { fakeBrowser } from 'wxt/testing/fake-browser';
-import { storage } from 'wxt/utils/storage';
 import { ZodError } from 'zod';
 import {
   type MessageData,
@@ -9,10 +8,6 @@ import {
   messagePayloadSchemas,
   onMessage,
 } from '@/infrastructure/browser/messages';
-import * as tracker from '@/infrastructure/storage/data-tracker';
-import { STORAGE_KEYS } from '@/infrastructure/storage/storage-keys';
-import * as cards from '@/services/cards';
-import * as sync from '@/services/gist-sync';
 import { buildProblem } from '@/test/utils/card-mocks';
 import background from '../index';
 
@@ -21,13 +16,6 @@ vi.mock('@/infrastructure/browser/messages', async (importOriginal) => ({
   onMessage: vi.fn(),
 }));
 
-vi.mock('@/services/gist-sync', async (importOriginal) => ({
-  ...(await importOriginal<typeof import('@/services/gist-sync')>()),
-  triggerGistSync: vi.fn(),
-  createNewGist: vi.fn(),
-}));
-
-// Exercise untrusted input through the listeners registered by the real background.
 function dispatch(name: MessageName, data?: unknown) {
   const listener = vi.mocked(onMessage).mock.calls.find(([registered]) => registered === name)?.[1];
   if (!listener) throw new Error(`Missing listener for ${name}`);
@@ -37,6 +25,7 @@ function dispatch(name: MessageName, data?: unknown) {
 beforeEach(async () => {
   fakeBrowser.reset();
   fakeBrowser.runtime.id = 'test';
+  vi.mocked(onMessage).mockClear();
   background.main();
   await dispatch('getSettings');
 });
@@ -44,85 +33,6 @@ beforeEach(async () => {
 const problem = buildProblem();
 
 describe('registered background execution', () => {
-  it.each(['  Remember the complement  ', ' \n\t '])(
-    'edits note text "%s" while preserving the card and its schedule',
-    async (text) => {
-      const card = await cards.addCard(problem);
-      await expect(dispatch('getNote', { slug: problem.slug })).resolves.toBeNull();
-      await dispatch('saveNote', { slug: problem.slug, text });
-      expect(await dispatch('getAllCards')).toEqual([{ ...card, note: text }]);
-      expect(await dispatch('getNote', { slug: problem.slug })).toBe(text);
-      await dispatch('saveNote', { slug: problem.slug, text: '' });
-      expect(await dispatch('getAllCards')).toEqual([card]);
-      expect(await dispatch('getNote', { slug: problem.slug })).toBeNull();
-    }
-  );
-
-  it('rejects a missing-card save, allows absent reads/deletes, and never looks up UUIDs', async () => {
-    const card = await cards.addCard(problem);
-    const tracking = vi.spyOn(tracker, 'markDataUpdated');
-    const writes = vi.spyOn(browser.storage.local, 'set');
-    await expect(dispatch('saveNote', { slug: card.id, text: 'No owner' })).rejects.toThrow('not found');
-    expect(tracking).not.toHaveBeenCalled();
-    expect(writes).not.toHaveBeenCalled();
-    expect(await dispatch('getNote', { slug: card.id })).toBeNull();
-    await expect(dispatch('deleteNote', { slug: card.id })).resolves.toBeUndefined();
-    expect(await dispatch('getAllCards')).toEqual([card]);
-  });
-
-  it('keeps serialized note and card edits together, then removes notes with cards and on reset', async () => {
-    await dispatch('addCard', { problem });
-    await Promise.all([
-      dispatch('saveNote', { slug: problem.slug, text: 'Keep me' }),
-      dispatch('setPauseStatus', { slug: problem.slug, paused: true }),
-    ]);
-    expect(await dispatch('getAllCards')).toMatchObject([{ slug: problem.slug, paused: true, note: 'Keep me' }]);
-    await dispatch('removeCard', { slug: problem.slug });
-    expect(await dispatch('getNote', { slug: problem.slug })).toBeNull();
-    await dispatch('addCard', { problem });
-    expect(await dispatch('getNote', { slug: problem.slug })).toBeNull();
-    await dispatch('saveNote', { slug: problem.slug, text: 'Reset me' });
-    await dispatch('resetAllData');
-    expect(await dispatch('getNote', { slug: problem.slug })).toBeNull();
-    expect(await dispatch('getAllCards')).toEqual([]);
-  });
-
-  it.each(['length', 'write'] as const)('preserves the note and timestamp after a %s failure', async (failure) => {
-    await dispatch('addCard', { problem });
-    await dispatch('saveNote', { slug: problem.slug, text: 'a'.repeat(500) });
-    const previous = await dispatch('getAllCards');
-    const timestamp = await storage.getItem(STORAGE_KEYS.dataUpdatedAt);
-    if (failure === 'write') vi.spyOn(browser.storage.local, 'set').mockRejectedValueOnce(new Error('Unavailable'));
-    await expect(
-      dispatch('saveNote', {
-        slug: problem.slug,
-        text: failure === 'length' ? 'b'.repeat(501) : 'Changed',
-      })
-    ).rejects.toThrow();
-    expect(await dispatch('getAllCards')).toEqual(previous);
-    expect(await dispatch('getNote', { slug: problem.slug })).toBe('a'.repeat(500));
-    expect(await storage.getItem(STORAGE_KEYS.dataUpdatedAt)).toBe(timestamp);
-  });
-
-  it('blocks normal commands when the embedded-note startup migration rejects an ambiguous owner', async () => {
-    fakeBrowser.reset();
-    vi.mocked(onMessage).mockClear();
-    const card = await cards.addCard(problem);
-    await storage.setItem(STORAGE_KEYS.cards, {
-      [problem.slug]: card,
-      other: { ...card, slug: 'other' },
-    });
-    await storage.setItem(STORAGE_KEYS.schemaVersion, 3);
-    await storage.setItem(`local:leetsrs:notes:${card.id}`, { text: 'Ambiguous' });
-    const before = await fakeBrowser.storage.local.get(null);
-    vi.spyOn(console, 'error').mockImplementation(() => {});
-    background.main();
-    await expect(dispatch('getAllCards')).rejects.toThrow('Duplicate card ID');
-    await expect(dispatch('saveNote', { slug: problem.slug, text: 'New' })).rejects.toThrow('Duplicate card ID');
-    await expect(dispatch('removeCard', { slug: problem.slug })).rejects.toThrow('Duplicate card ID');
-    expect(await fakeBrowser.storage.local.get(null)).toEqual(before);
-  });
-
   it('registers every message synchronously', () => {
     expect(
       vi
@@ -132,163 +42,112 @@ describe('registered background execution', () => {
     ).toEqual(Object.keys(messagePayloadSchemas).sort());
   });
 
-  it('lets reads overlap a write and keeps ordered effects inside the queue', async () => {
+  it('resets learning data, connection and status, then ignores stale learning data on restart', async () => {
+    await dispatch('rateCard', { input: { ...problem, rating: 3 } });
+    await dispatch('saveNote', { slug: problem.slug, text: 'Reset me' });
+    await dispatch('updateSettings', { changes: { language: 'de' } });
+    await dispatch('setGistSyncConfig', { config: { pat: 'secret', gistId: 'gist', enabled: true } });
+    const staleLocal = {
+      'leetsrs:cards': { stale: 'invalid leftover' },
+      'leetsrs:stats': { stale: 'invalid leftover' },
+      'leetsrs:schemaVersion': 3,
+      'leetsrs:dataUpdatedAt': '2024-01-01T00:00:00.000Z',
+      'leetsrs:notes:old-id': { text: 'stale note' },
+    };
+    await fakeBrowser.storage.local.set({
+      ...staleLocal,
+      'leetsrs:lastSyncTime': 'old',
+      'leetsrs:lastSyncDirection': 'pull',
+      unrelated: 'keep',
+    });
+    await fakeBrowser.storage.sync.set({
+      'leetsrs:githubPat': 'legacy secret',
+      'leetsrs:gistId': 'old-gist',
+      'leetsrs:gistSyncEnabled': true,
+      'leetsrs:theme': 'dark',
+      'leetsrs:dayStartHour': 4,
+      'leetsrs:autoClearLeetcode': true,
+      unrelated: 'keep',
+    });
+
+    await dispatch('resetAllData');
+
+    const empty = { schemaVersion: 6, cards: {}, stats: {}, settings: {} };
+    expect(JSON.parse((await dispatch('exportData')) as string)).toEqual(empty);
+    expect(await dispatch('getGistSyncConfig')).toEqual({ pat: '', gistId: null, enabled: false });
+    expect(await dispatch('getGistSyncStatus')).toEqual({
+      lastSyncTime: null,
+      lastSyncDirection: null,
+      syncInProgress: false,
+      lastError: null,
+    });
+    expect(await fakeBrowser.storage.local.get(null)).toEqual({ 'leetsrs:learningDocument': empty, unrelated: 'keep' });
+    expect(await fakeBrowser.storage.sync.get(null)).toEqual({ unrelated: 'keep' });
+
+    await fakeBrowser.storage.local.set(staleLocal);
+    vi.mocked(onMessage).mockClear();
+    background.main();
+    expect(await dispatch('getAllCards')).toEqual([]);
+    expect(await dispatch('getNote', { slug: problem.slug })).toBeNull();
+    expect(await dispatch('getTodayStats')).toBeNull();
+    expect(JSON.parse((await dispatch('exportData')) as string)).toEqual(empty);
+  });
+  it.each(['document', 'connection cleanup'] as const)(
+    'reports reset failure at %s without resurrecting data on restart',
+    async (stage) => {
+      await dispatch('addCard', { problem });
+      await dispatch('setGistSyncConfig', { config: { pat: 'secret', gistId: 'gist', enabled: true } });
+      const before = await dispatch('exportData');
+      const failure = new Error('Reset storage unavailable');
+      if (stage === 'document') {
+        vi.spyOn(fakeBrowser.storage.local, 'set').mockRejectedValueOnce(failure);
+      } else {
+        vi.spyOn(fakeBrowser.storage.sync, 'remove').mockRejectedValueOnce(failure);
+      }
+      await expect(dispatch('resetAllData')).rejects.toBe(failure);
+      expect(await dispatch('getGistSyncConfig')).toEqual({ pat: 'secret', gistId: 'gist', enabled: true });
+      vi.mocked(onMessage).mockClear();
+      background.main();
+      if (stage === 'document') {
+        expect(await dispatch('exportData')).toBe(before);
+      } else {
+        expect(await dispatch('getAllCards')).toEqual([]);
+      }
+      await dispatch('resetAllData');
+      expect(await dispatch('getAllCards')).toEqual([]);
+      expect(await dispatch('getGistSyncConfig')).toEqual({ pat: '', gistId: null, enabled: false });
+    }
+  );
+
+  it.each(['setBadgeText', 'setBadgeBackgroundColor'] as const)(
+    'keeps a saved card successful when %s fails and accepts the next write',
+    async (method) => {
+      const failure = new Error('Badge unavailable');
+      vi.spyOn(browser.action, method).mockRejectedValueOnce(failure);
+      const report = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      await expect(dispatch('addCard', { problem })).resolves.toMatchObject(problem);
+      expect(await dispatch('getAllCards')).toMatchObject([problem]);
+      expect(report).toHaveBeenCalledWith('Failed to refresh badge:', failure);
+      await dispatch('saveNote', { slug: problem.slug, text: 'saved after badge failure' });
+      expect(await dispatch('getNote', { slug: problem.slug })).toBe('saved after badge failure');
+    }
+  );
+
+  it('keeps badge effects inside the write queue while reads see the saved document', async () => {
     const started = Promise.withResolvers<void>();
     const release = Promise.withResolvers<void>();
-    const effectStarted = Promise.withResolvers<void>();
-    const releaseEffect = Promise.withResolvers<void>();
-    const events: string[] = [];
-    vi.spyOn(cards, 'removeCard').mockImplementation(async () => {
-      events.push('handler');
+    vi.spyOn(browser.action, 'setBadgeText').mockImplementationOnce(async () => {
       started.resolve();
       await release.promise;
     });
-    vi.spyOn(tracker, 'markDataUpdated').mockImplementationOnce(async () => {
-      events.push('mark');
-      effectStarted.resolve();
-      await releaseEffect.promise;
-    });
-    vi.spyOn(browser.action, 'setBadgeText').mockImplementation(async () => {
-      events.push('badge');
-    });
-    vi.spyOn(cards, 'deleteNote').mockImplementation(async () => {
-      events.push('next');
-    });
-
-    const first = dispatch('removeCard', { slug: 'two-sum' });
-    const second = dispatch('deleteNote', { slug: 'card' });
+    const first = dispatch('addCard', { problem });
+    const second = dispatch('saveNote', { slug: problem.slug, text: 'next edit' });
     await started.promise;
-    await expect(dispatch('getAllCards')).resolves.toEqual([]);
-    expect(events).toEqual(['handler']);
+    expect(await dispatch('getAllCards')).toMatchObject([problem]);
+    expect(await dispatch('getNote', { slug: problem.slug })).toBeNull();
     release.resolve();
-    await effectStarted.promise;
-    expect(events).toEqual(['handler', 'mark']);
-    releaseEffect.resolve();
     await Promise.all([first, second]);
-    expect(events).toEqual(['handler', 'mark', 'badge', 'next']);
-  });
-
-  it.each(['handler', 'tracking', 'badge'] as const)(
-    'recovers after %s rejection without running later effects',
-    async (stage) => {
-      const failure = new Error(`${stage} failed`);
-      const handler = vi.spyOn(cards, 'removeCard').mockResolvedValue(undefined);
-      const tracking = vi.spyOn(tracker, 'markDataUpdated').mockResolvedValue(undefined);
-      const badge = vi.spyOn(browser.action, 'setBadgeText').mockResolvedValue(undefined);
-      if (stage === 'handler') handler.mockRejectedValueOnce(failure);
-      if (stage === 'tracking') tracking.mockRejectedValueOnce(failure);
-      if (stage === 'badge') badge.mockRejectedValueOnce(failure);
-
-      await expect(dispatch('removeCard', { slug: 'two-sum' })).rejects.toBe(failure);
-      expect(tracking).toHaveBeenCalledTimes(stage === 'handler' ? 0 : 1);
-      expect(badge).toHaveBeenCalledTimes(stage === 'badge' ? 1 : 0);
-      await expect(dispatch('removeCard', { slug: 'two-sum' })).resolves.toBeUndefined();
-      expect(handler).toHaveBeenCalledTimes(2);
-    }
-  );
-
-  it.each([true, false])('queues sync network work until the previous sync settles (success: %s)', async (success) => {
-    const started = Promise.withResolvers<void>();
-    const release = Promise.withResolvers<void>();
-    const firstResult = success
-      ? { success: true as const, action: 'no-change' as const, timestamp: 'now' }
-      : { success: false as const, error: 'Gist not found' };
-    const handler = vi
-      .mocked(sync.triggerGistSync)
-      .mockImplementationOnce(async () => {
-        started.resolve();
-        await release.promise;
-        return firstResult;
-      })
-      .mockResolvedValueOnce({ success: true, action: 'pushed', timestamp: 'later' });
-    const tracking = vi.spyOn(tracker, 'markDataUpdated');
-    const badge = vi.spyOn(browser.action, 'setBadgeText');
-    const first = dispatch('triggerGistSync');
-    const second = dispatch('triggerGistSync');
-    await started.promise;
-    expect(handler).toHaveBeenCalledOnce();
-    release.resolve();
-    expect(await first).toEqual(firstResult);
-    expect(await second).toEqual({ success: true, action: 'pushed', timestamp: 'later' });
-    expect(tracking).not.toHaveBeenCalled();
-    expect(badge).toHaveBeenCalledTimes(2);
-  });
-
-  it('preserves Gist creation results and errors without executor effects', async () => {
-    const failure = new Error('save failed');
-    vi.mocked(sync.createNewGist).mockResolvedValueOnce({ gistId: 'created' }).mockRejectedValueOnce(failure);
-    const tracking = vi.spyOn(tracker, 'markDataUpdated');
-    const badge = vi.spyOn(browser.action, 'setBadgeText');
-    await expect(dispatch('createNewGist')).resolves.toEqual({ gistId: 'created' });
-    await expect(dispatch('createNewGist')).rejects.toBe(failure);
-    expect(tracking).not.toHaveBeenCalled();
-    expect(badge).not.toHaveBeenCalled();
-  });
-
-  it('updates the timestamp and displays the queue size after adding a card', async () => {
-    const tracking = vi.spyOn(tracker, 'markDataUpdated');
-    const badge = vi.spyOn(browser.action, 'setBadgeText');
-
-    const card = await dispatch('addCard', { problem });
-
-    expect(card).toMatchObject(problem);
-    expect(tracking).toHaveBeenCalledOnce();
-    expect(badge).toHaveBeenCalledExactlyOnceWith({ text: '1' });
-  });
-
-  it.each([
-    ['delayCard', { slug: problem.slug, days: 1 }],
-    ['setPauseStatus', { slug: problem.slug, paused: true }],
-    ['rateCard', { input: { ...problem, rating: 4 } }],
-    ['removeCard', { slug: problem.slug }],
-  ] as const)('%s updates the timestamp and refreshes the badge', async (name, data) => {
-    await cards.addCard(problem);
-    const tracking = vi.spyOn(tracker, 'markDataUpdated');
-    const badge = vi.spyOn(browser.action, 'setBadgeText');
-
-    await dispatch(name, data);
-
-    expect(tracking).toHaveBeenCalledOnce();
-    expect(badge).toHaveBeenCalledOnce();
-  });
-
-  it.each(['saveNote', 'deleteNote'] as const)(
-    '%s updates the timestamp without refreshing the badge',
-    async (name) => {
-      const card = await cards.addCard(problem);
-      await cards.saveNote(card.slug, 'existing note');
-      const tracking = vi.spyOn(tracker, 'markDataUpdated');
-      const badge = vi.spyOn(browser.action, 'setBadgeText');
-
-      await dispatch(name, { slug: card.slug, text: 'remember' });
-
-      expect(tracking).toHaveBeenCalledOnce();
-      expect(badge).not.toHaveBeenCalled();
-    }
-  );
-
-  it('lets settings own timestamp updates and clears the badge when disabled', async () => {
-    await cards.addCard(problem);
-    const tracking = vi.spyOn(tracker, 'markDataUpdated');
-    const badge = vi.spyOn(browser.action, 'setBadgeText');
-
-    await dispatch('updateSettings', { changes: { badgeEnabled: false } });
-
-    expect(tracking).toHaveBeenCalledOnce();
-    expect(badge).toHaveBeenCalledExactlyOnceWith({ text: '' });
-  });
-
-  it('preserves the imported timestamp and refreshes the badge', async () => {
-    await cards.addCard(problem);
-    const timestamp = '2024-01-15T10:00:00.000Z';
-    const backup = JSON.parse((await dispatch('exportData')) as string);
-    backup.dataUpdatedAt = timestamp;
-    const badge = vi.spyOn(browser.action, 'setBadgeText');
-
-    await dispatch('importData', { jsonData: JSON.stringify(backup) });
-
-    expect(await storage.getItem(STORAGE_KEYS.dataUpdatedAt)).toBe(timestamp);
-    expect(badge).toHaveBeenCalledExactlyOnceWith({ text: '1' });
+    expect(await dispatch('getNote', { slug: problem.slug })).toBe('next edit');
   });
 
   it('serializes whole-connection updates and exposes the previous record while a write is pending', async () => {
@@ -315,33 +174,6 @@ describe('registered background execution', () => {
       [{ 'leetsrs:gistConnection': { pat: 'new', gistId: 'new-gist', enabled: false } }],
       [{ 'leetsrs:gistConnection': { pat: 'new', gistId: 'new-gist', enabled: true } }],
     ]);
-  });
-
-  it('preserves the timestamp and badge when updating Gist configuration', async () => {
-    const timestamp = '2024-01-15T10:00:00.000Z';
-    await storage.setItem(STORAGE_KEYS.dataUpdatedAt, timestamp);
-    const tracking = vi.spyOn(tracker, 'markDataUpdated');
-    const badge = vi.spyOn(browser.action, 'setBadgeText');
-
-    await dispatch('setGistSyncConfig', { config: { enabled: false } });
-
-    expect(tracking).not.toHaveBeenCalled();
-    expect(badge).not.toHaveBeenCalled();
-    expect(await storage.getItem(STORAGE_KEYS.dataUpdatedAt)).toBe(timestamp);
-  });
-
-  it('removes cards and their timestamp and clears the badge on reset', async () => {
-    await cards.addCard(problem);
-    await storage.setItem(STORAGE_KEYS.dataUpdatedAt, '2024-01-15T10:00:00.000Z');
-    const tracking = vi.spyOn(tracker, 'markDataUpdated');
-    const badge = vi.spyOn(browser.action, 'setBadgeText');
-
-    await dispatch('resetAllData');
-
-    expect(await dispatch('getAllCards')).toEqual([]);
-    expect(await storage.getItem(STORAGE_KEYS.dataUpdatedAt)).toBeNull();
-    expect(tracking).not.toHaveBeenCalled();
-    expect(badge).toHaveBeenCalledExactlyOnceWith({ text: '' });
   });
 });
 

--- a/entrypoints/background/__tests__/execution.test.ts
+++ b/entrypoints/background/__tests__/execution.test.ts
@@ -2,12 +2,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { browser } from 'wxt/browser';
 import { fakeBrowser } from 'wxt/testing/fake-browser';
 import { ZodError } from 'zod';
-import {
-  type MessageData,
-  type MessageName,
-  messagePayloadSchemas,
-  onMessage,
-} from '@/infrastructure/browser/messages';
+import { type MessageName, messagePayloadSchemas, onMessage } from '@/infrastructure/browser/messages';
+import { dispatchBackgroundCommand as dispatch } from '@/test/utils/background-messages';
 import { buildProblem } from '@/test/utils/card-mocks';
 import background from '../index';
 
@@ -15,12 +11,6 @@ vi.mock('@/infrastructure/browser/messages', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@/infrastructure/browser/messages')>()),
   onMessage: vi.fn(),
 }));
-
-function dispatch(name: MessageName, data?: unknown) {
-  const listener = vi.mocked(onMessage).mock.calls.find(([registered]) => registered === name)?.[1];
-  if (!listener) throw new Error(`Missing listener for ${name}`);
-  return listener({ id: 1, type: name, data: data as MessageData<MessageName>, timestamp: 0, sender: {} });
-}
 
 beforeEach(async () => {
   fakeBrowser.reset();
@@ -73,7 +63,7 @@ describe('registered background execution', () => {
     await dispatch('resetAllData');
 
     const empty = { schemaVersion: 6, cards: {}, stats: {}, settings: {} };
-    expect(JSON.parse((await dispatch('exportData')) as string)).toEqual(empty);
+    expect(JSON.parse(await dispatch('exportData'))).toEqual(empty);
     expect(await dispatch('getGistSyncConfig')).toEqual({ pat: '', gistId: null, enabled: false });
     expect(await dispatch('getGistSyncStatus')).toEqual({
       lastSyncTime: null,
@@ -90,7 +80,7 @@ describe('registered background execution', () => {
     expect(await dispatch('getAllCards')).toEqual([]);
     expect(await dispatch('getNote', { slug: problem.slug })).toBeNull();
     expect(await dispatch('getTodayStats')).toBeNull();
-    expect(JSON.parse((await dispatch('exportData')) as string)).toEqual(empty);
+    expect(JSON.parse(await dispatch('exportData'))).toEqual(empty);
   });
   it.each(['document', 'connection cleanup'] as const)(
     'reports reset failure at %s without resurrecting data on restart',

--- a/entrypoints/background/__tests__/index.test.ts
+++ b/entrypoints/background/__tests__/index.test.ts
@@ -1,7 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { browser } from 'wxt/browser';
 import { fakeBrowser } from 'wxt/testing/fake-browser';
-import { type MessageData, type MessageName, onMessage } from '@/infrastructure/browser/messages';
+import { onMessage } from '@/infrastructure/browser/messages';
+import { dispatchBackgroundCommand as dispatch } from '@/test/utils/background-messages';
 import { buildProblem } from '@/test/utils/card-mocks';
 import background from '../index';
 
@@ -9,12 +10,6 @@ vi.mock('@/infrastructure/browser/messages', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@/infrastructure/browser/messages')>()),
   onMessage: vi.fn(),
 }));
-
-function dispatch(name: MessageName, data?: unknown) {
-  const listener = vi.mocked(onMessage).mock.calls.find(([registered]) => registered === name)?.[1];
-  if (!listener) throw new Error(`Missing listener for ${name}`);
-  return listener({ id: 1, type: name, data: data as MessageData<MessageName>, timestamp: 0, sender: {} });
-}
 
 function startBackground() {
   vi.mocked(onMessage).mockClear();
@@ -112,7 +107,7 @@ describe('document startup through registered background commands', () => {
       expect(await dispatch('getSettings')).toMatchObject({ language: stage === 'cleanup' ? 'pl' : 'de' });
       expect(await dispatch('getGistSyncConfig')).toEqual({ pat: 'secret', gistId: 'gist', enabled: true });
       if (stage !== 'cleanup') {
-        expect(JSON.parse((await dispatch('exportData')) as string)).toEqual({
+        expect(JSON.parse(await dispatch('exportData'))).toEqual({
           schemaVersion: 6,
           cards: {},
           stats: {},

--- a/entrypoints/background/__tests__/index.test.ts
+++ b/entrypoints/background/__tests__/index.test.ts
@@ -1,224 +1,159 @@
-import { Octokit } from 'octokit';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { browser } from 'wxt/browser';
 import { fakeBrowser } from 'wxt/testing/fake-browser';
-import { storage } from 'wxt/utils/storage';
-import { messagePayloadSchemas, onMessage } from '@/infrastructure/browser/messages';
-import * as tracker from '@/infrastructure/storage/data-tracker';
-import * as connection from '@/infrastructure/storage/gist-connection';
-import { runStartupMigrations } from '@/infrastructure/storage/migrations/runner';
-import * as cards from '@/services/cards';
-import * as setup from '@/services/gist-sync';
-import { triggerGistSync } from '@/services/gist-sync';
-import { getSettings } from '@/services/settings';
-import { buildSettings } from '@/test/utils/settings-mocks';
+import { type MessageData, type MessageName, onMessage } from '@/infrastructure/browser/messages';
+import { buildProblem } from '@/test/utils/card-mocks';
 import background from '../index';
 
-vi.mock('octokit', () => ({ Octokit: vi.fn() }));
 vi.mock('@/infrastructure/browser/messages', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@/infrastructure/browser/messages')>()),
   onMessage: vi.fn(),
 }));
-vi.mock('@/infrastructure/storage/migrations/runner', () => ({ runStartupMigrations: vi.fn() }));
-vi.mock('@/services/gist-sync', async (importOriginal) => ({
-  ...(await importOriginal<typeof import('@/services/gist-sync')>()),
-  getGistSyncStatus: vi.fn(),
-  triggerGistSync: vi.fn(),
-}));
-vi.mock('@/services/settings', () => ({ getSettings: vi.fn(), updateSettings: vi.fn() }));
 
-function startBackground() {
-  const registration = vi.spyOn(browser.alarms.onAlarm, 'addListener');
-  background.main();
-  const listener = registration.mock.calls[0]?.[0];
-  if (!listener) throw new Error('Alarm listener was not registered synchronously');
-  return (name = 'gist-sync') => listener({ name, scheduledTime: 0, persistAcrossSessions: true });
+function dispatch(name: MessageName, data?: unknown) {
+  const listener = vi.mocked(onMessage).mock.calls.find(([registered]) => registered === name)?.[1];
+  if (!listener) throw new Error(`Missing listener for ${name}`);
+  return listener({ id: 1, type: name, data: data as MessageData<MessageName>, timestamp: 0, sender: {} });
 }
 
-describe('background sync alarm', () => {
-  beforeEach(async () => {
-    fakeBrowser.reset();
-    fakeBrowser.runtime.id = 'test';
-    vi.mocked(runStartupMigrations).mockResolvedValue(undefined);
-    vi.mocked(getSettings).mockResolvedValue(buildSettings());
-    vi.spyOn(cards, 'getReviewQueue').mockResolvedValue([]);
-    vi.mocked(triggerGistSync).mockResolvedValue({ success: true, action: 'no-change', timestamp: 'now' });
-    await setup.setGistSyncConfig({ pat: 'token', gistId: 'gist', enabled: true });
-  });
+function startBackground() {
+  vi.mocked(onMessage).mockClear();
+  const registration = vi.spyOn(browser.alarms.onAlarm, 'addListener');
+  background.main();
+  const listener = registration.mock.calls.at(-1)?.[0];
+  if (!listener) throw new Error('Alarm listener was not registered synchronously');
+  return (name = 'gist-sync') =>
+    listener({ name, scheduledTime: Date.now(), periodInMinutes: 1, persistAcrossSessions: true });
+}
 
-  it.each([
-    { name: 'ready', enabled: true, pat: 'token', gistId: 'gist', syncs: true },
-    { name: 'disabled', enabled: false, pat: 'token', gistId: 'gist', syncs: false },
-    { name: 'missing credential', enabled: true, pat: null, gistId: 'gist', syncs: false },
-    { name: 'empty credential', enabled: true, pat: '', gistId: 'gist', syncs: false },
-    { name: 'missing destination', enabled: true, pat: 'token', gistId: null, syncs: false },
-    { name: 'empty destination', enabled: true, pat: 'token', gistId: '', syncs: false },
-  ])(
-    'handles $name configuration without network requests during readiness',
-    async ({ enabled, pat, gistId, syncs }) => {
-      await setup.setGistSyncConfig({ enabled, pat: pat ?? '', gistId });
-      const destination = vi.spyOn(connection, 'readGistConnection');
+beforeEach(() => {
+  fakeBrowser.reset();
+  fakeBrowser.runtime.id = 'test';
+});
+
+describe('document startup through registered background commands', () => {
+  it.each(['success', 'failure'] as const)(
+    'registers synchronously and holds reads, writes and alarms until startup %s',
+    async (outcome) => {
+      const started = Promise.withResolvers<void>();
+      const release = Promise.withResolvers<void>();
+      const failure = new Error('Document write failed');
+      const set = fakeBrowser.storage.local.set.bind(fakeBrowser.storage.local);
+      vi.spyOn(fakeBrowser.storage.local, 'set').mockImplementationOnce(async (items) => {
+        started.resolve();
+        await release.promise;
+        if (outcome === 'failure') throw failure;
+        await set(items);
+      });
+      const report = vi.spyOn(console, 'error').mockImplementation(() => {});
       const badge = vi.spyOn(browser.action, 'setBadgeText');
       const fireAlarm = startBackground();
-
-      await fireAlarm();
-
-      expect(destination).toHaveBeenCalledOnce();
-      expect(triggerGistSync).toHaveBeenCalledTimes(syncs ? 1 : 0);
-      expect(Octokit).not.toHaveBeenCalled();
-      // Startup refresh plus either the sync runner's refresh or the skipped-alarm fallback.
-      expect(badge.mock.calls).toEqual([[{ text: '' }], [{ text: '' }]]);
-    }
-  );
-
-  it('registers synchronously but waits for startup before checking readiness', async () => {
-    const migrations = Promise.withResolvers<void>();
-    vi.mocked(runStartupMigrations).mockReturnValue(migrations.promise);
-    const destination = vi.spyOn(connection, 'readGistConnection');
-    const fireAlarm = startBackground();
-    const pending = fireAlarm();
-    await Promise.resolve();
-    expect(destination).not.toHaveBeenCalled();
-    expect(triggerGistSync).not.toHaveBeenCalled();
-
-    migrations.resolve();
-    await pending;
-    expect(triggerGistSync).toHaveBeenCalledOnce();
-  });
-
-  it.each(['pending', 'failed'] as const)(
-    'blocks RPCs and sync alarms when migration fails (submitted while %s)',
-    async (startupState) => {
-      const migrations = Promise.withResolvers<void>();
-      const failure = new Error('migration failed');
-      vi.mocked(runStartupMigrations).mockReturnValue(migrations.promise);
-      const report = vi.spyOn(console, 'error').mockImplementation(() => {});
-      const readHandler = vi.spyOn(cards, 'getAllCards').mockResolvedValue([]);
-      const writeHandler = vi.spyOn(cards, 'removeCard').mockResolvedValue(undefined);
-      const tracking = vi.spyOn(tracker, 'markDataUpdated');
-      const writes = vi.spyOn(storage, 'setItem');
-      const destination = vi.spyOn(connection, 'readGistConnection');
-      const alarmRead = vi.spyOn(browser.alarms, 'get');
-      const alarmCreate = vi.spyOn(browser.alarms, 'create');
-      const badgeText = vi.spyOn(browser.action, 'setBadgeText');
-      const badgeColor = vi.spyOn(browser.action, 'setBadgeBackgroundColor');
-      const fireAlarm = startBackground();
-      const readListener = vi.mocked(onMessage).mock.calls.find(([name]) => name === 'getAllCards')?.[1];
-      const writeListener = vi.mocked(onMessage).mock.calls.find(([name]) => name === 'removeCard')?.[1];
-      if (!readListener || !writeListener) throw new Error('RPC listeners were not registered synchronously');
-
-      if (startupState === 'failed') {
-        migrations.reject(failure);
-        await vi.waitFor(() => expect(report).toHaveBeenCalled());
+      const read = dispatch('getAllCards');
+      const write = dispatch('addCard', { problem: buildProblem() });
+      const alarm = fireAlarm();
+      const settled = vi.fn();
+      const results = Promise.allSettled([read, write, alarm]).then((result) => {
+        settled();
+        return result;
+      });
+      await started.promise;
+      expect(settled).not.toHaveBeenCalled();
+      expect(badge).not.toHaveBeenCalled();
+      release.resolve();
+      const [readResult, writeResult, alarmResult] = await results;
+      expect(alarmResult).toEqual({ status: 'fulfilled', value: undefined });
+      if (outcome === 'success') {
+        expect(readResult).toEqual({ status: 'fulfilled', value: [] });
+        expect(writeResult).toMatchObject({ status: 'fulfilled', value: buildProblem() });
+        expect(await dispatch('getAllCards')).toMatchObject([buildProblem()]);
+      } else {
+        expect(readResult).toEqual({ status: 'rejected', reason: failure });
+        expect(writeResult).toEqual({ status: 'rejected', reason: failure });
+        await expect(dispatch('getSettings')).rejects.toBe(failure);
+        await expect(dispatch('removeCard', { slug: 'two-sum' })).rejects.toBe(failure);
+        expect(report).toHaveBeenCalledExactlyOnceWith('Failed to initialize background:', failure);
+        expect(badge).not.toHaveBeenCalled();
+        startBackground();
+        expect(await dispatch('getAllCards')).toEqual([]);
       }
-      const results = Promise.allSettled([
-        readListener({ id: 1, type: 'getAllCards', data: undefined, timestamp: 0, sender: {} }),
-        writeListener({ id: 2, type: 'removeCard', data: { slug: 'two-sum' }, timestamp: 0, sender: {} }),
-        fireAlarm(),
-      ]);
-      if (startupState === 'pending') migrations.reject(failure);
-      const [read, write, alarm] = await results;
-
-      expect.soft(read).toEqual({ status: 'rejected', reason: failure });
-      expect.soft(write).toEqual({ status: 'rejected', reason: failure });
-      expect.soft(alarm).toEqual({ status: 'fulfilled', value: undefined });
-      expect.soft(readHandler).not.toHaveBeenCalled();
-      expect.soft(writeHandler).not.toHaveBeenCalled();
-      expect.soft(triggerGistSync).not.toHaveBeenCalled();
-      expect.soft(Octokit).not.toHaveBeenCalled();
-      expect.soft(tracking).not.toHaveBeenCalled();
-      expect.soft(writes).not.toHaveBeenCalled();
-      expect.soft(destination).not.toHaveBeenCalled();
-      expect.soft(alarmRead).not.toHaveBeenCalled();
-      expect.soft(alarmCreate).not.toHaveBeenCalled();
-      expect.soft(getSettings).not.toHaveBeenCalled();
-      expect.soft(cards.getReviewQueue).not.toHaveBeenCalled();
-      expect.soft(badgeText).not.toHaveBeenCalled();
-      expect.soft(badgeColor).not.toHaveBeenCalled();
-      expect(report).toHaveBeenCalledExactlyOnceWith('Failed to initialize background:', failure);
     }
   );
 
-  it('keeps alarm sync behind writes submitted through messaging', async () => {
-    const writeStarted = Promise.withResolvers<void>();
-    const releaseWrite = Promise.withResolvers<void>();
-    const checked = Promise.withResolvers<void>();
-    vi.spyOn(cards, 'deleteNote').mockImplementation(async () => {
-      writeStarted.resolve();
-      await releaseWrite.promise;
-    });
-    const readConfig = connection.readGistConnection;
-    vi.spyOn(connection, 'readGistConnection').mockImplementation(async () => {
-      const ready = await readConfig();
-      checked.resolve();
-      return ready;
-    });
-    const fireAlarm = startBackground();
-    const listener = vi.mocked(onMessage).mock.calls.find(([name]) => name === 'deleteNote')?.[1];
-    if (!listener) throw new Error('deleteNote listener was not registered');
-    const writing = listener({ id: 1, type: 'deleteNote', data: { slug: 'card' }, timestamp: 0, sender: {} });
-    await writeStarted.promise;
-    const syncing = fireAlarm();
-    await checked.promise;
-    expect(triggerGistSync).not.toHaveBeenCalled();
+  it.each(['write', 'cleanup', 'connection'] as const)(
+    'preserves a legacy installation across a startup %s failure and retry',
+    async (stage) => {
+      const legacy = {
+        'leetsrs:schemaVersion': 5,
+        'leetsrs:cards': {},
+        'leetsrs:stats': {},
+        'leetsrs:dataUpdatedAt': '2024-01-01T00:00:00.000Z',
+      };
+      await fakeBrowser.storage.local.set(legacy);
+      await fakeBrowser.storage.sync.set({
+        'leetsrs:language': 'de',
+        'leetsrs:githubPat': 'secret',
+        'leetsrs:gistId': 'gist',
+        'leetsrs:gistSyncEnabled': true,
+      });
+      const failure = new Error('Storage unavailable');
+      if (stage === 'write') vi.spyOn(fakeBrowser.storage.local, 'set').mockRejectedValueOnce(failure);
+      if (stage === 'cleanup') vi.spyOn(fakeBrowser.storage.local, 'remove').mockRejectedValueOnce(failure);
+      if (stage === 'connection') vi.spyOn(fakeBrowser.storage.sync, 'set').mockRejectedValueOnce(failure);
+      vi.spyOn(console, 'error').mockImplementation(() => {});
+      vi.spyOn(console, 'warn').mockImplementation(() => {});
+      startBackground();
+      if (stage === 'cleanup') {
+        await dispatch('updateSettings', { changes: { language: 'pl' } });
+      } else {
+        await expect(dispatch('getSettings')).rejects.toBe(failure);
+        expect(await fakeBrowser.storage.local.get(null)).toEqual(legacy);
+      }
+      startBackground();
+      expect(await dispatch('getSettings')).toMatchObject({ language: stage === 'cleanup' ? 'pl' : 'de' });
+      expect(await dispatch('getGistSyncConfig')).toEqual({ pat: 'secret', gistId: 'gist', enabled: true });
+      if (stage !== 'cleanup') {
+        expect(JSON.parse((await dispatch('exportData')) as string)).toEqual({
+          schemaVersion: 6,
+          cards: {},
+          stats: {},
+          settings: { language: 'de' },
+          dataUpdatedAt: legacy['leetsrs:dataUpdatedAt'],
+        });
+      }
+    }
+  );
 
-    releaseWrite.resolve();
-    await Promise.all([writing, syncing]);
-    expect(triggerGistSync).toHaveBeenCalledOnce();
-  });
-
-  it('validates direct alarm execution and recovers its shared queue after rejection', async () => {
-    const fireAlarm = startBackground();
-    const failure = new Error('invalid alarm payload');
-    const parse = vi.spyOn(messagePayloadSchemas.triggerGistSync, 'parse').mockImplementationOnce(() => {
-      throw failure;
+  it.each([
+    { schemaVersion: 7, cards: {}, stats: {}, settings: {} },
+    { schemaVersion: 6, cards: 'corrupt', stats: {}, settings: {} },
+  ])('rejects a saved invalid document without falling back to legacy data: %j', async (document) => {
+    await fakeBrowser.storage.local.set({
+      'leetsrs:learningDocument': document,
+      'leetsrs:cards': {},
+      'leetsrs:schemaVersion': 5,
     });
-    await expect(fireAlarm()).rejects.toBe(failure);
-    expect(parse).toHaveBeenCalledExactlyOnceWith(undefined);
-    expect(triggerGistSync).not.toHaveBeenCalled();
+    const before = await fakeBrowser.storage.local.get(null);
+    const writes = vi.spyOn(fakeBrowser.storage.local, 'set');
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    const fireAlarm = startBackground();
+    await expect(dispatch('getAllCards')).rejects.toThrow();
+    await expect(dispatch('addCard', { problem: buildProblem() })).rejects.toThrow();
     await fireAlarm();
-    expect(triggerGistSync).toHaveBeenCalledOnce();
-  });
-
-  it('holds reads and writes until startup succeeds', async () => {
-    const migrations = Promise.withResolvers<void>();
-    vi.mocked(runStartupMigrations).mockReturnValue(migrations.promise);
-    startBackground();
-    const listeners = vi.mocked(onMessage).mock.calls;
-    const read = listeners.find(([name]) => name === 'getAllCards')?.[1];
-    const write = listeners.find(([name]) => name === 'deleteNote')?.[1];
-    if (!read || !write) throw new Error('Missing synchronous listeners');
-    const deleteNote = vi.spyOn(cards, 'deleteNote').mockResolvedValue(undefined);
-    let readCompleted = false;
-    const reading = Promise.resolve(
-      read({ id: 1, type: 'getAllCards', data: undefined, timestamp: 0, sender: {} })
-    ).then((result) => {
-      readCompleted = true;
-      return result;
-    });
-    const writing = write({ id: 2, type: 'deleteNote', data: { slug: 'card' }, timestamp: 0, sender: {} });
-    await Promise.resolve();
-    expect(readCompleted).toBe(false);
-    expect(deleteNote).not.toHaveBeenCalled();
-    migrations.resolve();
-    await expect(reading).resolves.toEqual([]);
-    await writing;
-    expect(deleteNote).toHaveBeenCalledOnce();
+    expect(writes).not.toHaveBeenCalled();
+    expect(await fakeBrowser.storage.local.get(null)).toEqual(before);
   });
 
   it.each([false, true])('preserves the one-minute alarm (already exists: %s)', async (exists) => {
     if (exists) await browser.alarms.create('gist-sync', { periodInMinutes: 1 });
     const create = vi.spyOn(browser.alarms, 'create');
-    await startBackground()();
-    expect(create.mock.calls).toEqual(exists ? [] : [['gist-sync', { periodInMinutes: 1 }]]);
-  });
-
-  it('ignores unrelated alarms', async () => {
     const fireAlarm = startBackground();
+    await dispatch('getSettings');
+    expect(create.mock.calls).toEqual(exists ? [] : [['gist-sync', { periodInMinutes: 1 }]]);
+    const badge = vi.spyOn(browser.action, 'setBadgeText');
     await fireAlarm();
-    vi.clearAllMocks();
-
+    expect(badge).toHaveBeenCalledExactlyOnceWith({ text: '' });
+    badge.mockClear();
     await fireAlarm('unrelated');
-    expect(triggerGistSync).not.toHaveBeenCalled();
+    expect(badge).not.toHaveBeenCalled();
   });
 });

--- a/entrypoints/background/index.ts
+++ b/entrypoints/background/index.ts
@@ -8,37 +8,34 @@ import {
   messagePayloadSchemas,
   onMessage,
 } from '@/infrastructure/browser/messages';
-import { markDataUpdated } from '@/infrastructure/storage/data-tracker';
 import { readGistConnection } from '@/infrastructure/storage/gist-connection';
-import { runStartupMigrations } from '@/infrastructure/storage/migrations/runner';
+import { initializeLearningDocument } from '@/infrastructure/storage/learning-document-startup';
+import { createNewGist, getGistSyncStatus, triggerGistSync } from '@/services/document-gist-sync';
+import { exportData, importData, resetAllData } from '@/services/document-import-export';
 import {
   addCard,
   delayCard,
   deleteNote,
   getAllCards,
+  getCardStateStats,
+  getLastNDaysStats,
+  getNextNDaysStats,
   getNote,
   getReviewQueue,
+  getTodayStats,
   rateCard,
   removeCard,
   saveNote,
   setPauseStatus,
-} from '@/services/cards';
-import { shouldResetEditor } from '@/services/editor-reset';
-import {
-  createNewGist,
-  getGistSyncStatus,
-  setGistSyncConfig,
-  triggerGistSync,
-  validateGistId,
-} from '@/services/gist-sync';
+  shouldResetEditor,
+} from '@/services/document-learning';
+import { getSettings, updateSettings } from '@/services/document-settings';
+import { setGistSyncConfig, validateGistId } from '@/services/gist-sync';
 import { validatePat } from '@/services/github-auth';
-import { exportData, importData, resetAllData } from '@/services/import-export';
-import { getSettings, updateSettings } from '@/services/settings';
-import { getCardStateStats, getLastNDaysStats, getNextNDaysStats, getTodayStats } from '@/services/stats';
 
 type Command<Name extends MessageName> = {
   handler: (data: MessageData<Name>) => MaybePromise<MessageResult<Name>>;
-} & ({ kind: 'read' } | { kind: 'write'; updateDataTimestamp?: boolean; refreshBadge: boolean });
+} & ({ kind: 'read' } | { kind: 'write'; refreshBadge: boolean });
 
 const payloadSchemas: { [Name in MessageName]: z.ZodType<MessageData<Name>> } = messagePayloadSchemas;
 
@@ -47,33 +44,30 @@ function read<Data, Result>(handler: (data: Data) => MaybePromise<Result>) {
 }
 
 type WriteOptions = {
-  // Set dataUpdatedAt to now after success so Gist sync can compare dataset freshness.
-  updateDataTimestamp?: boolean;
   refreshBadge?: boolean;
 };
 
 function write<Data, Result>(
   handler: (data: Data) => MaybePromise<Result>,
-  { updateDataTimestamp = false, refreshBadge = false }: WriteOptions = {}
+  { refreshBadge = false }: WriteOptions = {}
 ) {
-  return { kind: 'write' as const, handler, updateDataTimestamp, refreshBadge };
+  return { kind: 'write' as const, handler, refreshBadge };
 }
 
 const commands: { [Name in MessageName]: Command<Name> } = {
-  addCard: write(({ problem }) => addCard(problem), { updateDataTimestamp: true, refreshBadge: true }),
+  addCard: write(({ problem }) => addCard(problem), { refreshBadge: true }),
   getAllCards: read(getAllCards),
-  removeCard: write(({ slug }) => removeCard(slug), { updateDataTimestamp: true, refreshBadge: true }),
-  delayCard: write(({ slug, days }) => delayCard(slug, days), { updateDataTimestamp: true, refreshBadge: true }),
+  removeCard: write(({ slug }) => removeCard(slug), { refreshBadge: true }),
+  delayCard: write(({ slug, days }) => delayCard(slug, days), { refreshBadge: true }),
   setPauseStatus: write(({ slug, paused }) => setPauseStatus(slug, paused), {
-    updateDataTimestamp: true,
     refreshBadge: true,
   }),
-  rateCard: write(({ input }) => rateCard(input), { updateDataTimestamp: true, refreshBadge: true }),
+  rateCard: write(({ input }) => rateCard(input), { refreshBadge: true }),
   getReviewQueue: read(getReviewQueue),
   getTodayStats: read(getTodayStats),
   getNote: read(({ slug }) => getNote(slug)),
-  saveNote: write(({ slug, text }) => saveNote(slug, text), { updateDataTimestamp: true }),
-  deleteNote: write(({ slug }) => deleteNote(slug), { updateDataTimestamp: true }),
+  saveNote: write(({ slug, text }) => saveNote(slug, text)),
+  deleteNote: write(({ slug }) => deleteNote(slug)),
   getSettings: read(getSettings),
   updateSettings: write(({ changes }) => updateSettings(changes), { refreshBadge: true }),
   shouldResetEditor: read(({ slug, domain }) => shouldResetEditor(slug, domain)),
@@ -109,9 +103,9 @@ async function updateBadge() {
 }
 
 export default defineBackground(() => {
-  // Keep message and alarm handlers from accessing storage while startup migrations are running.
+  // Keep message and alarm handlers from accessing storage until the learning document is ready.
   const readyPromise = (async () => {
-    await runStartupMigrations();
+    await initializeLearningDocument();
 
     const existingAlarm = await browser.alarms.get(SYNC_ALARM_NAME);
     if (!existingAlarm) {
@@ -139,9 +133,12 @@ export default defineBackground(() => {
       const schema: z.ZodType<MessageData<Name>> = payloadSchemas[name];
       const payload = schema.parse(data);
       const result = await command.handler(payload);
-      if (command.kind === 'write') {
-        if (command.updateDataTimestamp) await markDataUpdated();
-        if (command.refreshBadge) await updateBadge();
+      if (command.kind === 'write' && command.refreshBadge) {
+        try {
+          await updateBadge();
+        } catch (error) {
+          console.warn('Failed to refresh badge:', error);
+        }
       }
       return result;
     };

--- a/entrypoints/popup/queries/__tests__/cards.test.tsx
+++ b/entrypoints/popup/queries/__tests__/cards.test.tsx
@@ -9,7 +9,7 @@ import { fakeBrowser } from 'wxt/testing/fake-browser';
 import type { Card } from '@/domain/cards';
 import background from '@/entrypoints/background';
 import { onMessage, sendMessage } from '@/infrastructure/browser/messages';
-import { saveCards } from '@/infrastructure/storage/cards';
+
 import { buildProblem, createMockCard } from '@/test/utils/card-mocks';
 import { createMessageMock } from '@/test/utils/message-mocks';
 import { createTestWrapper } from '@/test/utils/test-wrapper';
@@ -136,7 +136,7 @@ describe('usePauseCardMutation', () => {
 });
 
 describe('card queries through JSON messaging and background handlers', () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     fakeBrowser.reset();
     fakeBrowser.runtime.id = 'test';
     background.main();
@@ -144,6 +144,7 @@ describe('card queries through JSON messaging and background handlers', () => {
     for (const [name, listener] of vi.mocked(onMessage).mock.calls) {
       messaging.handle(name, (data) => listener({ id: 1, type: name, data, timestamp: 0, sender: {} }));
     }
+    await sendMessage('getSettings');
   });
 
   it.each([State.Learning, State.Relearning])(
@@ -153,7 +154,9 @@ describe('card queries through JSON messaging and background handlers', () => {
       vi.setSystemTime(new Date('2024-03-15T10:00:00'));
       const card = createMockCard(state);
       card.fsrs.due = Date.now() + 10_000;
-      await saveCards([card]);
+      await sendMessage('importData', {
+        jsonData: JSON.stringify({ schemaVersion: 6, cards: { [card.slug]: card }, stats: {}, settings: {} }),
+      });
       const view = renderHook(() => useReviewQueueQuery(), { wrapper: createTestWrapper().wrapper });
 
       try {
@@ -175,7 +178,9 @@ describe('card queries through JSON messaging and background handlers', () => {
     card.fsrs.due = 0;
     if (lastReview === undefined) delete card.fsrs.last_review;
     else card.fsrs.last_review = lastReview;
-    await saveCards([card]);
+    await sendMessage('importData', {
+      jsonData: JSON.stringify({ schemaVersion: 6, cards: { [card.slug]: card }, stats: {}, settings: {} }),
+    });
 
     const { result } = renderHook(() => useCardsQuery(), { wrapper: createTestWrapper().wrapper });
 

--- a/infrastructure/storage/learning-document-startup.ts
+++ b/infrastructure/storage/learning-document-startup.ts
@@ -60,7 +60,6 @@ async function promoteLegacyConnection(sync: Record<string, unknown>): Promise<v
   await writeGistConnection(connection);
 }
 
-// Prepared for background startup activation in #378.
 export async function initializeLearningDocument(): Promise<void> {
   const saved = await storage.getItem<unknown>(STORAGE_KEYS.learningDocument);
 
@@ -83,18 +82,23 @@ export async function initializeLearningDocument(): Promise<void> {
   await replaceLearningDocument(document);
 
   try {
-    await storage.removeItems([
-      STORAGE_KEYS.cards,
-      STORAGE_KEYS.stats,
-      STORAGE_KEYS.dataUpdatedAt,
-      STORAGE_KEYS.schemaVersion,
-      ...Object.keys(local)
-        .filter((key) => key.startsWith('leetsrs:notes:'))
-        .map((key): `local:${string}` => `local:${key}`),
-      ...legacySettingNames.map((name): `sync:${string}` => `sync:leetsrs:${name}`),
-    ]);
+    await removeLegacyLearningData();
   } catch (error) {
     // Publication succeeded. Retained legacy values must never become authoritative again.
     console.warn('Failed to clean up legacy learning data:', error);
   }
+}
+
+export async function removeLegacyLearningData(): Promise<void> {
+  const local = await storage.snapshot('local');
+  await storage.removeItems([
+    STORAGE_KEYS.cards,
+    STORAGE_KEYS.stats,
+    STORAGE_KEYS.dataUpdatedAt,
+    STORAGE_KEYS.schemaVersion,
+    ...Object.keys(local)
+      .filter((key) => key.startsWith('leetsrs:notes:'))
+      .map((key): `local:${string}` => `local:${key}`),
+    ...legacySettingNames.map((name): `sync:${string}` => `sync:leetsrs:${name}`),
+  ]);
 }

--- a/infrastructure/storage/sync-metadata.ts
+++ b/infrastructure/storage/sync-metadata.ts
@@ -40,3 +40,7 @@ export async function writeSyncStatus(status: z.infer<typeof syncStatusUpdateSch
 export function removeSyncMetadata(key: keyof SyncMetadata): Promise<void> {
   return storage.removeItem(STORAGE_KEYS[key]);
 }
+
+export function removeSyncStatus(): Promise<void> {
+  return storage.removeItems([STORAGE_KEYS.lastSyncTime, STORAGE_KEYS.lastSyncDirection]);
+}

--- a/infrastructure/storage/translations.ts
+++ b/infrastructure/storage/translations.ts
@@ -52,7 +52,7 @@ export const { get: getStoredTranslations, watch: watchStoredTranslations } = cr
   (value) => value
 );
 
-// Prepared for content activation in #378; content remains read-only.
+// Content reads and watches the authoritative document without writing it.
 export const { get: getDocumentTranslations, watch: watchDocumentTranslations } = createTranslationReader(
   STORAGE_KEYS.learningDocument,
   (value) => documentLanguageSchema.safeParse(value).data?.settings.language

--- a/services/document-gist-sync.ts
+++ b/services/document-gist-sync.ts
@@ -8,12 +8,9 @@ import {
   readLearningDocument,
   replaceLearningDocument,
 } from '@/infrastructure/storage/learning-document';
-import { readSyncMetadata, writeSyncStatus } from '@/infrastructure/storage/sync-metadata';
+import { readSyncMetadata, removeSyncStatus, writeSyncStatus } from '@/infrastructure/storage/sync-metadata';
 import { createGistFromBackup } from './gist-sync';
 
-// Prepared for the coordinated runtime activation in #378.
-// Keep the legacy workflow authoritative until then; #379 removes its duplicate
-// request/error handling along with the old persistence path.
 // In-memory state for sync status (not persisted)
 let syncInProgress = false;
 let lastError: string | null = null;
@@ -118,4 +115,9 @@ export async function createNewGist(): Promise<{ gistId: string }> {
     JSON.stringify(document, null, 2),
     translations[language].settings.gistSync.gistDescription
   );
+}
+
+export async function resetGistSyncStatus(): Promise<void> {
+  await removeSyncStatus();
+  lastError = null;
 }

--- a/services/document-import-export.ts
+++ b/services/document-import-export.ts
@@ -1,10 +1,13 @@
+import { LEARNING_DOCUMENT_VERSION } from '@/domain/learning-document';
+import { removeGistConnection } from '@/infrastructure/storage/gist-connection';
 import {
   parseLearningDocumentBackup,
   readLearningDocument,
   replaceLearningDocument,
 } from '@/infrastructure/storage/learning-document';
+import { removeLegacyLearningData } from '@/infrastructure/storage/learning-document-startup';
+import { resetGistSyncStatus } from './document-gist-sync';
 
-// Prepared for the coordinated runtime activation in #378.
 export async function exportData(): Promise<string> {
   const document = await readLearningDocument();
   if (!document) {
@@ -18,4 +21,11 @@ export async function importData(json: string): Promise<void> {
   const document = parseLearningDocumentBackup(json);
 
   await replaceLearningDocument(document);
+}
+
+export async function resetAllData(): Promise<void> {
+  await replaceLearningDocument({ schemaVersion: LEARNING_DOCUMENT_VERSION, cards: {}, stats: {}, settings: {} });
+  await removeGistConnection();
+  await resetGistSyncStatus();
+  await removeLegacyLearningData();
 }

--- a/services/document-learning.ts
+++ b/services/document-learning.ts
@@ -22,7 +22,6 @@ import {
 import { detectBrowserLanguage } from '@/infrastructure/browser/language';
 import { readLearningDocument, replaceLearningDocument } from '@/infrastructure/storage/learning-document';
 
-// Prepared for the coordinated runtime activation in #378.
 const fsrs = new FSRS(generatorParameters({ maximum_interval: 1000 }));
 
 async function getDocument(): Promise<LearningDocument> {

--- a/services/document-settings.ts
+++ b/services/document-settings.ts
@@ -3,7 +3,6 @@ import { resolveSettings, type Settings, type SettingsUpdate, settingsUpdateSche
 import { detectBrowserLanguage } from '@/infrastructure/browser/language';
 import { readLearningDocument, replaceLearningDocument } from '@/infrastructure/storage/learning-document';
 
-// Prepared for the coordinated runtime activation in #378.
 export async function getSettings(): Promise<Settings> {
   const document = await readLearningDocument();
   if (!document) {

--- a/test/utils/background-messages.ts
+++ b/test/utils/background-messages.ts
@@ -1,0 +1,16 @@
+import { vi } from 'vitest';
+import { type MessageData, type MessageName, type MessageResult, onMessage } from '@/infrastructure/browser/messages';
+
+// Accept untrusted payloads so tests exercise validation in the registered dispatcher.
+export function dispatchBackgroundCommand<Name extends MessageName>(
+  name: Name,
+  data?: unknown
+): Promise<MessageResult<Name>> {
+  const listener = vi.mocked(onMessage).mock.calls.find(([registered]) => registered === name)?.[1];
+  if (!listener) {
+    throw new Error(`Missing listener for ${name}`);
+  }
+  return Promise.resolve(
+    listener({ id: 1, type: name, data: data as MessageData<MessageName>, timestamp: 0, sender: {} })
+  ) as Promise<MessageResult<Name>>;
+}


### PR DESCRIPTION
- Activate the learning document across startup, background commands, content translations, backups, and Gist sync.
- Keep save timestamps in document replacements, isolate badge failures, and make reset clear learning data, connection/status, and legacy keys.
- Exercise the real background interface for startup failures, queue behavior, transfers, and reset/restart. `npm run check` (1,254 tests) and production build pass.

Closes #378. Remaining superseded-code cleanup is tracked in #379.
