### PR TITLE
test: silence console output for passing tests

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,6 +3,7 @@ import { WxtVitest } from 'wxt/testing/vitest-plugin';
 
 export default defineConfig({
   test: {
+    silent: 'passed-only',
     mockReset: true,
     restoreMocks: true,
     setupFiles: './test/setup.ts',


### PR DESCRIPTION
- Hide passing-test console chatter with Vitest’s `passed-only` mode while retaining failure diagnostics and existing cleanup coverage.
- Verified content-startup tests, `npm run check` (772 tests), and console/teardown diagnostics with a temporary failing-test probe.

Closes #300
